### PR TITLE
Add helpful messages to read/write errors, fix indentation with tabs

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11941,7 +11941,8 @@ function util.cache(dir, string, salt, transform, suffix)
   local name = util.pathname(dir, digest .. suffix)
   local file = io.open(name, "r")
   if file == nil then -- If no cache entry exists, then create a new one.
-    local file = assert(io.open(name, "w"))
+    local file = assert(io.open(name, "w"),
+      [[could not open file "]] .. name .. [[" for writing]])
     local result = string
     if transform ~= nil then
       result = transform(result)
@@ -16931,7 +16932,9 @@ larsers.PipeTable = Ct(larsers.table_row * parsers.newline
       else
         mode = "w"
       end
-      file = assert(io.open(options.frozenCacheFileName, mode))
+      file = assert(io.open(options.frozenCacheFileName, mode),
+        [[could not open file "]] .. options.frozenCacheFileName
+        .. [[" for writing]])
       assert(file:write([[\expandafter\global\expandafter\def\csname ]]
         .. [[markdownFrozenCache]] .. options.frozenCacheCounter
         .. [[\endcsname{]] .. output .. [[}]] .. "\n"))
@@ -16978,7 +16981,8 @@ return M
 
 local input
 if input_filename then
-  local input_file = assert(io.open(input_filename, "r"))
+  local input_file = assert(io.open(input_filename, "r"),
+    [[could not open file "]] .. input_filename .. [[" for reading]])
   input = assert(input_file:read("*a"))
   assert(input_file:close())
 else
@@ -17020,7 +17024,8 @@ local convert = md.new(options)
 local output = convert(input:gsub("\r\n?", "\n") .. "\n")
 
 if output_filename then
-  local output_file = assert(io.open(output_filename, "w"))
+  local output_file = assert(io.open(output_filename, "w"),
+    [[could not open file "]] .. output_filename .. [[" for writing]])
   assert(output_file:write(output))
   assert(output_file:close())
 else
@@ -17731,7 +17736,8 @@ end
       |closein|markdownInputFileStream
       |markdownLuaExecute{%
         |markdownPrepare
-        local file = assert(io.open("#1", "r"))
+        local file = assert(io.open("#1", "r"),
+          [[could not open file "#1" for reading]])
         local input = assert(file:read("*a"))
         assert(file:close())
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -18722,12 +18722,12 @@ end
 \def\markdownConTeXtCSV{csv}
 \def\markdownRendererContentBlockPrototype#1#2#3#4{%
   \def\markdownConTeXtCSV@arg{#1}%
-	\ifx\markdownConTeXtCSV@arg\markdownConTeXtCSV
+  \ifx\markdownConTeXtCSV@arg\markdownConTeXtCSV
     \placetable[][tab:#1]{#4}{%
       \processseparatedfile[MarkdownConTeXtCSV][#3]}%
-	\else
-		\markdownInput{#3}%
-	\fi}%
+  \else
+    \markdownInput{#3}%
+  \fi}%
 \def\markdownRendererImagePrototype#1#2#3#4{%
   \placefigure[][fig:#1]{#4}{\externalfigure[#3]}}%
 \def\markdownRendererUlBeginPrototype{\startitemize}%


### PR DESCRIPTION
When using `\markdownInput` to read a file that does not exist or is not readable, the error message written in the error output file is not very indicative of the problem:

`./main.markdown.lua:1: attempt to index a nil value`

This pull request makes the message more descriptive:

`./main.markdown.lua:1: could not open file "input.md" for reading`

Such messages have been added to several other places in the code where reads/writes are performed (only the important ones wrapped with asserts that are likely to fail).

Also fixes a few stray tab indents.