### PR TITLE
Add further reflection capabilities

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -14662,14 +14662,12 @@ from being loaded:
   { boolean }
   { false }
 \ExplSyntaxOff
-\newif\ifmarkdownLaTeXPlain
-  \markdownLaTeXPlainfalse
 \define@key{markdownOptions}{plain}[true]{%
   \ifmarkdownLaTeXLoaded
     \markdownWarning
       {The plain option must be specified when loading the package}%
   \else
-    \markdownLaTeXPlaintrue
+    \renewcommand\markdownOptionPlain{#1}%
   \fi}
 %    \end{macrocode}
 % \iffalse
@@ -22505,7 +22503,7 @@ end
 % it will take effect.
 % \end{markdown}
 %  \begin{macrocode}
-\ifmarkdownLaTeXPlain\else
+\markdownIfOption{plain}{\iffalse}{\iftrue}
 %    \end{macrocode}
 % \par
 % \begin{markdown}%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21624,8 +21624,8 @@ end
                 \tl_case:cnF
                   { \l_tmpa_tl }
                   {
-                    \c_@@_lua_option_value_true  { }
-                    \c_@@_lua_option_value_false { }
+                    \c_@@_option_value_true  { }
+                    \c_@@_option_value_false { }
                   }
                   {
                     \msg_error:nnxv
@@ -21755,8 +21755,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\tl_const:Nn \c_@@_lua_option_value_true  { true  }
-\tl_const:Nn \c_@@_lua_option_value_false { false }
+\tl_const:Nn \c_@@_option_value_true  { true  }
+\tl_const:Nn \c_@@_option_value_false { false }
 \msg_new:nnn
   { markdown }
   { expected-boolean-option }
@@ -21797,7 +21797,7 @@ end
       }
     \tl_if_eq:NNTF
       \l_tmpb_tl
-      \c_@@_lua_option_value_true
+      \c_@@_option_value_true
       { #2 }
       { #3 }
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8411,8 +8411,8 @@ For more information, see the examples for the \Opt{finalizeCache} option.
         \@@_option_tl_to_csname:nN
           { #1 }
           \l_tmpa_tl
-        \cs_new:cpn
-          \l_tmpa_tl
+        \cs_set:cpn
+          { \l_tmpa_tl }
           { #2 }
       }
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1985,7 +1985,7 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
     Option~#1~is~undefined.
   }
 \cs_new:Nn
-  \@@_get_default_option:nN
+  \@@_get_default_option_value:nN
   {
     \bool_set_false:N
       \l_tmpa_bool
@@ -2020,7 +2020,7 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
     \cs_if_free:cTF
       { \l_tmpa_tl }
       {
-        \@@_get_default_option:nN
+        \@@_get_default_option_value:nN
           { #1 }
           #2
       }
@@ -8381,7 +8381,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   }
 \cs_new:Nn \@@_plain_tex_define_option_command:n
   {
-    \@@_get_default_option:nN
+    \@@_get_default_option_value:nN
       { #1 }
       \l_tmpa_tl
     \@@_set_option_value:nV

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1935,31 +1935,38 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 \cs_new:Nn
   \@@_get_option_type:nN
   {
-    \prop_get:NnNF
-      \g_@@_lua_option_types_prop
-      { #1 }
-      \l_tmpa_tl
+    \bool_set_false:N
+      \l_tmpa_bool
+    \seq_map_inline:Nn
+      \g_@@_option_categories_seq
       {
-        \prop_get:NnNF
-          \g_@@_plain_tex_option_types_prop
+        \prop_get:cnNT
+          { g_@@_ ##1 _option_types_prop }
           { #1 }
           \l_tmpa_tl
           {
-            \msg_error:nnn
-              { markdown }
-              { undefined-option }
-              { #1 }
+            \bool_set_true:N
+              \l_tmpa_bool
+            \seq_map_break:
           }
+      }
+    \bool_if:nF
+      \l_tmpa_bool
+      {
+        \msg_error:nnn
+          { markdown }
+          { undefined-option }
+          { #1 }
       }
     \seq_if_in:NVF
       \g_@@_option_types_seq
       \l_tmpa_tl
       {
-        \msg_error:nnxx
+        \msg_error:nnnV
           { markdown }
           { unknown-option-type }
           { #1 }
-          { \l_tmpa_tl }
+          \l_tmpa_tl
       }
     \tl_set_eq:NN
       #2
@@ -2000,7 +2007,7 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
       {
         \msg_error:nnn
           { markdown }
-          { undefined-lua-or-plain-tex-option }
+          { undefined-option }
           { #1 }
       }
   }
@@ -14409,6 +14416,19 @@ pdflatex --shell-escape document.tex
 % are rendered. The rest of the interface is inherited from the plain \TeX{}
 % interface (see Section <#sec:texinterface>).
 %
+% The \LaTeX{} implementation redefines the plain \TeX{} logging macros (see
+% Section <#sec:texinterfacelogging>) to use the \LaTeX{} \mref{PackageInfo},
+% \mref{PackageWarning}, and \mref{PackageError} macros.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\newcommand\markdownInfo[1]{\PackageInfo{markdown}{#1}}%
+\newcommand\markdownWarning[1]{\PackageWarning{markdown}{#1}}%
+\newcommand\markdownError[2]{\PackageError{markdown}{#1}{#2.}}%
+\input markdown/markdown
+%    \end{macrocode}
+% \begin{markdown}
+%
 % The \LaTeX{} interface is implemented by the `markdown.sty` file, which
 % can be loaded from the \LaTeX{} document preamble as follows:
 % \end{markdown}
@@ -14588,8 +14608,46 @@ document:
 }
 ```
 
+%</manual-options>
+%<*latex>
 % \fi
 % \par
+% \begin{markdown}
+%
+% To enable the enumeration of \LaTeX{} options, we will maintain the
+% \mdef{g_\@\@_latex_options_seq} sequence.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\seq_new:N \g_@@_latex_options_seq
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To enable the reflection of default \LaTeX{} options and their types, we
+% will maintain the \mdef{g_\@\@_default_latex_options_prop} and
+% \mdef{g_\@\@_latex_option_types_prop} property lists, respectively.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\prop_new:N \g_@@_latex_option_types_prop
+\prop_new:N \g_@@_default_latex_options_prop
+\tl_const:Nn \c_@@_option_category_latex_tl { latex }
+\seq_put_right:NV \g_@@_option_categories_seq \c_@@_option_category_latex_tl
+\cs_new:Nn
+  \@@_add_latex_option:nnn
+  {
+    \@@_add_option:Vnnn
+      \c_@@_option_category_latex_tl
+      { #1 }
+      { #2 }
+      { #3 }
+  }
+%    \end{macrocode}
+% \iffalse
+%</latex>
+%<*manual-options>
+% \fi
 % \begin{markdown}
 
 #### No default token renderer prototypes {#latexplain}
@@ -14614,6 +14672,11 @@ from being loaded:
 %<*latex>
 % \fi
 %  \begin{macrocode}
+\@@_add_latex_option:nnn
+  { plain }
+  { boolean }
+  { false }
+\ExplSyntaxOff
 \newif\ifmarkdownLaTeXPlain
   \markdownLaTeXPlainfalse
 \define@key{markdownOptions}{plain}[true]{%
@@ -22063,16 +22126,8 @@ end
 % format~[@latex17, Section 9]. As a consequence, we can directly reuse the
 % existing plain \TeX{} implementation.
 %
-% The \LaTeX{} implementation redefines the plain \TeX{} logging macros (see
-% Section <#sec:texinterfacelogging>) to use the \LaTeX{} \mref{PackageInfo},
-% \mref{PackageWarning}, and \mref{PackageError} macros.
-%
 % \end{markdown}
 %  \begin{macrocode}
-\newcommand\markdownInfo[1]{\PackageInfo{markdown}{#1}}%
-\newcommand\markdownWarning[1]{\PackageWarning{markdown}{#1}}%
-\newcommand\markdownError[2]{\PackageError{markdown}{#1}{#2.}}%
-\input markdown/markdown
 \def\markdownVersionSpace{ }%
 \ProvidesPackage{markdown}[\markdownLastModified\markdownVersionSpace v%
   \markdownVersion\markdownVersionSpace markdown renderer]%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8524,7 +8524,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
       }
   }
 \@@_plain_tex_define_options:
-\ExplSyntaxOff
 %    \end{macrocode}
 %
 % \iffalse
@@ -8643,7 +8642,18 @@ A PDF document named `document.pdf` should be produced and contain the text
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionStripPercentSigns{false}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { stripPercentSigns }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { stripPercentSigns }
+  { boolean }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { stripPercentSigns }
+  { false }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</tex>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8156,11 +8156,11 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\cs_new:Nn \@@_plain_tex_define_options:
+\cs_new:Nn \@@_plain_tex_define_option_commands:
   {
     \seq_map_function:NN
       \g_@@_lua_options_seq
-      \@@_plain_tex_define_lua_option:n
+      \@@_plain_tex_define_lua_option_command:n
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -8178,18 +8178,18 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %  \begin{macrocode}
     \seq_map_function:NN
       \g_@@_plain_tex_options_seq
-      \@@_plain_tex_define_plain_tex_option:n
+      \@@_plain_tex_define_plain_tex_option_command:n
   }
-\cs_new:Nn \@@_plain_tex_define_lua_option:n
+\cs_new:Nn \@@_plain_tex_define_lua_option_command:n
   {
-    \@@_plain_tex_define_option:nNN
+    \@@_plain_tex_define_option_command:nNN
       { #1 }
       \g_@@_default_lua_options_prop
       \g_@@_lua_option_types_prop
   }
-\cs_new:Nn \@@_plain_tex_define_plain_tex_option:n
+\cs_new:Nn \@@_plain_tex_define_plain_tex_option_command:n
   {
-    \@@_plain_tex_define_option:nNN
+    \@@_plain_tex_define_option_command:nNN
       { #1 }
       \g_@@_default_plain_tex_options_prop
       \g_@@_plain_tex_option_types_prop
@@ -8197,7 +8197,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \seq_new:N \g_@@_option_types_seq
 \tl_const:Nn \c_@@_option_type_counter_tl { counter }
 \seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter_tl
-\cs_new:Nn \@@_plain_tex_define_option:nNN
+\cs_new:Nn \@@_plain_tex_define_option_command:nNN
   {
     \@@_option_tl_to_csname:nN
       { #1 }
@@ -8247,7 +8247,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
         \tl_tail:n { #1 }
       }
   }
-\@@_plain_tex_define_options:
+\@@_plain_tex_define_option_commands:
 %    \end{macrocode}
 %
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8237,7 +8237,6 @@ following code in your plain \TeX{} document:
 #### Finalizing and Freezing the Cache
 
 % \fi
-% \begin{markdown}
 %
 The \mdef{markdownOptionFrozenCache} option uses the mapping previously
 % created by the \mref{markdownOptionFinalizeCache} option,

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8177,7 +8177,25 @@ pdftex --shell-escape document.tex
 % Section <#sec:luaoptions>), while some of them are specific to the plain
 % \TeX{} interface.
 %
+% To enable the enumeration of plain \TeX{} options, we will maintain the
+% \mdef{g_\@\@_plain_tex_options_seq} sequence.
+%
 % \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\seq_new:N \g_@@_plain_tex_options_seq
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To enable the reflection of default plain \TeX{} options and their types, we
+% will maintain the \mdef{g_\@\@_default_plain_tex_options_prop} and
+% \mdef{g_\@\@_plain_tex_option_types_prop} property lists, respectively.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\prop_new:N \g_@@_plain_tex_option_types_prop
+\prop_new:N \g_@@_default_plain_tex_options_prop
+%    \end{macrocode}
 % \iffalse
 %</tex>
 %<*manual-options>
@@ -8278,7 +8296,24 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionHelperScriptFileName{\jobname.markdown.lua}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { helperScriptFileName }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { helperScriptFileName }
+  { string }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { helperScriptFileName }
+  { \jobname.markdown.lua }
+\tl_gset:Nx
+  \markdownOptionHelperScriptFileName
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { helperScriptFileName }
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8291,7 +8326,24 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionInputTempFileName{\jobname.markdown.in}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { inputTempFileName }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { inputTempFileName }
+  { string }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { inputTempFileName }
+  { \jobname.markdown.in }
+\tl_gset:Nx
+  \markdownOptionInputTempFileName
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { inputTempFileName }
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8304,7 +8356,24 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionOutputTempFileName{\jobname.markdown.out}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { outputTempFileName }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { outputTempFileName }
+  { string }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { outputTempFileName }
+  { \jobname.markdown.out }
+\tl_gset:Nx
+  \markdownOptionOutputTempFileName
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { outputTempFileName }
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8318,7 +8387,24 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionErrorTempFileName{\jobname.markdown.err}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { errorTempFileName }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { errorTempFileName }
+  { string }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { errorTempFileName }
+  { \jobname.markdown.err }
+\tl_gset:Nx
+  \markdownOptionErrorTempFileName
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { errorTempFileName }
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8336,7 +8422,24 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionOutputDir{.}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { outputDir }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { outputDir }
+  { string }
+\prop_put:Nnn
+  \g_@@_default_plain_tex_options_prop
+  { outputDir }
+  { . }
+\tl_gset:Nx
+  \markdownOptionOutputDir
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { outputDir }
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8350,7 +8453,29 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionCacheDir{\markdownOptionOutputDir/_markdown_\jobname}%
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { cacheDir }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { cacheDir }
+  { string }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { cacheDir }
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { outputDir }
+    / _markdown_\jobname
+  }
+\tl_gset:Nx
+  \markdownOptionCacheDir
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { cacheDir }
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8364,7 +8489,30 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownOptionFrozenCacheFileName{\markdownOptionCacheDir/frozenCache.tex}
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { frozenCacheFileName }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { frozenCacheFileName }
+  { string }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { frozenCacheFileName }
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { cacheDir }
+    / frozenCache.tex
+  }
+\tl_gset:Nx
+  \markdownOptionFrozenCacheFileName
+  {
+    \prop_item:Nn
+      \g_@@_default_plain_tex_options_prop
+      { frozenCacheFileName }
+  }
+\ExplSyntaxOff
 %    \end{macrocode}
 %
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8474,7 +8474,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter_tl
 \cs_new:Nn \@@_plain_tex_define_option:nNN
   {
-    \@@_option_tl_to_cs:nN
+    \@@_option_tl_to_csname:nN
       { #1 }
       \l_tmpa_tl
     \prop_get:NnN
@@ -8508,7 +8508,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
             { \l_tmpb_tl }
       }
   }
-\cs_new:Nn \@@_option_tl_to_cs:nN
+\cs_new:Nn \@@_option_tl_to_csname:nN
   {
     \tl_set:Nn
       \l_tmpa_tl
@@ -14305,7 +14305,7 @@ following text:
   }
 \cs_new:Nn \@@_plaintex_define_renderer_prototype:n
   {
-    \@@_renderer_prototype_tl_to_cs:nN
+    \@@_renderer_prototype_tl_to_csname:nN
       { #1 }
       \l_tmpa_tl
     \prop_get:NnN
@@ -14316,7 +14316,7 @@ following text:
       { \l_tmpa_tl }
       \l_tmpb_tl
   }
-\cs_new:Nn \@@_renderer_prototype_tl_to_cs:nN
+\cs_new:Nn \@@_renderer_prototype_tl_to_csname:nN
   {
     \tl_set:Nn
       \l_tmpa_tl
@@ -15336,7 +15336,7 @@ The following ordered list will be preceded by roman numerals:
   }
 \cs_new:Nn \@@_latex_define_renderer:n
   {
-    \@@_renderer_tl_to_cs:nN
+    \@@_renderer_tl_to_csname:nN
       { #1 }
       \l_tmpa_tl
     \prop_get:NnN
@@ -15348,7 +15348,7 @@ The following ordered list will be preceded by roman numerals:
       { \l_tmpa_tl }
       \l_tmpb_tl
   }
-\cs_new:Nn \@@_renderer_tl_to_cs:nN
+\cs_new:Nn \@@_renderer_tl_to_csname:nN
   {
     \tl_set:Nn
       \l_tmpa_tl
@@ -15413,7 +15413,7 @@ The following ordered list will be preceded by roman numerals:
   }
 \cs_new:Nn \@@_latex_define_renderer_prototype:n
   {
-    \@@_renderer_prototype_tl_to_cs:nN
+    \@@_renderer_prototype_tl_to_csname:nN
       { #1 }
       \l_tmpa_tl
     \prop_get:NnN
@@ -21783,7 +21783,7 @@ end
 \cs_new:Nn
   \@@_get_option_value:nN
   {
-    \@@_option_tl_to_cs:nN
+    \@@_option_tl_to_csname:nN
       { #1 }
       \l_tmpa_tl
     \cs_if_free:cTF
@@ -21801,7 +21801,7 @@ end
           \c_@@_option_type_counter_tl
           \l_tmpa_tl
           {
-            \@@_option_tl_to_cs:nN
+            \@@_option_tl_to_csname:nN
               { #1 }
               \l_tmpa_tl
             \tl_set:Nx
@@ -21809,7 +21809,7 @@ end
               { \the \cs:w \l_tmpa_tl \cs_end: }
           }
           {
-            \@@_option_tl_to_cs:nN
+            \@@_option_tl_to_csname:nN
               { #1 }
               \l_tmpa_tl
             \tl_set:Nv

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8470,8 +8470,8 @@ For more information, see the examples for the \Opt{finalizeCache} option.
       \g_@@_plain_tex_option_types_prop
   }
 \seq_new:N \g_@@_option_types_seq
-\tl_const:Nn \c_@@_option_type_counter { counter }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter
+\tl_const:Nn \c_@@_option_type_counter_tl { counter }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter_tl
 \cs_new:Nn \@@_plain_tex_define_option:nNN
   {
     \@@_option_tl_to_cs:nN
@@ -8484,7 +8484,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
     \tl_case:NnF
       \l_tmpb_tl
       {
-        \c_@@_option_type_counter
+        \c_@@_option_type_counter_tl
           {
             \prop_get:NnN
               #2
@@ -21532,16 +21532,16 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \tl_new:N \g_@@_formatted_lua_options_tl
-\tl_const:Nn \c_@@_option_type_boolean { boolean }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean
-\tl_const:Nn \c_@@_option_type_number  { number  }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_number
-\tl_const:Nn \c_@@_option_type_path    { path    }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_path
-\tl_const:Nn \c_@@_option_type_slice   { slice   }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_slice
-\tl_const:Nn \c_@@_option_type_string  { string  }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_string
+\tl_const:Nn \c_@@_option_type_boolean_tl { boolean }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean_tl
+\tl_const:Nn \c_@@_option_type_number_tl  { number  }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_number_tl
+\tl_const:Nn \c_@@_option_type_path_tl    { path    }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_path_tl
+\tl_const:Nn \c_@@_option_type_slice_tl   { slice   }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_slice_tl
+\tl_const:Nn \c_@@_option_type_string_tl  { string  }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_string_tl
 \cs_new:Nn \@@_format_lua_options:
   {
     \tl_gclear:N
@@ -21568,19 +21568,19 @@ end
         \tl_case:NnF
           \l_tmpb_tl
           {
-            \c_@@_option_type_boolean
+            \c_@@_option_type_boolean_tl
               {
                 \tl_gput_right:Nx
                   \g_@@_formatted_lua_options_tl
                   { #1~=~      \cs:w \l_tmpa_tl \cs_end:  ,~ }
               }
-            \c_@@_option_type_number
+            \c_@@_option_type_number_tl
               {
                 \tl_gput_right:Nx
                   \g_@@_formatted_lua_options_tl
                   { #1~=~      \cs:w \l_tmpa_tl \cs_end:  ,~ }
               }
-            \c_@@_option_type_counter
+            \c_@@_option_type_counter_tl
               {
                 \tl_gput_right:Nx
                   \g_@@_formatted_lua_options_tl
@@ -21615,7 +21615,7 @@ end
         \tl_case:Nn
           \l_tmpa_tl
           {
-            \c_@@_option_type_boolean
+            \c_@@_option_type_boolean_tl
               {
                 \@@_option_tl_to_cs:nN
                   { #1 }
@@ -21624,10 +21624,10 @@ end
                   {
                     \str_if_eq_p:vV
                       { \l_tmpa_tl }
-                      \c_@@_option_value_true ||
+                      \c_@@_option_value_true_tl ||
                     \str_if_eq_p:vV
                       { \l_tmpa_tl }
-                      \c_@@_option_value_false
+                      \c_@@_option_value_false_tl
                   }
                   {
                     \msg_error:nnxv
@@ -21761,8 +21761,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\tl_const:Nn \c_@@_option_value_true  { true  }
-\tl_const:Nn \c_@@_option_value_false { false }
+\tl_const:Nn \c_@@_option_value_true_tl  { true  }
+\tl_const:Nn \c_@@_option_value_false_tl { false }
 \msg_new:nnn
   { markdown }
   { expected-boolean-option }
@@ -21778,7 +21778,7 @@ end
       \l_tmpa_tl
     \tl_if_eq:NNF
       \l_tmpa_tl
-      \c_@@_option_type_boolean
+      \c_@@_option_type_boolean_tl
       {
         \msg_error:nnxx
           { markdown }
@@ -21803,7 +21803,7 @@ end
       }
     \tl_if_eq:NNTF
       \l_tmpb_tl
-      \c_@@_option_value_true
+      \c_@@_option_value_true_tl
       { #2 }
       { #3 }
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -14178,84 +14178,52 @@ following text:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\def\markdownRendererAttributeIdentifierPrototype#1{}%
-\def\markdownRendererAttributeClassNamePrototype#1{}%
-\def\markdownRendererAttributeKeyValuePrototype#1#2{}%
-\def\markdownRendererDocumentBeginPrototype{}%
-\def\markdownRendererDocumentEndPrototype{}%
-\def\markdownRendererInterblockSeparatorPrototype{}%
-\def\markdownRendererLineBreakPrototype{}%
-\def\markdownRendererEllipsisPrototype{}%
-\def\markdownRendererHeaderAttributeContextBeginPrototype{}%
-\def\markdownRendererHeaderAttributeContextEndPrototype{}%
-\def\markdownRendererNbspPrototype{}%
-\def\markdownRendererLeftBracePrototype{}%
-\def\markdownRendererRightBracePrototype{}%
-\def\markdownRendererDollarSignPrototype{}%
-\def\markdownRendererPercentSignPrototype{}%
-\def\markdownRendererAmpersandPrototype{}%
-\def\markdownRendererUnderscorePrototype{}%
-\def\markdownRendererHashPrototype{}%
-\def\markdownRendererCircumflexPrototype{}%
-\def\markdownRendererBackslashPrototype{}%
-\def\markdownRendererTildePrototype{}%
-\def\markdownRendererPipePrototype{}%
-\def\markdownRendererCodeSpanPrototype#1{}%
-\def\markdownRendererLinkPrototype#1#2#3#4{}%
-\def\markdownRendererImagePrototype#1#2#3#4{}%
-\def\markdownRendererContentBlockPrototype#1#2#3#4{}%
-\def\markdownRendererContentBlockOnlineImagePrototype#1#2#3#4{}%
-\def\markdownRendererContentBlockCodePrototype#1#2#3#4#5{}%
-\def\markdownRendererUlBeginPrototype{}%
-\def\markdownRendererUlBeginTightPrototype{}%
-\def\markdownRendererUlItemPrototype{}%
-\def\markdownRendererUlItemEndPrototype{}%
-\def\markdownRendererUlEndPrototype{}%
-\def\markdownRendererUlEndTightPrototype{}%
-\def\markdownRendererOlBeginPrototype{}%
-\def\markdownRendererOlBeginTightPrototype{}%
-\def\markdownRendererOlItemPrototype{}%
-\def\markdownRendererOlItemWithNumberPrototype#1{}%
-\def\markdownRendererOlItemEndPrototype{}%
-\def\markdownRendererOlEndPrototype{}%
-\def\markdownRendererOlEndTightPrototype{}%
-\def\markdownRendererDlBeginPrototype{}%
-\def\markdownRendererDlBeginTightPrototype{}%
-\def\markdownRendererDlItemPrototype#1{}%
-\def\markdownRendererDlItemEndPrototype{}%
-\def\markdownRendererDlDefinitionBeginPrototype{}%
-\def\markdownRendererDlDefinitionEndPrototype{}%
-\def\markdownRendererDlEndPrototype{}%
-\def\markdownRendererDlEndTightPrototype{}%
-\def\markdownRendererEmphasisPrototype#1{}%
-\def\markdownRendererStrongEmphasisPrototype#1{}%
-\def\markdownRendererBlockQuoteBeginPrototype{}%
-\def\markdownRendererBlockQuoteEndPrototype{}%
-\def\markdownRendererInputVerbatimPrototype#1{}%
-\def\markdownRendererInputFencedCodePrototype#1#2{}%
-\def\markdownRendererJekyllDataBeginPrototype{}%
-\def\markdownRendererJekyllDataEndPrototype{}%
-\def\markdownRendererHeadingOnePrototype#1{}%
-\def\markdownRendererHeadingTwoPrototype#1{}%
-\def\markdownRendererHeadingThreePrototype#1{}%
-\def\markdownRendererHeadingFourPrototype#1{}%
-\def\markdownRendererHeadingFivePrototype#1{}%
-\def\markdownRendererHeadingSixPrototype#1{}%
-\def\markdownRendererHorizontalRulePrototype{}%
-\def\markdownRendererFootnotePrototype#1{}%
-\def\markdownRendererCitePrototype#1{}%
-\def\markdownRendererTextCitePrototype#1{}%
-\def\markdownRendererTablePrototype#1#2#3{}%
-\def\markdownRendererInlineHtmlCommentPrototype#1{}%
-\let\markdownRendererBlockHtmlCommentBeginPrototype=\iffalse
-\let\markdownRendererBlockHtmlCommentBegin=\iffalse
-\let\markdownRendererBlockHtmlCommentEndPrototype=\fi
-\let\markdownRendererBlockHtmlCommentEnd=\fi
-\def\markdownRendererInlineHtmlTagPrototype#1{}%
-\def\markdownRendererInputBlockHtmlElementPrototype#1{}%
-\def\markdownRendererTickedBoxPrototype{}%
-\def\markdownRendererHalfTickedBoxPrototype{}%
-\def\markdownRendererUntickedBoxPrototype{}%
+\ExplSyntaxOn
+\cs_new:Nn \@@_plaintex_define_renderer_prototypes:
+  {
+    \seq_map_function:NN
+      \g_@@_renderers_seq
+      \@@_plaintex_define_renderer_prototype:n
+    \let\markdownRendererBlockHtmlCommentBeginPrototype=\iffalse
+    \let\markdownRendererBlockHtmlCommentBegin=\iffalse
+    \let\markdownRendererBlockHtmlCommentEndPrototype=\fi
+    \let\markdownRendererBlockHtmlCommentEnd=\fi
+  }
+\cs_new:Nn \@@_plaintex_define_renderer_prototype:n
+  {
+    \tl_set:Nn
+      \l_tmpb_tl
+%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
+      { \str_upper_case:n { #1 } }
+    \tl_set:Nx
+      \l_tmpa_tl
+      {
+        markdownRenderer
+        \tl_head:f { \l_tmpb_tl }
+        \tl_tail:n { #1 }
+        Prototype
+      }
+    \prop_get:NnN
+      \g_@@_renderer_arities_prop
+      { #1 }
+      \l_tmpb_tl
+    \@@_plaintex_define_renderer_prototype:cV
+      { \l_tmpa_tl }
+      \l_tmpb_tl
+  }
+\cs_new:Nn \@@_plaintex_define_renderer_prototype:Nn
+  {
+    \cs_generate_from_arg_count:NNnn
+      #1
+      \cs_set:Npn
+      { #2 }
+      { }
+  }
+\cs_generate_variant:Nn
+  \@@_plaintex_define_renderer_prototype:Nn
+  { cV }
+\@@_plaintex_define_renderer_prototypes:
+\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21621,11 +21621,14 @@ end
                 \@@_option_tl_to_cs:nN
                   { #1 }
                   \l_tmpa_tl
-                \tl_case:cnF
-                  { \l_tmpa_tl }
+                \bool_if:nF
                   {
-                    \c_@@_option_value_true  { }
-                    \c_@@_option_value_false { }
+                    \str_if_eq_p:vV
+                      { \l_tmpa_tl }
+                      \c_@@_option_value_true ||
+                    \str_if_eq_p:vV
+                      { \l_tmpa_tl }
+                      \c_@@_option_value_false
                   }
                   {
                     \msg_error:nnxv
@@ -21638,6 +21641,10 @@ end
           }
       }
   }
+\prg_generate_conditional_variant:Nnn
+  \str_if_eq:nn
+  { vV }
+  { p  }
 \cs_generate_variant:Nn
   \msg_error:nnnn
   { nnxv }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1840,6 +1840,30 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 %  \begin{macrocode}
 \prop_new:N \g_@@_lua_option_types_prop
 \prop_new:N \g_@@_default_lua_options_prop
+\cs_new:Nn
+  \@@_add_lua_option:nnn
+  {
+    \@@_add_option:nnnn
+      { lua }
+      { #1 }
+      { #2 }
+      { #3 }
+  }
+\cs_new:Nn
+  \@@_add_option:nnnn
+  {
+    \seq_put_right:cn
+      { g_@@_ #1 _options_seq }
+      { #2 }
+    \prop_put:cnn
+      { g_@@_ #1 _option_types_prop }
+      { #2 }
+      { #3 }
+    \prop_put:cnn
+      { g_@@_default_ #1 _options_prop }
+      { #2 }
+      { #4 }
+  }
 %    \end{macrocode}
 % \iffalse
 %</tex>
@@ -1996,16 +2020,9 @@ option.
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { cacheDir }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { cacheDir }
   { path }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { cacheDir }
   { \markdownOptionOutputDir / _markdown_\jobname }
 %    \end{macrocode}
 % \iffalse
@@ -2231,16 +2248,9 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { frozenCacheFileName }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { frozenCacheFileName }
   { path }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { frozenCacheFileName }
   { \markdownOptionCacheDir / frozenCache.tex }
 %    \end{macrocode}
 % \iffalse
@@ -2462,16 +2472,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { blankBeforeBlockquote }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { blankBeforeBlockquote }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { blankBeforeBlockquote }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -2718,16 +2721,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { blankBeforeCodeFence }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { blankBeforeCodeFence }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { blankBeforeCodeFence }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -2957,16 +2953,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { blankBeforeHeading }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { blankBeforeHeading }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { blankBeforeHeading }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -3188,16 +3177,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { breakableBlockquotes }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { breakableBlockquotes }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { breakableBlockquotes }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -3289,16 +3271,9 @@ following text, where the middot (`·`) denotes a non-breaking space:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { citationNbsps }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { citationNbsps }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { citationNbsps }
   { true }
 %    \end{macrocode}
 % \iffalse
@@ -3397,16 +3372,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { citations }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { citations }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { citations }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -3622,16 +3590,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { codeSpans }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { codeSpans }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { codeSpans }
   { true }
 %    \end{macrocode}
 % \iffalse
@@ -3803,16 +3764,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { contentBlocks }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { contentBlocks }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { contentBlocks }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -3970,16 +3924,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { contentBlocksLanguageMap }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { contentBlocksLanguageMap }
   { path }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { contentBlocksLanguageMap }
   { markdown-languages.json }
 %    \end{macrocode}
 % \iffalse
@@ -4116,16 +4063,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { definitionLists }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { definitionLists }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { definitionLists }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -4224,16 +4164,9 @@ Hello \markdownRendererEmphasis{world}!\relax
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { eagerCache }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { eagerCache }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { eagerCache }
   { true }
 %    \end{macrocode}
 % \iffalse
@@ -4359,16 +4292,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { expectJekyllData }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { expectJekyllData }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { expectJekyllData }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -4534,16 +4460,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { fencedCode }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { fencedCode }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { fencedCode }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -4705,16 +4624,9 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { finalizeCache }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { finalizeCache }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { finalizeCache }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -4881,16 +4793,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { footnotes }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { footnotes }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { footnotes }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -4953,16 +4858,9 @@ requested using the `frozenCacheCounter` option.
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { frozenCacheCounter }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { frozenCacheCounter }
   { counter }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { frozenCacheCounter }
   { 0 }
 %    \end{macrocode}
 % \iffalse
@@ -5044,16 +4942,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { hardLineBreaks }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { hardLineBreaks }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { hardLineBreaks }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -5182,16 +5073,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { hashEnumerators }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { hashEnumerators }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { hashEnumerators }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -5244,16 +5128,9 @@ defaultOptions.hashEnumerators = false
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { headerAttributes }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { headerAttributes }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { headerAttributes }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -5513,16 +5390,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { html }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { html }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { html }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -5731,16 +5601,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { hybrid }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { hybrid }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { hybrid }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -5837,16 +5700,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { inlineFootnotes }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { inlineFootnotes }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { inlineFootnotes }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -6012,16 +5868,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { jekyllData }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { jekyllData }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { jekyllData }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -6128,16 +5977,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { pipeTables }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { pipeTables }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { pipeTables }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -6175,16 +6017,9 @@ defaultOptions.pipeTables = false
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { preserveTabs }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { preserveTabs }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { preserveTabs }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -6271,16 +6106,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { relativeReferences }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { relativeReferences }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { relativeReferences }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -6423,16 +6251,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { shiftHeadings }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { shiftHeadings }
   { number }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { shiftHeadings }
   { 0 }
 %    \end{macrocode}
 % \iffalse
@@ -6648,15 +6469,8 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
+\@@_add_lua_option:nnn
   { slice }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
-  { slice }
-  { slice }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
   { slice }
   { ^~$ }
 %    \end{macrocode}
@@ -6862,16 +6676,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { smartEllipses }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { smartEllipses }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { smartEllipses }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -7005,16 +6812,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { startNumber }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { startNumber }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { startNumber }
   { true }
 %    \end{macrocode}
 % \iffalse
@@ -7125,16 +6925,9 @@ text “Hello *world*!”
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { stripIndent }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { stripIndent }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { stripIndent }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -7256,16 +7049,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { tableCaptions }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { tableCaptions }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { tableCaptions }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -7373,16 +7159,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { taskLists }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { taskLists }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { taskLists }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -7496,16 +7275,9 @@ text “Hello *world*!”
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { texComments }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { texComments }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { texComments }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -7625,16 +7397,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { tightLists }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { tightLists }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { tightLists }
   { true }
 %    \end{macrocode}
 % \iffalse
@@ -7774,16 +7539,9 @@ following text:
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_lua_options_seq
-  { underscores }
-\prop_put:Nnn
-  \g_@@_lua_option_types_prop
+\@@_add_lua_option:nnn
   { underscores }
   { boolean }
-\prop_put:Nnn
-  \g_@@_default_lua_options_prop
-  { underscores }
   { true }
 \ExplSyntaxOff
 %    \end{macrocode}
@@ -8195,6 +7953,15 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \prop_new:N \g_@@_plain_tex_option_types_prop
 \prop_new:N \g_@@_default_plain_tex_options_prop
+\cs_new:Nn
+  \@@_add_plain_tex_option:nnn
+  {
+    \@@_add_option:nnnn
+      { plain_tex }
+      { #1 }
+      { #2 }
+      { #3 }
+  }
 %    \end{macrocode}
 % \iffalse
 %</tex>
@@ -8254,16 +8021,9 @@ defaults to `false`.
 %<*tex>
 % \fi
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { frozenCache }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
+\@@_add_plain_tex_option:nnn
   { frozenCache }
   { boolean }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { frozenCache }
   { false }
 %    \end{macrocode}
 % \iffalse
@@ -8314,16 +8074,9 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { helperScriptFileName }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
+\@@_add_plain_tex_option:nnn
   { helperScriptFileName }
   { path }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { helperScriptFileName }
   { \jobname.markdown.lua }
 %    \end{macrocode}
 % \par
@@ -8337,16 +8090,9 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { inputTempFileName }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
+\@@_add_plain_tex_option:nnn
   { inputTempFileName }
   { path }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { inputTempFileName }
   { \jobname.markdown.in }
 %    \end{macrocode}
 % \par
@@ -8360,16 +8106,9 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { outputTempFileName }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
+\@@_add_plain_tex_option:nnn
   { outputTempFileName }
   { path }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { outputTempFileName }
   { \jobname.markdown.out }
 %    \end{macrocode}
 % \par
@@ -8384,16 +8123,9 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { errorTempFileName }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
+\@@_add_plain_tex_option:nnn
   { errorTempFileName }
   { path }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { errorTempFileName }
   { \jobname.markdown.err }
 %    \end{macrocode}
 % \par
@@ -8412,16 +8144,9 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { outputDir }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
+\@@_add_plain_tex_option:nnn
   { outputDir }
   { path }
-\prop_put:Nnn
-  \g_@@_default_plain_tex_options_prop
-  { outputDir }
   { . }
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21557,36 +21557,17 @@ end
     \@@_get_option_type:nN
       { #1 }
       \l_tmpa_tl
-    \tl_case:NnF
-      \l_tmpa_tl
+    \bool_if:nTF
       {
-        \c_@@_option_type_boolean_tl
-          {
-            \@@_get_option:nN
-              { #1 }
-              \l_tmpa_tl
-            \tl_gput_right:Nx
-              \g_@@_formatted_lua_options_tl
-              { #1~=~  \l_tmpa_tl   ,~ }
-          }
-        \c_@@_option_type_number_tl
-          {
-            \@@_get_option:nN
-              { #1 }
-              \l_tmpa_tl
-            \tl_gput_right:Nx
-              \g_@@_formatted_lua_options_tl
-              { #1~=~  \l_tmpa_tl   ,~ }
-          }
-        \c_@@_option_type_counter_tl
-          {
-            \@@_get_option:nN
-              { #1 }
-              \l_tmpa_tl
-            \tl_gput_right:Nx
-              \g_@@_formatted_lua_options_tl
-              { #1~=~  \l_tmpa_tl   ,~ }
-          }
+        \str_if_eq_p:VV
+          \l_tmpa_tl
+          \c_@@_option_type_boolean_tl ||
+        \str_if_eq_p:VV
+          \l_tmpa_tl
+          \c_@@_option_type_number_tl ||
+        \str_if_eq_p:VV
+          \l_tmpa_tl
+          \c_@@_option_type_counter_tl
       }
       {
         \@@_get_option:nN
@@ -21594,7 +21575,15 @@ end
           \l_tmpa_tl
         \tl_gput_right:Nx
           \g_@@_formatted_lua_options_tl
-          {     #1~=~ " \l_tmpa_tl " ,~ }
+          { #1~=~  \l_tmpa_tl   ,~ }
+      }
+      {
+        \@@_get_option:nN
+          { #1 }
+          \l_tmpa_tl
+        \tl_gput_right:Nx
+          \g_@@_formatted_lua_options_tl
+          { #1~=~ " \l_tmpa_tl " ,~ }
       }
   }
 \msg_new:nnn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1846,9 +1846,9 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 %<*manual-options>
 % \fi
 % \begin{markdown}
-% 
+%
 %### File and Directory Names
-% 
+%
 % \end{markdown}
 % \par
 % \iffalse
@@ -2006,7 +2006,7 @@ option.
 \prop_put:Nnn
   \g_@@_default_lua_options_prop
   { cacheDir }
-  { . }
+  { \markdownOptionOutputDir / _markdown_\jobname }
 %    \end{macrocode}
 % \iffalse
 %</tex>
@@ -2241,7 +2241,7 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 \prop_put:Nnn
   \g_@@_default_lua_options_prop
   { frozenCacheFileName }
-  { frozenCache.tex }
+  { \markdownOptionCacheDir / frozenCache.tex }
 %    \end{macrocode}
 % \iffalse
 %</tex>
@@ -8307,13 +8307,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   \g_@@_default_plain_tex_options_prop
   { helperScriptFileName }
   { \jobname.markdown.lua }
-\tl_gset:Nx
-  \markdownOptionHelperScriptFileName
-  {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { helperScriptFileName }
-  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8337,13 +8330,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   \g_@@_default_plain_tex_options_prop
   { inputTempFileName }
   { \jobname.markdown.in }
-\tl_gset:Nx
-  \markdownOptionInputTempFileName
-  {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { inputTempFileName }
-  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8367,13 +8353,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   \g_@@_default_plain_tex_options_prop
   { outputTempFileName }
   { \jobname.markdown.out }
-\tl_gset:Nx
-  \markdownOptionOutputTempFileName
-  {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { outputTempFileName }
-  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8398,13 +8377,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   \g_@@_default_plain_tex_options_prop
   { errorTempFileName }
   { \jobname.markdown.err }
-\tl_gset:Nx
-  \markdownOptionErrorTempFileName
-  {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { errorTempFileName }
-  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -8433,85 +8405,79 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   \g_@@_default_plain_tex_options_prop
   { outputDir }
   { . }
-\tl_gset:Nx
-  \markdownOptionOutputDir
-  {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { outputDir }
-  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
 %
-% The \mdef{markdownOptionCacheDir} macro corresponds to the Lua interface
-% \Opt{cacheDir} option that sets the path to the directory that will contain
-% the produced cache files. The option defaults to `_markdown_`\mref{jobname},
-% which is a similar naming scheme to the one used by the \pkg{minted} \LaTeX{}
-% package. The same limitations apply here as in the case of the
+% Here, we automatically define all the above macros for plain \TeX{} options.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\cs_new:Nn \@@_plain_tex_define_options:
+  {
+    \seq_map_function:NN
+      \g_@@_lua_options_seq
+      \@@_plain_tex_define_lua_option:n
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### Lua Interface Options
+% Furthemore, we also define macros that map directly to the options recognized
+% by the Lua interface, such as \mdef{markdownOptionHybrid} for the
+% \Opt{hybrid} Lua option (see Section <#sec:luaoptions>), which are not
+% processed by the plain \TeX{} implementation, only passed along to Lua.
+%
+% For the macros that correspond to the non-boolean options recognized by the
+% Lua interface, the same limitations apply here in the case of the
 % \mref{markdownOptionHelperScriptFileName} macro.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { cacheDir }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
-  { cacheDir }
-  { path }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { cacheDir }
-  {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { outputDir }
-    / _markdown_\jobname
+    \seq_map_function:NN
+      \g_@@_plain_tex_options_seq
+      \@@_plain_tex_define_plain_tex_option:n
   }
-\tl_gset:Nx
-  \markdownOptionCacheDir
+\cs_new:Nn \@@_plain_tex_define_lua_option:n
   {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { cacheDir }
+    \@@_plain_tex_define_option:nN
+      { #1 }
+      \g_@@_default_lua_options_prop
   }
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% The \mdef{markdownOptionFrozenCacheFileName} macro corresponds to the Lua
-% interface \Opt{frozenCacheFileName} option that sets the path to an output
-% file (frozen cache) that will contain a mapping between an enumeration of the
-% markdown documents in the plain \TeX{} document and their auxiliary cache
-% files. The option defaults to `frozenCache.tex`. The same limitations apply
-% here as in the case of the \mref{markdownOptionHelperScriptFileName} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\seq_put_right:Nn
-  \g_@@_plain_tex_options_seq
-  { frozenCacheFileName }
-\prop_put:Nnn
-  \g_@@_plain_tex_option_types_prop
-  { frozenCacheFileName }
-  { path }
-\prop_put:Nnx
-  \g_@@_default_plain_tex_options_prop
-  { frozenCacheFileName }
+\cs_new:Nn \@@_plain_tex_define_plain_tex_option:n
   {
-    \prop_item:Nn
+    \@@_plain_tex_define_option:nN
+      { #1 }
       \g_@@_default_plain_tex_options_prop
-      { cacheDir }
-    / frozenCache.tex
   }
-\tl_gset:Nx
-  \markdownOptionFrozenCacheFileName
+\cs_new:Nn \@@_plain_tex_define_option:nN
   {
-    \prop_item:Nn
-      \g_@@_default_plain_tex_options_prop
-      { frozenCacheFileName }
+    \@@_option_tl_to_cs:nN
+      { #1 }
+      \l_tmpa_tl
+    \prop_get:NnN
+      #2
+      { #1 }
+      \l_tmpb_tl
+    \exp_args:NNo
+      \cs_new:cpn
+        \l_tmpa_tl
+        { \l_tmpb_tl }
   }
+\cs_new:Nn \@@_option_tl_to_cs:nN
+  {
+    \tl_set:Nn
+      \l_tmpa_tl
+%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
+      { \str_upper_case:n { #1 } }
+    \tl_set:Nx
+      #2
+      {
+        markdownOption
+        \tl_head:f { \l_tmpa_tl }
+        \tl_tail:n { #1 }
+      }
+  }
+\@@_plain_tex_define_options:
 \ExplSyntaxOff
 %    \end{macrocode}
 %
@@ -8578,61 +8544,6 @@ No document named `error-output.txt` should be produced in the folder named
 `output-directory`. This document would only be produced if an error had occured
 while executing the Lua code. If this happens, please [file a
 bug](https://github.com/witiko/markdown/issues).
-
-%</manual-options>
-%<*tex>
-% \fi
-% \par
-% \begin{markdown}
-%
-%#### Lua Interface Options
-% The following macros map directly to the options recognized by the Lua
-% interface (see Section <#sec:luaoptions>) and are not processed by the
-% plain \TeX{} implementation, only passed along to Lua. They are undefined, which
-% makes them fall back to the default values provided by the Lua interface.
-%
-% For the macros that correspond to the non-boolean options recognized by the
-% Lua interface, the same limitations apply here in the case of the
-% \mref{markdownOptionHelperScriptFileName} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\let\markdownOptionBlankBeforeBlockquote\undefined
-\let\markdownOptionBlankBeforeCodeFence\undefined
-\let\markdownOptionBlankBeforeHeading\undefined
-\let\markdownOptionBreakableBlockquotes\undefined
-\let\markdownOptionCitations\undefined
-\let\markdownOptionCitationNbsps\undefined
-\let\markdownOptionContentBlocks\undefined
-\let\markdownOptionContentBlocksLanguageMap\undefined
-\let\markdownOptionDefinitionLists\undefined
-\let\markdownOptionEagerCache\undefined
-\let\markdownOptionFootnotes\undefined
-\let\markdownOptionFencedCode\undefined
-\let\markdownOptionHardLineBreaks\undefined
-\let\markdownOptionHashEnumerators\undefined
-\let\markdownOptionHeaderAttributes\undefined
-\let\markdownOptionHtml\undefined
-\let\markdownOptionHybrid\undefined
-\let\markdownOptionInlineFootnotes\undefined
-\let\markdownOptionJekyllData\undefined
-\let\markdownOptionPipeTables\undefined
-\let\markdownOptionPreserveTabs\undefined
-\let\markdownOptionRelativeReferences\undefined
-\let\markdownOptionShiftHeadings\undefined
-\let\markdownOptionSlice\undefined
-\let\markdownOptionSmartEllipses\undefined
-\let\markdownOptionStartNumber\undefined
-\let\markdownOptionStripIndent\undefined
-\let\markdownOptionTableCaptions\undefined
-\let\markdownOptionTaskLists\undefined
-\let\markdownOptionTexComments\undefined
-\let\markdownOptionTightLists\undefined
-%    \end{macrocode}
-% \par
-% \iffalse
-%</tex>
-%<*manual-options>
 
 #### Package Documentation
 
@@ -14339,18 +14250,9 @@ following text:
   }
 \cs_new:Nn \@@_plaintex_define_renderer_prototype:n
   {
-    \tl_set:Nn
-      \l_tmpb_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
+    \@@_renderer_prototype_tl_to_cs:nN
+      { #1 }
       \l_tmpa_tl
-      {
-        markdownRenderer
-        \tl_head:f { \l_tmpb_tl }
-        \tl_tail:n { #1 }
-        Prototype
-      }
     \prop_get:NnN
       \g_@@_renderer_arities_prop
       { #1 }
@@ -14358,6 +14260,21 @@ following text:
     \@@_plaintex_define_renderer_prototype:cV
       { \l_tmpa_tl }
       \l_tmpb_tl
+  }
+\cs_new:Nn \@@_renderer_prototype_tl_to_cs:nN
+  {
+    \tl_set:Nn
+      \l_tmpa_tl
+%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
+      { \str_upper_case:n { #1 } }
+    \tl_set:Nx
+      #2
+      {
+        markdownRenderer
+        \tl_head:f { \l_tmpa_tl }
+        \tl_tail:n { #1 }
+        Prototype
+      }
   }
 \cs_new:Nn \@@_plaintex_define_renderer_prototype:Nn
   {
@@ -15364,17 +15281,9 @@ The following ordered list will be preceded by roman numerals:
   }
 \cs_new:Nn \@@_latex_define_renderer:n
   {
-    \tl_set:Nn
-      \l_tmpb_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
+    \@@_renderer_tl_to_cs:nN
+      { #1 }
       \l_tmpa_tl
-      {
-        markdownRenderer
-        \tl_head:f { \l_tmpb_tl }
-        \tl_tail:n { #1 }
-      }
     \prop_get:NnN
       \g_@@_renderer_arities_prop
       { #1 }
@@ -15383,6 +15292,20 @@ The following ordered list will be preceded by roman numerals:
       { #1 }
       { \l_tmpa_tl }
       \l_tmpb_tl
+  }
+\cs_new:Nn \@@_renderer_tl_to_cs:nN
+  {
+    \tl_set:Nn
+      \l_tmpa_tl
+%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
+      { \str_upper_case:n { #1 } }
+    \tl_set:Nx
+      #2
+      {
+        markdownRenderer
+        \tl_head:f { \l_tmpa_tl }
+        \tl_tail:n { #1 }
+      }
   }
 \cs_new:Nn \@@_latex_define_renderer:nNn
   {
@@ -15435,18 +15358,9 @@ The following ordered list will be preceded by roman numerals:
   }
 \cs_new:Nn \@@_latex_define_renderer_prototype:n
   {
-    \tl_set:Nn
-      \l_tmpb_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
+    \@@_renderer_prototype_tl_to_cs:nN
+      { #1 }
       \l_tmpa_tl
-      {
-        markdownRenderer
-        \tl_head:f { \l_tmpb_tl }
-        \tl_tail:n { #1 }
-        Prototype
-      }
     \prop_get:NnN
       \g_@@_renderer_arities_prop
       { #1 }
@@ -21603,18 +21517,11 @@ end
   }
 \cs_new:Nn \@@_format_lua_option:n
   {
-    \@@_typecheck_lua_option:n { #1 }
-    \tl_set:Nn
-      \l_tmpb_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
+    \@@_typecheck_lua_option:n
+      { #1 }
+    \@@_option_tl_to_cs:nN
+      { #1 }
       \l_tmpa_tl
-      {
-        markdownOption
-        \tl_head:f { \l_tmpb_tl }
-        \tl_tail:n { #1 }
-      }
     \prop_get:NnN
       \g_@@_lua_option_types_prop
       { #1 }
@@ -21673,17 +21580,9 @@ end
   }
 \cs_new:Nn \@@_typecheck_lua_option:n
   {
-    \tl_set:Nn
-      \l_tmpb_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
+    \@@_option_tl_to_cs:nN
+      { #1 }
       \l_tmpa_tl
-      {
-        markdownOption
-        \tl_head:f { \l_tmpb_tl }
-        \tl_tail:n { #1 }
-      }
     \prop_get:NnNTF
       \g_@@_lua_option_types_prop
       { #1 }
@@ -21785,17 +21684,9 @@ end
 \tl_const:Nn \c_@@_lua_option_value_false { false }
 \cs_new:Nn \@@_if_option:nTF
   {
-    \tl_set:Nn
-      \l_tmpb_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
+    \@@_option_tl_to_cs:nN
+      { #1 }
       \l_tmpa_tl
-      {
-        markdownOption
-        \tl_head:f { \l_tmpb_tl }
-        \tl_tail:n { #1 }
-      }
     \cs_if_free:cTF
       { \l_tmpa_tl }
       {

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8350,10 +8350,10 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   { path }
   { . }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
-% Here, we automatically define all the above macros for plain \TeX{} options.
+% Here, we automatically define plain \TeX{} macros for the above plain \TeX{}
+% options.
 %
 % Furthemore, we also define macros that map directly to the options recognized
 % by the Lua interface, such as \mdef{markdownOptionHybrid} for the
@@ -14674,7 +14674,8 @@ definitions from the plain \TeX{} implementation
 % (see Section <#sec:textokenrendererprototypes>)
 and prevent the soft \LaTeX{} prerequisites
 % in Section <#sec:latexprerequisites>
-from being loaded:
+from being loaded: The plain option must be set before or when loading the
+package. Setting the option after loading the package will have no effect.
 
 ``` tex
 \usepackage[plain]{markdown}
@@ -14691,13 +14692,6 @@ from being loaded:
   { boolean }
   { false }
 \ExplSyntaxOff
-\define@key{markdownOptions}{plain}[true]{%
-  \ifmarkdownLaTeXLoaded
-    \markdownWarning
-      {The plain option must be specified when loading the package}%
-  \else
-    \renewcommand\markdownOptionPlain{#1}%
-  \fi}
 %    \end{macrocode}
 % \iffalse
 %</latex>
@@ -15149,98 +15143,81 @@ The following ordered list will be preceded by roman numerals:
 
 ```````
 
-%#### Plain \TeX{} Interface Options
-% The following options map directly to the option macros exposed by the plain
-% \TeX{} interface (see Section <#sec:texoptions>).
-%
 % \markdownEnd
 % \iffalse
 %</manual-options>
 %<*latex>
 % \fi
+% \begin{markdown}
+%
+%#### Plain \TeX{} Interface Options
+% Here, we automatically define plain \TeX{} macros and the
+% \meta{key}`=`\meta{value} interface for the above \LaTeX{} options.
+%
+% \end{markdown}
 %  \begin{macrocode}
-\define@key{markdownOptions}{helperScriptFileName}{%
-  \def\markdownOptionHelperScriptFileName{#1}}%
-\define@key{markdownOptions}{inputTempFileName}{%
-  \def\markdownOptionInputTempFileName{#1}}%
-\define@key{markdownOptions}{outputTempFileName}{%
-  \def\markdownOptionOutputTempFileName{#1}}%
-\define@key{markdownOptions}{errorTempFileName}{%
-  \def\markdownOptionErrorTempFileName{#1}}%
-\define@key{markdownOptions}{cacheDir}{%
-  \def\markdownOptionCacheDir{#1}}%
-\define@key{markdownOptions}{outputDir}{%
-  \def\markdownOptionOutputDir{#1}}%
-\define@key{markdownOptions}{blankBeforeBlockquote}[true]{%
-  \def\markdownOptionBlankBeforeBlockquote{#1}}%
-\define@key{markdownOptions}{blankBeforeCodeFence}[true]{%
-  \def\markdownOptionBlankBeforeCodeFence{#1}}%
-\define@key{markdownOptions}{blankBeforeHeading}[true]{%
-  \def\markdownOptionBlankBeforeHeading{#1}}%
-\define@key{markdownOptions}{breakableBlockquotes}[true]{%
-  \def\markdownOptionBreakableBlockquotes{#1}}%
-\define@key{markdownOptions}{citations}[true]{%
-  \def\markdownOptionCitations{#1}}%
-\define@key{markdownOptions}{citationNbsps}[true]{%
-  \def\markdownOptionCitationNbsps{#1}}%
-\define@key{markdownOptions}{contentBlocks}[true]{%
-  \def\markdownOptionContentBlocks{#1}}%
-\define@key{markdownOptions}{codeSpans}[true]{%
-  \def\markdownOptionCodeSpans{#1}}%
-\define@key{markdownOptions}{contentBlocksLanguageMap}{%
-  \def\markdownOptionContentBlocksLanguageMap{#1}}%
-\define@key{markdownOptions}{definitionLists}[true]{%
-  \def\markdownOptionDefinitionLists{#1}}%
-\define@key{markdownOptions}{eagerCache}[true]{%
-  \def\markdownOptionEagerCache{#1}}%
-\define@key{markdownOptions}{expectJekyllData}[true]{%
-  \def\markdownOptionExpectJekyllData{#1}}%
-\define@key{markdownOptions}{footnotes}[true]{%
-  \def\markdownOptionFootnotes{#1}}%
-\define@key{markdownOptions}{fencedCode}[true]{%
-  \def\markdownOptionFencedCode{#1}}%
-\define@key{markdownOptions}{jekyllData}[true]{%
-  \def\markdownOptionJekyllData{#1}}%
-\define@key{markdownOptions}{hardLineBreaks}[true]{%
-  \def\markdownOptionHardLineBreaks{#1}}%
-\define@key{markdownOptions}{hashEnumerators}[true]{%
-  \def\markdownOptionHashEnumerators{#1}}%
-\define@key{markdownOptions}{headerAttributes}[true]{%
-  \def\markdownOptionHeaderAttributes{#1}}%
-\define@key{markdownOptions}{html}[true]{%
-  \def\markdownOptionHtml{#1}}%
-\define@key{markdownOptions}{hybrid}[true]{%
-  \def\markdownOptionHybrid{#1}}%
-\define@key{markdownOptions}{inlineFootnotes}[true]{%
-  \def\markdownOptionInlineFootnotes{#1}}%
-\define@key{markdownOptions}{pipeTables}[true]{%
-  \def\markdownOptionPipeTables{#1}}%
-\define@key{markdownOptions}{preserveTabs}[true]{%
-  \def\markdownOptionPreserveTabs{#1}}%
-\define@key{markdownOptions}{relativeReferences}[true]{%
-  \def\markdownOptionRelativeReferences{#1}}%
-\define@key{markdownOptions}{smartEllipses}[true]{%
-  \def\markdownOptionSmartEllipses{#1}}%
-\define@key{markdownOptions}{shiftHeadings}{%
-  \def\markdownOptionShiftHeadings{#1}}%
-\define@key{markdownOptions}{slice}{%
-  \def\markdownOptionSlice{#1}}%
-\define@key{markdownOptions}{startNumber}[true]{%
-  \def\markdownOptionStartNumber{#1}}%
-\define@key{markdownOptions}{stripIndent}[true]{%
-  \def\markdownOptionStripIndent{#1}}%
-\define@key{markdownOptions}{tableCaptions}[true]{%
-  \def\markdownOptionTableCaptions{#1}}%
-\define@key{markdownOptions}{taskLists}[true]{%
-  \def\markdownOptionTaskLists{#1}}%
-\define@key{markdownOptions}{texComments}[true]{%
-  \def\markdownOptionTexComments{#1}}%
-\define@key{markdownOptions}{tightLists}[true]{%
-  \def\markdownOptionTightLists{#1}}%
-\define@key{markdownOptions}{underscores}[true]{%
-  \def\markdownOptionUnderscores{#1}}%
-\define@key{markdownOptions}{stripPercentSigns}[true]{%
-  \def\markdownOptionStripPercentSigns{#1}}%
+\ExplSyntaxOn
+\cs_new:Nn \@@_latex_define_option_commands_and_keyvals:
+  {
+    \seq_map_inline:Nn
+      \g_@@_latex_options_seq
+      {
+          \@@_plain_tex_define_option_command:n
+            { ##1 }
+      }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Furthermore, we also define the \meta{key}`=`\meta{value} interface
+% for all option macros recognized by the Lua plain \TeX{} interfaces.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \seq_map_inline:Nn
+      \g_@@_option_layers_seq
+      {
+        \seq_map_inline:cn
+          { g_@@_ ##1 _options_seq }
+          {
+              \@@_latex_define_option_keyval:nn
+                { ##1 }
+                { ####1 }
+          }
+      }
+  }
+\cs_new:Nn \@@_latex_define_option_keyval:nn
+  {
+    \prop_get:cnN
+      { g_@@_ #1 _option_types_prop }
+      { #2 }
+      \l_tmpa_tl
+    \str_if_eq:VVTF
+      \l_tmpa_tl
+      \c_@@_option_type_boolean_tl
+      {
+        \define@key
+          { markdownOptions }
+          { #2 }
+          [ true ]
+          {
+            \@@_set_option_value:nn
+              { #2 }
+              { ##1 }
+          }
+      }
+      {
+        \define@key
+          { markdownOptions }
+          { #2 }
+          {
+            \@@_set_option_value:nn
+              { #2 }
+              { ##1 }
+          }
+      }
+  }
+\@@_latex_define_option_commands_and_keyvals:
+\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -15270,14 +15247,8 @@ The following ordered list will be preceded by roman numerals:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\define@key{markdownOptions}{finalizeCache}[true]{%
-  \def\markdownOptionFinalizeCache{#1}}%
 \DeclareOption{finalizecache}{\markdownSetup{finalizeCache}}
-\define@key{markdownOptions}{frozenCache}[true]{%
-  \def\markdownOptionFrozenCache{#1}}%
 \DeclareOption{frozencache}{\markdownSetup{frozenCache}}
-\define@key{markdownOptions}{frozenCacheFileName}{%
-  \def\markdownOptionFrozenCacheFileName{#1}}%
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8374,20 +8374,18 @@ For more information, see the examples for the \Opt{finalizeCache} option.
         \seq_map_inline:cn
           { g_@@_ ##1 _options_seq }
           {
-              \@@_plain_tex_define_option_command:nn
-                { ##1 }
+              \@@_plain_tex_define_option_command:n
                 { ####1 }
           }
       }
   }
-\cs_new:Nn \@@_plain_tex_define_option_command:nn
+\cs_new:Nn \@@_plain_tex_define_option_command:n
   {
-    \prop_get:cnN
-      { g_@@_default_ #1 _options_prop }
-      { #2 }
+    \@@_get_default_option:nN
+      { #1 }
       \l_tmpa_tl
     \@@_set_option_value:nV
-      { #2 }
+      { #1 }
       \l_tmpa_tl
   }
 \cs_new:Nn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1879,10 +1879,10 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
     \@@_get_option_type:nN
       { #1 }
       \l_tmpa_tl
-    \tl_case:Nn
+    \str_case_e:Vn
       \l_tmpa_tl
       {
-        \c_@@_option_type_boolean_tl
+        { \c_@@_option_type_boolean_tl }
           {
             \@@_get_option_value:nN
               { #1 }
@@ -1913,10 +1913,9 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
     Option~#1~has~value~#2,~
     but~a~boolean~(true~or~false)~was~expected.
   }
-\prg_generate_conditional_variant:Nnn
-  \str_if_eq:nn
-  { vV }
-  { p  }
+\cs_generate_variant:Nn
+  \str_case_e:nn
+  { Vn }
 \cs_generate_variant:Nn
   \msg_error:nnnn
   { nnnV }
@@ -8398,21 +8397,19 @@ For more information, see the examples for the \Opt{finalizeCache} option.
       #3
       { #1 }
       \l_tmpb_tl
-    \tl_case:NnF
+    \str_if_eq:VVTF
       \l_tmpb_tl
+      \c_@@_option_type_counter_tl
       {
-        \c_@@_option_type_counter_tl
-          {
-            \prop_get:NnN
-              #2
-              { #1 }
-              \l_tmpb_tl
-            \int_new:c
-              { \l_tmpa_tl }
-            \int_gset:cn
-              { \l_tmpa_tl }
-              { \l_tmpb_tl }
-          }
+        \prop_get:NnN
+          #2
+          { #1 }
+          \l_tmpb_tl
+        \int_new:c
+          { \l_tmpa_tl }
+        \int_gset:cn
+          { \l_tmpa_tl }
+          { \l_tmpb_tl }
       }
       {
         \prop_get:NnN

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8230,11 +8230,6 @@ following code in your plain \TeX{} document:
 % between an enumeration of the markdown documents in the plain \TeX{} document
 % and their auxiliary files cached in the \Opt{cacheDir} directory.
 %
-% \end{markdown}
-%  \begin{macrocode}
-\let\markdownOptionFinalizeCache\undefined
-%    \end{macrocode}
-% \par
 % \iffalse
 %</tex>
 %<*manual-options>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21561,9 +21561,8 @@ end
       \g_@@_lua_option_types_prop
       { #1 }
       \l_tmpb_tl
-    \cs_if_free:cTF
+    \cs_if_free:cF
       { \l_tmpa_tl }
-      { }
       {
         \tl_case:NnF
           \l_tmpb_tl

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8382,36 +8382,67 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   }
 \cs_new:Nn \@@_plain_tex_define_option_command:nn
   {
-    \@@_option_tl_to_csname:nN
+    \prop_get:cnN
+      { g_@@_default_ #1 _options_prop }
       { #2 }
       \l_tmpa_tl
-    \prop_get:cnN
-      { g_@@_ #1 _option_types_prop }
+    \@@_set_option_value:nV
       { #2 }
-      \l_tmpb_tl
-    \str_if_eq:VVTF
-      \l_tmpb_tl
+      \l_tmpa_tl
+  }
+\cs_new:Nn
+  \@@_set_option_value:nn
+  {
+    \@@_define_option:n
+      { #1 }
+    \@@_get_option_type:nN
+      { #1 }
+      \l_tmpa_tl
+    \str_if_eq:NNTF
       \c_@@_option_type_counter_tl
+      \l_tmpa_tl
       {
-        \prop_get:cnN
-          { g_@@_default_ #1 _options_prop }
-          { #2 }
-          \l_tmpb_tl
-        \int_new:c
-          { \l_tmpa_tl }
+        \@@_option_tl_to_csname:nN
+          { #1 }
+          \l_tmpa_tl
         \int_gset:cn
           { \l_tmpa_tl }
-          { \l_tmpb_tl }
+          { #2 }
       }
       {
-        \prop_get:cnN
-          { g_@@_default_ #1 _options_prop }
+        \@@_option_tl_to_csname:nN
+          { #1 }
+          \l_tmpa_tl
+        \cs_new:cpn
+          \l_tmpa_tl
           { #2 }
+      }
+  }
+\cs_generate_variant:Nn
+  \@@_set_option_value:nn
+  { nV }
+\cs_new:Nn
+  \@@_define_option:n
+  {
+    \@@_option_tl_to_csname:nN
+      { #1 }
+      \l_tmpa_tl
+    \cs_if_free:cT
+      { \l_tmpa_tl }
+      {
+        \@@_get_option_type:nN
+          { #1 }
           \l_tmpb_tl
-        \exp_args:NNo
-          \cs_new:cpn
-            \l_tmpa_tl
-            { \l_tmpb_tl }
+        \str_if_eq:NNT
+          \c_@@_option_type_counter_tl
+          \l_tmpb_tl
+          {
+            \@@_option_tl_to_csname:nN
+              { #1 }
+              \l_tmpa_tl
+            \int_new:c
+              { \l_tmpa_tl }
+          }
       }
   }
 \@@_plain_tex_define_option_commands:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1840,11 +1840,14 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 %  \begin{macrocode}
 \prop_new:N \g_@@_lua_option_types_prop
 \prop_new:N \g_@@_default_lua_options_prop
+\seq_new:N \g_@@_option_categories_seq
+\tl_const:Nn \c_@@_option_category_lua_tl { lua }
+\seq_put_right:NV \g_@@_option_categories_seq \c_@@_option_category_lua_tl
 \cs_new:Nn
   \@@_add_lua_option:nnn
   {
-    \@@_add_option:nnnn
-      { lua }
+    \@@_add_option:Vnnn
+      \c_@@_option_category_lua_tl
       { #1 }
       { #2 }
       { #3 }
@@ -1863,6 +1866,196 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
       { g_@@_default_ #1 _options_prop }
       { #2 }
       { #4 }
+    \@@_typecheck_option:n
+      { #2 }
+  }
+\cs_generate_variant:Nn
+  \@@_add_option:nnnn
+  { Vnnn }
+\tl_const:Nn \c_@@_option_value_true_tl  { true  }
+\tl_const:Nn \c_@@_option_value_false_tl { false }
+\cs_new:Nn \@@_typecheck_option:n
+  {
+    \@@_get_option_type:nN
+      { #1 }
+      \l_tmpa_tl
+    \tl_case:Nn
+      \l_tmpa_tl
+      {
+        \c_@@_option_type_boolean_tl
+          {
+            \@@_get_option_value:nN
+              { #1 }
+              \l_tmpa_tl
+            \bool_if:nF
+              {
+                \str_if_eq_p:VV
+                  \l_tmpa_tl
+                  \c_@@_option_value_true_tl ||
+                \str_if_eq_p:VV
+                  \l_tmpa_tl
+                  \c_@@_option_value_false_tl
+              }
+              {
+                \msg_error:nnnV
+                  { markdown }
+                  { failed-typecheck-for-boolean-option }
+                  { #1 }
+                  \l_tmpa_tl
+              }
+          }
+      }
+  }
+\msg_new:nnn
+  { markdown }
+  { failed-typecheck-for-boolean-option }
+  {
+    Option~#1~has~value~#2,~
+    but~a~boolean~(true~or~false)~was~expected.
+  }
+\prg_generate_conditional_variant:Nnn
+  \str_if_eq:nn
+  { vV }
+  { p  }
+\cs_generate_variant:Nn
+  \msg_error:nnnn
+  { nnnV }
+\seq_new:N \g_@@_option_types_seq
+\tl_const:Nn \c_@@_option_type_counter_tl { counter }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter_tl
+\tl_const:Nn \c_@@_option_type_boolean_tl { boolean }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean_tl
+\tl_const:Nn \c_@@_option_type_number_tl  { number  }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_number_tl
+\tl_const:Nn \c_@@_option_type_path_tl    { path    }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_path_tl
+\tl_const:Nn \c_@@_option_type_slice_tl   { slice   }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_slice_tl
+\tl_const:Nn \c_@@_option_type_string_tl  { string  }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_string_tl
+\cs_new:Nn
+  \@@_get_option_type:nN
+  {
+    \prop_get:NnNF
+      \g_@@_lua_option_types_prop
+      { #1 }
+      \l_tmpa_tl
+      {
+        \prop_get:NnNF
+          \g_@@_plain_tex_option_types_prop
+          { #1 }
+          \l_tmpa_tl
+          {
+            \msg_error:nnn
+              { markdown }
+              { undefined-option }
+              { #1 }
+          }
+      }
+    \seq_if_in:NVF
+      \g_@@_option_types_seq
+      \l_tmpa_tl
+      {
+        \msg_error:nnxx
+          { markdown }
+          { unknown-option-type }
+          { #1 }
+          { \l_tmpa_tl }
+      }
+    \tl_set_eq:NN
+      #2
+      \l_tmpa_tl
+  }
+\msg_new:nnn
+  { markdown }
+  { unknown-option-type }
+  {
+    Option~#1~has~unknown~type~#2.
+  }
+\msg_new:nnn
+  { markdown }
+  { undefined-option }
+  {
+    Option~#1~is~undefined.
+  }
+\cs_new:Nn
+  \@@_get_default_option:nN
+  {
+    \bool_set_false:N
+      \l_tmpa_bool
+    \seq_map_inline:Nn
+      \g_@@_option_categories_seq
+      {
+        \prop_get:cnNT
+          { g_@@_default_ ##1 _options_prop }
+          { #1 }
+          #2
+          {
+            \bool_set_true:N
+              \l_tmpa_bool
+            \seq_map_break:
+          }
+      }
+    \bool_if:nF
+      \l_tmpa_bool
+      {
+        \msg_error:nnn
+          { markdown }
+          { undefined-lua-or-plain-tex-option }
+          { #1 }
+      }
+  }
+\cs_new:Nn
+  \@@_get_option_value:nN
+  {
+    \@@_option_tl_to_csname:nN
+      { #1 }
+      \l_tmpa_tl
+    \cs_if_free:cTF
+      { \l_tmpa_tl }
+      {
+        \@@_get_default_option:nN
+          { #1 }
+          #2
+      }
+      {
+        \@@_get_option_type:nN
+          { #1 }
+          \l_tmpa_tl
+        \str_if_eq:NNTF
+          \c_@@_option_type_counter_tl
+          \l_tmpa_tl
+          {
+            \@@_option_tl_to_csname:nN
+              { #1 }
+              \l_tmpa_tl
+            \tl_set:Nx
+              #2
+              { \the \cs:w \l_tmpa_tl \cs_end: }
+          }
+          {
+            \@@_option_tl_to_csname:nN
+              { #1 }
+              \l_tmpa_tl
+            \tl_set:Nv
+              #2
+              { \l_tmpa_tl }
+          }
+      }
+  }
+\cs_new:Nn \@@_option_tl_to_csname:nN
+  {
+    \tl_set:Nn
+      \l_tmpa_tl
+%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
+      { \str_upper_case:n { #1 } }
+    \tl_set:Nx
+      #2
+      {
+        markdownOption
+        \tl_head:f { \l_tmpa_tl }
+        \tl_tail:n { #1 }
+      }
   }
 %    \end{macrocode}
 % \iffalse
@@ -7953,11 +8146,13 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \prop_new:N \g_@@_plain_tex_option_types_prop
 \prop_new:N \g_@@_default_plain_tex_options_prop
+\tl_const:Nn \c_@@_option_category_plain_tex_tl { plain_tex }
+\seq_put_right:NV \g_@@_option_categories_seq \c_@@_option_category_plain_tex_tl
 \cs_new:Nn
   \@@_add_plain_tex_option:nnn
   {
-    \@@_add_option:nnnn
-      { plain_tex }
+    \@@_add_option:Vnnn
+      \c_@@_option_category_plain_tex_tl
       { #1 }
       { #2 }
       { #3 }
@@ -8194,9 +8389,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
       \g_@@_default_plain_tex_options_prop
       \g_@@_plain_tex_option_types_prop
   }
-\seq_new:N \g_@@_option_types_seq
-\tl_const:Nn \c_@@_option_type_counter_tl { counter }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter_tl
 \cs_new:Nn \@@_plain_tex_define_option_command:nNN
   {
     \@@_option_tl_to_csname:nN
@@ -8231,20 +8423,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
           \cs_new:cpn
             \l_tmpa_tl
             { \l_tmpb_tl }
-      }
-  }
-\cs_new:Nn \@@_option_tl_to_csname:nN
-  {
-    \tl_set:Nn
-      \l_tmpa_tl
-%     TODO: Replace with \str_uppercase:n in TeX Live 2020.
-      { \str_upper_case:n { #1 } }
-    \tl_set:Nx
-      #2
-      {
-        markdownOption
-        \tl_head:f { \l_tmpa_tl }
-        \tl_tail:n { #1 }
       }
   }
 \@@_plain_tex_define_option_commands:
@@ -21257,16 +21435,6 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \tl_new:N \g_@@_formatted_lua_options_tl
-\tl_const:Nn \c_@@_option_type_boolean_tl { boolean }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean_tl
-\tl_const:Nn \c_@@_option_type_number_tl  { number  }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_number_tl
-\tl_const:Nn \c_@@_option_type_path_tl    { path    }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_path_tl
-\tl_const:Nn \c_@@_option_type_slice_tl   { slice   }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_slice_tl
-\tl_const:Nn \c_@@_option_type_string_tl  { string  }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_string_tl
 \cs_new:Nn \@@_format_lua_options:
   {
     \tl_gclear:N
@@ -21309,117 +21477,6 @@ end
         \tl_gput_right:Nx
           \g_@@_formatted_lua_options_tl
           { #1~=~ " \l_tmpa_tl " ,~ }
-      }
-  }
-\msg_new:nnn
-  { markdown }
-  { failed-typecheck-for-boolean-option }
-  {
-    Option~#1~has~value~#2,~
-    but~a~boolean~(true~or~false)~was~expected.
-  }
-\cs_new:Nn \@@_typecheck_option:n
-  {
-    \@@_get_option_type:nN
-      { #1 }
-      \l_tmpa_tl
-    \tl_case:Nn
-      \l_tmpa_tl
-      {
-        \c_@@_option_type_boolean_tl
-          {
-            \@@_get_option_value:nN
-              { #1 }
-              \l_tmpa_tl
-            \bool_if:nF
-              {
-                \str_if_eq_p:VV
-                  \l_tmpa_tl
-                  \c_@@_option_value_true_tl ||
-                \str_if_eq_p:VV
-                  \l_tmpa_tl
-                  \c_@@_option_value_false_tl
-              }
-              {
-                \msg_error:nnnV
-                  { markdown }
-                  { failed-typecheck-for-boolean-option }
-                  { #1 }
-                  \l_tmpa_tl
-              }
-          }
-      }
-  }
-\prg_generate_conditional_variant:Nnn
-  \str_if_eq:nn
-  { vV }
-  { p  }
-\cs_generate_variant:Nn
-  \msg_error:nnnn
-  { nnnV }
-\msg_new:nnn
-  { markdown }
-  { unknown-option-type }
-  {
-    Option~#1~has~unknown~type~#2.
-  }
-\msg_new:nnn
-  { markdown }
-  { undefined-option }
-  {
-    Option~#1~is~undefined.
-  }
-\cs_new:Nn
-  \@@_get_option_type:nN
-  {
-    \prop_get:NnNF
-      \g_@@_lua_option_types_prop
-      { #1 }
-      \l_tmpa_tl
-      {
-        \prop_get:NnNF
-          \g_@@_plain_tex_option_types_prop
-          { #1 }
-          \l_tmpa_tl
-          {
-            \msg_error:nnn
-              { markdown }
-              { undefined-option }
-              { #1 }
-          }
-      }
-    \seq_if_in:NVF
-      \g_@@_option_types_seq
-      \l_tmpa_tl
-      {
-        \msg_error:nnxx
-          { markdown }
-          { unknown-option-type }
-          { #1 }
-          { \l_tmpa_tl }
-      }
-    \tl_set_eq:NN
-      #2
-      \l_tmpa_tl
-  }
-\cs_new:Nn
-  \@@_get_default_option:nN
-  {
-    \prop_get:NnNF
-      \g_@@_default_lua_options_prop
-      { #1 }
-      #2
-      {
-        \prop_get:NnNF
-          \g_@@_default_plain_tex_options_prop
-          { #1 }
-          #2
-          {
-            \msg_error:nnn
-              { markdown }
-              { undefined-lua-or-plain-tex-option }
-              { #1 }
-          }
       }
   }
 \let\markdownPrepareLuaOptions=\@@_format_lua_options:
@@ -21471,15 +21528,6 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\tl_const:Nn \c_@@_option_value_true_tl  { true  }
-\tl_const:Nn \c_@@_option_value_false_tl { false }
-\msg_new:nnn
-  { markdown }
-  { expected-boolean-option }
-  {
-    Option~#1~has~type~#2,~
-    but~a~boolean~was~expected.
-  }
 \cs_new:Nn
   \@@_if_option:nTF
   {
@@ -21505,43 +21553,12 @@ end
       { #2 }
       { #3 }
   }
-\cs_new:Nn
-  \@@_get_option_value:nN
+\msg_new:nnn
+  { markdown }
+  { expected-boolean-option }
   {
-    \@@_option_tl_to_csname:nN
-      { #1 }
-      \l_tmpa_tl
-    \cs_if_free:cTF
-      { \l_tmpa_tl }
-      {
-        \@@_get_default_option:nN
-          { #1 }
-          #2
-      }
-      {
-        \@@_get_option_type:nN
-          { #1 }
-          \l_tmpa_tl
-        \str_if_eq:NNTF
-          \c_@@_option_type_counter_tl
-          \l_tmpa_tl
-          {
-            \@@_option_tl_to_csname:nN
-              { #1 }
-              \l_tmpa_tl
-            \tl_set:Nx
-              #2
-              { \the \cs:w \l_tmpa_tl \cs_end: }
-          }
-          {
-            \@@_option_tl_to_csname:nN
-              { #1 }
-              \l_tmpa_tl
-            \tl_set:Nv
-              #2
-              { \l_tmpa_tl }
-          }
-      }
+    Option~#1~has~type~#2,~
+    but~a~boolean~was~expected.
   }
 \let\markdownIfOption=\@@_if_option:nTF
 \ExplSyntaxOff

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21628,7 +21628,7 @@ end
                     \c_@@_lua_option_value_false { }
                   }
                   {
-                    \msg_error:nnxx
+                    \msg_error:nnxv
                       { markdown }
                       { failed-typecheck-for-boolean-option }
                       { #1 }
@@ -21638,6 +21638,9 @@ end
           }
       }
   }
+\cs_generate_variant:Nn
+  \msg_error:nnnn
+  { nnxv }
 \msg_new:nnn
   { markdown }
   { unknown-option-type }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21563,74 +21563,107 @@ end
   }
 \msg_new:nnn
   { markdown }
-  { undefined-lua-option }
+  { failed-typecheck-for-boolean-option }
   {
-    Lua~option~#1~is~undefined.
-  }
-\msg_new:nnn
-  { markdown }
-  { unknown-lua-option-type }
-  {
-    Lua~option~#1~has~unknown~type~#2.
-  }
-\msg_new:nnn
-  { markdown }
-  { failed-typecheck-for-boolean-lua-option }
-  {
-    Lua~option~#1~has~value~#2,~
+    Option~#1~has~value~#2,~
     but~a~boolean~(true~or~false)~was~expected.
   }
-\cs_new:Nn \@@_typecheck_lua_option:n
+\cs_new:Nn \@@_typecheck_option:n
   {
     \@@_option_tl_to_cs:nN
       { #1 }
       \l_tmpa_tl
-    \prop_get:NnNTF
-      \g_@@_lua_option_types_prop
+    \@@_get_option_type:nN
       { #1 }
       \l_tmpb_tl
+    \cs_if_free:cF
+      { \l_tmpa_tl }
       {
-        \seq_if_in:NVF
-          \g_@@_option_types_seq
+        \tl_case:Nn
           \l_tmpb_tl
           {
-            \msg_error:nnxx
-              { markdown }
-              { unknown-lua-option-type }
-              { #1 }
-              { \l_tmpb_tl }
-          }
-        \cs_if_free:cTF
-          { \l_tmpa_tl }
-          { }
-          {
-            \tl_case:Nn
-              \l_tmpb_tl
+            \c_@@_option_type_boolean
               {
-                \c_@@_lua_option_type_boolean
+                \tl_case:cnF
+                  { \l_tmpa_tl }
                   {
-                    \tl_case:cnF
+                    \c_@@_lua_option_value_true  { }
+                    \c_@@_lua_option_value_false { }
+                  }
+                  {
+                    \msg_error:nnxx
+                      { markdown }
+                      { failed-typecheck-for-boolean-option }
+                      { #1 }
                       { \l_tmpa_tl }
-                      {
-                        \c_@@_lua_option_value_true  { }
-                        \c_@@_lua_option_value_false { }
-                      }
-                      {
-                        \msg_error:nnxx
-                          { markdown }
-                          { failed-typecheck-for-boolean-lua-option }
-                          { #1 }
-                          { \l_tmpa_tl }
-                      }
                   }
               }
           }
       }
+  }
+\msg_new:nnn
+  { markdown }
+  { unknown-option-type }
+  {
+    Option~#1~has~unknown~type~#2.
+  }
+\msg_new:nnn
+  { markdown }
+  { undefined-option }
+  {
+    Option~#1~is~undefined.
+  }
+\cs_new:Nn
+  \@@_get_option_type:nN
+  {
+    \prop_get:NnNF
+      \g_@@_lua_option_types_prop
+      { #1 }
+      \l_tmpa_tl
       {
-        \msg_error:nnn
-          { markdown }
-          { undefined-lua-option }
+        \prop_get:NnNF
+          \g_@@_plain_tex_option_types_prop
           { #1 }
+          \l_tmpa_tl
+          {
+            \msg_error:nnn
+              { markdown }
+              { undefined-option }
+              { #1 }
+          }
+      }
+    \seq_if_in:NVF
+      \g_@@_option_types_seq
+      \l_tmpa_tl
+      {
+        \msg_error:nnxx
+          { markdown }
+          { unknown-option-type }
+          { #1 }
+          { \l_tmpa_tl }
+      }
+    \tl_set_eq:NN
+      #2
+      \l_tmpa_tl
+  }
+\cs_new:Nn
+  \@@_get_default_option:nN
+  {
+    \prop_get:NnNF
+      \g_@@_default_lua_options_prop
+      { #1 }
+      #2
+      {
+        \prop_get:NnNF
+          \g_@@_default_plain_tex_options_prop
+          { #1 }
+          #2
+          {
+            \msg_error:nnn
+              { markdown }
+              { undefined-lua-or-plain-tex-option }
+              { #1 }
+          }
       }
   }
 \let\markdownPrepareLuaOptions=\@@_format_lua_options:
@@ -21684,16 +21717,36 @@ end
 \ExplSyntaxOn
 \tl_const:Nn \c_@@_lua_option_value_true  { true  }
 \tl_const:Nn \c_@@_lua_option_value_false { false }
-\cs_new:Nn \@@_if_option:nTF
+\msg_new:nnn
+  { markdown }
+  { expected-boolean-option }
   {
+    Option~#1~has~type~#2,~
+    but~a~boolean~was~expected.
+  }
+\cs_new:Nn
+  \@@_if_option:nTF
+  {
+    \@@_get_option_type:nN
+      { #1 }
+      \l_tmpa_tl
+    \tl_if_eq:NNF
+      \l_tmpa_tl
+      \c_@@_option_type_boolean
+      {
+        \msg_error:nnxx
+          { markdown }
+          { expected-boolean-option }
+          { #1 }
+          { \l_tmpa_tl }
+      }
     \@@_option_tl_to_cs:nN
       { #1 }
       \l_tmpa_tl
     \cs_if_free:cTF
       { \l_tmpa_tl }
       {
-        \prop_get:NnN
-          \g_@@_default_lua_options_prop
+        \@@_get_default_option:nN
           { #1 }
           \l_tmpb_tl
       }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8355,17 +8355,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % Here, we automatically define all the above macros for plain \TeX{} options.
 %
-% \end{markdown}
-%  \begin{macrocode}
-\cs_new:Nn \@@_plain_tex_define_option_commands:
-  {
-    \seq_map_function:NN
-      \g_@@_lua_options_seq
-      \@@_plain_tex_define_lua_option_command:n
-%    \end{macrocode}
-% \begin{markdown}
-%
-%#### Lua Interface Options
 % Furthemore, we also define macros that map directly to the options recognized
 % by the Lua interface, such as \mdef{markdownOptionHybrid} for the
 % \Opt{hybrid} Lua option (see Section <#sec:luaoptions>), which are not
@@ -8377,40 +8366,36 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \seq_map_function:NN
-      \g_@@_plain_tex_options_seq
-      \@@_plain_tex_define_plain_tex_option_command:n
-  }
-\cs_new:Nn \@@_plain_tex_define_lua_option_command:n
+\cs_new:Nn \@@_plain_tex_define_option_commands:
   {
-    \@@_plain_tex_define_option_command:nNN
-      { #1 }
-      \g_@@_default_lua_options_prop
-      \g_@@_lua_option_types_prop
+    \seq_map_inline:Nn
+      \g_@@_option_categories_seq
+      {
+        \seq_map_inline:cn
+          { g_@@_ ##1 _options_seq }
+          {
+              \@@_plain_tex_define_option_command:nn
+                { ##1 }
+                { ####1 }
+          }
+      }
   }
-\cs_new:Nn \@@_plain_tex_define_plain_tex_option_command:n
-  {
-    \@@_plain_tex_define_option_command:nNN
-      { #1 }
-      \g_@@_default_plain_tex_options_prop
-      \g_@@_plain_tex_option_types_prop
-  }
-\cs_new:Nn \@@_plain_tex_define_option_command:nNN
+\cs_new:Nn \@@_plain_tex_define_option_command:nn
   {
     \@@_option_tl_to_csname:nN
-      { #1 }
+      { #2 }
       \l_tmpa_tl
-    \prop_get:NnN
-      #3
-      { #1 }
+    \prop_get:cnN
+      { g_@@_ #1 _option_types_prop }
+      { #2 }
       \l_tmpb_tl
     \str_if_eq:VVTF
       \l_tmpb_tl
       \c_@@_option_type_counter_tl
       {
-        \prop_get:NnN
-          #2
-          { #1 }
+        \prop_get:cnN
+          { g_@@_default_ #1 _options_prop }
+          { #2 }
           \l_tmpb_tl
         \int_new:c
           { \l_tmpa_tl }
@@ -8419,9 +8404,9 @@ For more information, see the examples for the \Opt{finalizeCache} option.
           { \l_tmpb_tl }
       }
       {
-        \prop_get:NnN
-          #2
-          { #1 }
+        \prop_get:cnN
+          { g_@@_default_ #1 _options_prop }
+          { #2 }
           \l_tmpb_tl
         \exp_args:NNo
           \cs_new:cpn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -2002,7 +2002,7 @@ option.
 \prop_put:Nnn
   \g_@@_lua_option_types_prop
   { cacheDir }
-  { string }
+  { path }
 \prop_put:Nnn
   \g_@@_default_lua_options_prop
   { cacheDir }
@@ -2237,7 +2237,7 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 \prop_put:Nnn
   \g_@@_lua_option_types_prop
   { frozenCacheFileName }
-  { string }
+  { path }
 \prop_put:Nnn
   \g_@@_default_lua_options_prop
   { frozenCacheFileName }
@@ -3976,7 +3976,7 @@ following text:
 \prop_put:Nnn
   \g_@@_lua_option_types_prop
   { contentBlocksLanguageMap }
-  { string }
+  { path }
 \prop_put:Nnn
   \g_@@_default_lua_options_prop
   { contentBlocksLanguageMap }
@@ -6654,7 +6654,7 @@ following text:
 \prop_put:Nnn
   \g_@@_lua_option_types_prop
   { slice }
-  { string }
+  { slice }
 \prop_put:Nnn
   \g_@@_default_lua_options_prop
   { slice }
@@ -8302,7 +8302,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { helperScriptFileName }
-  { string }
+  { path }
 \prop_put:Nnx
   \g_@@_default_plain_tex_options_prop
   { helperScriptFileName }
@@ -8332,7 +8332,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { inputTempFileName }
-  { string }
+  { path }
 \prop_put:Nnx
   \g_@@_default_plain_tex_options_prop
   { inputTempFileName }
@@ -8362,7 +8362,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { outputTempFileName }
-  { string }
+  { path }
 \prop_put:Nnx
   \g_@@_default_plain_tex_options_prop
   { outputTempFileName }
@@ -8393,7 +8393,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { errorTempFileName }
-  { string }
+  { path }
 \prop_put:Nnx
   \g_@@_default_plain_tex_options_prop
   { errorTempFileName }
@@ -8428,7 +8428,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { outputDir }
-  { string }
+  { path }
 \prop_put:Nnn
   \g_@@_default_plain_tex_options_prop
   { outputDir }
@@ -8459,7 +8459,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { cacheDir }
-  { string }
+  { path }
 \prop_put:Nnx
   \g_@@_default_plain_tex_options_prop
   { cacheDir }
@@ -8495,7 +8495,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \prop_put:Nnn
   \g_@@_plain_tex_option_types_prop
   { frozenCacheFileName }
-  { string }
+  { path }
 \prop_put:Nnx
   \g_@@_default_plain_tex_options_prop
   { frozenCacheFileName }
@@ -21580,10 +21580,19 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \tl_new:N \g_@@_formatted_lua_options_tl
-\tl_const:Nn \c_@@_lua_option_type_boolean { boolean }
-\tl_const:Nn \c_@@_lua_option_type_counter { counter }
-\tl_const:Nn \c_@@_lua_option_type_number  { number  }
-\tl_const:Nn \c_@@_lua_option_type_string  { string  }
+\seq_new:N \g_@@_option_types_seq
+\tl_const:Nn \c_@@_option_type_boolean { boolean }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean
+\tl_const:Nn \c_@@_option_type_counter { counter }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter
+\tl_const:Nn \c_@@_option_type_number  { number  }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_number
+\tl_const:Nn \c_@@_option_type_path    { path    }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_path
+\tl_const:Nn \c_@@_option_type_slice   { slice   }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_slice
+\tl_const:Nn \c_@@_option_type_string  { string  }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_string
 \cs_new:Nn \@@_format_lua_options:
   {
     \tl_gclear:N
@@ -21617,23 +21626,29 @@ end
         \tl_case:NnF
           \l_tmpb_tl
           {
-            \c_@@_lua_option_type_string
+            \c_@@_option_type_boolean
               {
                 \tl_gput_right:Nx
                   \g_@@_formatted_lua_options_tl
-                  { #1~=~"     \cs:w \l_tmpa_tl \cs_end: ",~ }
+                  { #1~=~      \cs:w \l_tmpa_tl \cs_end:  ,~ }
               }
-            \c_@@_lua_option_type_counter
+            \c_@@_option_type_number
               {
                 \tl_gput_right:Nx
                   \g_@@_formatted_lua_options_tl
-                  { #1~=~ \the \cs:w \l_tmpa_tl \cs_end: ,~ }
+                  { #1~=~      \cs:w \l_tmpa_tl \cs_end:  ,~ }
+              }
+            \c_@@_option_type_counter
+              {
+                \tl_gput_right:Nx
+                  \g_@@_formatted_lua_options_tl
+                  { #1~=~ \the \cs:w \l_tmpa_tl \cs_end:  ,~ }
               }
           }
           {
             \tl_gput_right:Nx
               \g_@@_formatted_lua_options_tl
-              {     #1~=~      \cs:w \l_tmpa_tl \cs_end: ,~ }
+              {     #1~=~"     \cs:w \l_tmpa_tl \cs_end: ",~ }
           }
       }
   }
@@ -21642,6 +21657,12 @@ end
   { undefined-lua-option }
   {
     Lua~option~#1~is~undefined.
+  }
+\msg_new:nnn
+  { markdown }
+  { unknown-lua-option-type }
+  {
+    Lua~option~#1~has~unknown~type~#2.
   }
 \msg_new:nnn
   { markdown }
@@ -21668,6 +21689,16 @@ end
       { #1 }
       \l_tmpb_tl
       {
+        \seq_if_in:NVF
+          \g_@@_option_types_seq
+          \l_tmpb_tl
+          {
+            \msg_error:nnxx
+              { markdown }
+              { unknown-lua-option-type }
+              { #1 }
+              { \l_tmpb_tl }
+          }
         \cs_if_free:cTF
           { \l_tmpa_tl }
           { }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21554,43 +21554,47 @@ end
   {
     \@@_typecheck_option:n
       { #1 }
-    \@@_option_tl_to_cs:nN
+    \@@_get_option_type:nN
       { #1 }
       \l_tmpa_tl
-    \prop_get:NnN
-      \g_@@_lua_option_types_prop
-      { #1 }
-      \l_tmpb_tl
-    \cs_if_free:cF
-      { \l_tmpa_tl }
+    \tl_case:NnF
+      \l_tmpa_tl
       {
-        \tl_case:NnF
-          \l_tmpb_tl
+        \c_@@_option_type_boolean_tl
           {
-            \c_@@_option_type_boolean_tl
-              {
-                \tl_gput_right:Nx
-                  \g_@@_formatted_lua_options_tl
-                  { #1~=~      \cs:w \l_tmpa_tl \cs_end:  ,~ }
-              }
-            \c_@@_option_type_number_tl
-              {
-                \tl_gput_right:Nx
-                  \g_@@_formatted_lua_options_tl
-                  { #1~=~      \cs:w \l_tmpa_tl \cs_end:  ,~ }
-              }
-            \c_@@_option_type_counter_tl
-              {
-                \tl_gput_right:Nx
-                  \g_@@_formatted_lua_options_tl
-                  { #1~=~ \the \cs:w \l_tmpa_tl \cs_end:  ,~ }
-              }
-          }
-          {
+            \@@_get_option:nN
+              { #1 }
+              \l_tmpa_tl
             \tl_gput_right:Nx
               \g_@@_formatted_lua_options_tl
-              {     #1~=~"     \cs:w \l_tmpa_tl \cs_end: ",~ }
+              { #1~=~  \l_tmpa_tl   ,~ }
           }
+        \c_@@_option_type_number_tl
+          {
+            \@@_get_option:nN
+              { #1 }
+              \l_tmpa_tl
+            \tl_gput_right:Nx
+              \g_@@_formatted_lua_options_tl
+              { #1~=~  \l_tmpa_tl   ,~ }
+          }
+        \c_@@_option_type_counter_tl
+          {
+            \@@_get_option:nN
+              { #1 }
+              \l_tmpa_tl
+            \tl_gput_right:Nx
+              \g_@@_formatted_lua_options_tl
+              { #1~=~  \l_tmpa_tl   ,~ }
+          }
+      }
+      {
+        \@@_get_option:nN
+          { #1 }
+          \l_tmpa_tl
+        \tl_gput_right:Nx
+          \g_@@_formatted_lua_options_tl
+          {     #1~=~ " \l_tmpa_tl " ,~ }
       }
   }
 \msg_new:nnn
@@ -21602,39 +21606,32 @@ end
   }
 \cs_new:Nn \@@_typecheck_option:n
   {
-    \@@_option_tl_to_cs:nN
+    \@@_get_option_type:nN
       { #1 }
       \l_tmpa_tl
-    \cs_if_free:cF
-      { \l_tmpa_tl }
+    \tl_case:Nn
+      \l_tmpa_tl
       {
-        \@@_get_option_type:nN
-          { #1 }
-          \l_tmpa_tl
-        \tl_case:Nn
-          \l_tmpa_tl
+        \c_@@_option_type_boolean_tl
           {
-            \c_@@_option_type_boolean_tl
+            \@@_get_option:nN
+              { #1 }
+              \l_tmpa_tl
+            \bool_if:nF
               {
-                \@@_option_tl_to_cs:nN
+                \str_if_eq_p:VV
+                  \l_tmpa_tl
+                  \c_@@_option_value_true_tl ||
+                \str_if_eq_p:VV
+                  \l_tmpa_tl
+                  \c_@@_option_value_false_tl
+              }
+              {
+                \msg_error:nnnV
+                  { markdown }
+                  { failed-typecheck-for-boolean-option }
                   { #1 }
                   \l_tmpa_tl
-                \bool_if:nF
-                  {
-                    \str_if_eq_p:vV
-                      { \l_tmpa_tl }
-                      \c_@@_option_value_true_tl ||
-                    \str_if_eq_p:vV
-                      { \l_tmpa_tl }
-                      \c_@@_option_value_false_tl
-                  }
-                  {
-                    \msg_error:nnxv
-                      { markdown }
-                      { failed-typecheck-for-boolean-option }
-                      { #1 }
-                      { \l_tmpa_tl }
-                  }
               }
           }
       }
@@ -21645,7 +21642,7 @@ end
   { p  }
 \cs_generate_variant:Nn
   \msg_error:nnnn
-  { nnxv }
+  { nnnV }
 \msg_new:nnn
   { markdown }
   { unknown-option-type }
@@ -21785,6 +21782,18 @@ end
           { #1 }
           { \l_tmpa_tl }
       }
+    \@@_get_option:nN
+      { #1 }
+      \l_tmpa_tl
+    \str_if_eq:NNTF
+      \l_tmpa_tl
+      \c_@@_option_value_true_tl
+      { #2 }
+      { #3 }
+  }
+\cs_new:Nn
+  \@@_get_option:nN
+  {
     \@@_option_tl_to_cs:nN
       { #1 }
       \l_tmpa_tl
@@ -21793,18 +21802,32 @@ end
       {
         \@@_get_default_option:nN
           { #1 }
-          \l_tmpb_tl
+          #2
       }
       {
-        \tl_set:Nf
-          \l_tmpb_tl
-          { \cs:w \l_tmpa_tl \cs_end: }
+        \@@_get_option_type:nN
+          { #1 }
+          \l_tmpa_tl
+        \str_if_eq:NNTF
+          \c_@@_option_type_counter_tl
+          \l_tmpa_tl
+          {
+            \@@_option_tl_to_cs:nN
+              { #1 }
+              \l_tmpa_tl
+            \tl_set:Nx
+              #2
+              { \the \cs:w \l_tmpa_tl \cs_end: }
+          }
+          {
+            \@@_option_tl_to_cs:nN
+              { #1 }
+              \l_tmpa_tl
+            \tl_set:Nv
+              #2
+              { \l_tmpa_tl }
+          }
       }
-    \str_if_eq:NNTF
-      \l_tmpb_tl
-      \c_@@_option_value_true_tl
-      { #2 }
-      { #3 }
   }
 \let\markdownIfOption=\@@_if_option:nTF
 \ExplSyntaxOff

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21345,7 +21345,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-      \tl_if_eq:NNTF
+      \str_if_eq:NNTF
         \l_tmpa_tl
         \c_@@_jekyll_data_sequence_tl
         {
@@ -21776,7 +21776,7 @@ end
     \@@_get_option_type:nN
       { #1 }
       \l_tmpa_tl
-    \tl_if_eq:NNF
+    \str_if_eq:NNF
       \l_tmpa_tl
       \c_@@_option_type_boolean_tl
       {
@@ -21801,7 +21801,7 @@ end
           \l_tmpb_tl
           { \cs:w \l_tmpa_tl \cs_end: }
       }
-    \tl_if_eq:NNTF
+    \str_if_eq:NNTF
       \l_tmpb_tl
       \c_@@_option_value_true_tl
       { #2 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8249,6 +8249,30 @@ result, the plain \TeX{} document becomes more portable, but further changes
 in the order and the content of markdown documents will not be reflected. It
 defaults to `false`.
 
+% \end{markdown}
+% \iffalse
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\seq_put_right:Nn
+  \g_@@_plain_tex_options_seq
+  { frozenCache }
+\prop_put:Nnn
+  \g_@@_plain_tex_option_types_prop
+  { frozenCache }
+  { boolean }
+\prop_put:Nnx
+  \g_@@_default_plain_tex_options_prop
+  { frozenCache }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*manual-options>
+% \fi
+% \begin{markdown}
+%
 % The standard usage of the above two options is as follows:
 % \iffalse
 The standard usage of the \Opt{finalizeCache} and \Opt{frozenCache}
@@ -21519,7 +21543,7 @@ end
   }
 \cs_new:Nn \@@_format_lua_option:n
   {
-    \@@_typecheck_lua_option:n
+    \@@_typecheck_option:n
       { #1 }
     \@@_option_tl_to_cs:nN
       { #1 }
@@ -21573,17 +21597,20 @@ end
     \@@_option_tl_to_cs:nN
       { #1 }
       \l_tmpa_tl
-    \@@_get_option_type:nN
-      { #1 }
-      \l_tmpb_tl
     \cs_if_free:cF
       { \l_tmpa_tl }
       {
+        \@@_get_option_type:nN
+          { #1 }
+          \l_tmpa_tl
         \tl_case:Nn
-          \l_tmpb_tl
+          \l_tmpa_tl
           {
             \c_@@_option_type_boolean
               {
+                \@@_option_tl_to_cs:nN
+                  { #1 }
+                  \l_tmpa_tl
                 \tl_case:cnF
                   { \l_tmpa_tl }
                   {

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8439,29 +8439,56 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   }
 \cs_new:Nn \@@_plain_tex_define_lua_option:n
   {
-    \@@_plain_tex_define_option:nN
+    \@@_plain_tex_define_option:nNN
       { #1 }
       \g_@@_default_lua_options_prop
+      \g_@@_lua_option_types_prop
   }
 \cs_new:Nn \@@_plain_tex_define_plain_tex_option:n
   {
-    \@@_plain_tex_define_option:nN
+    \@@_plain_tex_define_option:nNN
       { #1 }
       \g_@@_default_plain_tex_options_prop
+      \g_@@_plain_tex_option_types_prop
   }
-\cs_new:Nn \@@_plain_tex_define_option:nN
+\seq_new:N \g_@@_option_types_seq
+\tl_const:Nn \c_@@_option_type_counter { counter }
+\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter
+\cs_new:Nn \@@_plain_tex_define_option:nNN
   {
     \@@_option_tl_to_cs:nN
       { #1 }
       \l_tmpa_tl
     \prop_get:NnN
-      #2
+      #3
       { #1 }
       \l_tmpb_tl
-    \exp_args:NNo
-      \cs_new:cpn
-        \l_tmpa_tl
-        { \l_tmpb_tl }
+    \tl_case:NnF
+      \l_tmpb_tl
+      {
+        \c_@@_option_type_counter
+          {
+            \prop_get:NnN
+              #2
+              { #1 }
+              \l_tmpb_tl
+            \int_new:c
+              { \l_tmpa_tl }
+            \int_gset:cn
+              { \l_tmpa_tl }
+              { \l_tmpb_tl }
+          }
+      }
+      {
+        \prop_get:NnN
+          #2
+          { #1 }
+          \l_tmpb_tl
+        \exp_args:NNo
+          \cs_new:cpn
+            \l_tmpa_tl
+            { \l_tmpb_tl }
+      }
   }
 \cs_new:Nn \@@_option_tl_to_cs:nN
   {
@@ -21154,23 +21181,6 @@ end
 % \par
 % \begin{markdown}
 %
-%### Finalizing and Freezing the Cache
-%
-% When the \mref{markdownOptionFinalizeCache} option is enabled, then the
-% \mdef{markdownFrozenCacheCounter} counter is used to enumerate the markdown
-% documents using the Lua interface \Opt{frozenCacheCounter} option.
-%
-% When the \mref{markdownOptionFrozenCache} option is enabled, then the
-% \mref{markdownFrozenCacheCounter} counter is used to render markdown documents
-% from the frozen cache without invoking Lua.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\newcount\markdownFrozenCacheCounter
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
 %### Token Renderer Prototypes {#textokenrendererprototypes}
 %
 % The following definitions should be considered placeholder.
@@ -21494,11 +21504,8 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \tl_new:N \g_@@_formatted_lua_options_tl
-\seq_new:N \g_@@_option_types_seq
 \tl_const:Nn \c_@@_option_type_boolean { boolean }
 \seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean
-\tl_const:Nn \c_@@_option_type_counter { counter }
-\seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_counter
 \tl_const:Nn \c_@@_option_type_number  { number  }
 \seq_put_right:NV \g_@@_option_types_seq \c_@@_option_type_number
 \tl_const:Nn \c_@@_option_type_path    { path    }
@@ -22145,19 +22152,19 @@ end
 % \begin{markdown}
 % If we are reading from the frozen cache, input it, expand the corresponding
 % `\markdownFrozenCache`\meta{number} macro, and increment
-% \mref{markdownFrozenCacheCounter}.
+% \Opt{frozenCacheCounter}.
 % \end{markdown}
 %  \begin{macrocode}
     |markdownIfOption{frozenCache}{%
-      |ifnum|markdownFrozenCacheCounter=0|relax
+      |ifnum|markdownOptionFrozenCacheCounter=0|relax
         |markdownInfo{Reading frozen cache from
           "|markdownOptionFrozenCacheFileName"}%
         |input|markdownOptionFrozenCacheFileName|relax
       |fi
       |markdownInfo{Including markdown document number
-        "|the|markdownFrozenCacheCounter" from frozen cache}%
-      |csname markdownFrozenCache|the|markdownFrozenCacheCounter|endcsname
-      |global|advance|markdownFrozenCacheCounter by 1|relax
+        "|the|markdownOptionFrozenCacheCounter" from frozen cache}%
+      |csname markdownFrozenCache|the|markdownOptionFrozenCacheCounter|endcsname
+      |global|advance|markdownOptionFrozenCacheCounter by 1|relax
     }{%
       |markdownInfo{Including markdown document "#1"}%
 %    \end{macrocode}
@@ -22186,12 +22193,11 @@ end
         print(convert(input:gsub("\r\n?", "\n") .. "\n"))}%
 %    \end{macrocode}
 % \begin{markdown}
-% If we are finalizing the frozen cache, increment
-% \mref{markdownFrozenCacheCounter}.
+% If we are finalizing the frozen cache, increment \Opt{frozenCacheCounter}.
 % \end{markdown}
 %  \begin{macrocode}
       |markdownIfOption{finalizeCache}{%
-        |global|advance|markdownFrozenCacheCounter by 1|relax
+        |global|advance|markdownOptionFrozenCacheCounter by 1|relax
       }%
     }%
     |endgroup

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21570,7 +21570,7 @@ end
           \c_@@_option_type_counter_tl
       }
       {
-        \@@_get_option:nN
+        \@@_get_option_value:nN
           { #1 }
           \l_tmpa_tl
         \tl_gput_right:Nx
@@ -21578,7 +21578,7 @@ end
           { #1~=~  \l_tmpa_tl   ,~ }
       }
       {
-        \@@_get_option:nN
+        \@@_get_option_value:nN
           { #1 }
           \l_tmpa_tl
         \tl_gput_right:Nx
@@ -21603,7 +21603,7 @@ end
       {
         \c_@@_option_type_boolean_tl
           {
-            \@@_get_option:nN
+            \@@_get_option_value:nN
               { #1 }
               \l_tmpa_tl
             \bool_if:nF
@@ -21771,7 +21771,7 @@ end
           { #1 }
           { \l_tmpa_tl }
       }
-    \@@_get_option:nN
+    \@@_get_option_value:nN
       { #1 }
       \l_tmpa_tl
     \str_if_eq:NNTF
@@ -21781,7 +21781,7 @@ end
       { #3 }
   }
 \cs_new:Nn
-  \@@_get_option:nN
+  \@@_get_option_value:nN
   {
     \@@_option_tl_to_cs:nN
       { #1 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1840,14 +1840,14 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 %  \begin{macrocode}
 \prop_new:N \g_@@_lua_option_types_prop
 \prop_new:N \g_@@_default_lua_options_prop
-\seq_new:N \g_@@_option_categories_seq
-\tl_const:Nn \c_@@_option_category_lua_tl { lua }
-\seq_put_right:NV \g_@@_option_categories_seq \c_@@_option_category_lua_tl
+\seq_new:N \g_@@_option_layers_seq
+\tl_const:Nn \c_@@_option_layer_lua_tl { lua }
+\seq_put_right:NV \g_@@_option_layers_seq \c_@@_option_layer_lua_tl
 \cs_new:Nn
   \@@_add_lua_option:nnn
   {
     \@@_add_option:Vnnn
-      \c_@@_option_category_lua_tl
+      \c_@@_option_layer_lua_tl
       { #1 }
       { #2 }
       { #3 }
@@ -1938,7 +1938,7 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
     \bool_set_false:N
       \l_tmpa_bool
     \seq_map_inline:Nn
-      \g_@@_option_categories_seq
+      \g_@@_option_layers_seq
       {
         \prop_get:cnNT
           { g_@@_ ##1 _option_types_prop }
@@ -1990,7 +1990,7 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
     \bool_set_false:N
       \l_tmpa_bool
     \seq_map_inline:Nn
-      \g_@@_option_categories_seq
+      \g_@@_option_layers_seq
       {
         \prop_get:cnNT
           { g_@@_default_ ##1 _options_prop }
@@ -8152,13 +8152,13 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \prop_new:N \g_@@_plain_tex_option_types_prop
 \prop_new:N \g_@@_default_plain_tex_options_prop
-\tl_const:Nn \c_@@_option_category_plain_tex_tl { plain_tex }
-\seq_put_right:NV \g_@@_option_categories_seq \c_@@_option_category_plain_tex_tl
+\tl_const:Nn \c_@@_option_layer_plain_tex_tl { plain_tex }
+\seq_put_right:NV \g_@@_option_layers_seq \c_@@_option_layer_plain_tex_tl
 \cs_new:Nn
   \@@_add_plain_tex_option:nnn
   {
     \@@_add_option:Vnnn
-      \c_@@_option_category_plain_tex_tl
+      \c_@@_option_layer_plain_tex_tl
       { #1 }
       { #2 }
       { #3 }
@@ -8369,7 +8369,7 @@ For more information, see the examples for the \Opt{finalizeCache} option.
 \cs_new:Nn \@@_plain_tex_define_option_commands:
   {
     \seq_map_inline:Nn
-      \g_@@_option_categories_seq
+      \g_@@_option_layers_seq
       {
         \seq_map_inline:cn
           { g_@@_ ##1 _options_seq }
@@ -14617,13 +14617,13 @@ document:
 %  \begin{macrocode}
 \prop_new:N \g_@@_latex_option_types_prop
 \prop_new:N \g_@@_default_latex_options_prop
-\tl_const:Nn \c_@@_option_category_latex_tl { latex }
-\seq_put_right:NV \g_@@_option_categories_seq \c_@@_option_category_latex_tl
+\tl_const:Nn \c_@@_option_layer_latex_tl { latex }
+\seq_put_right:NV \g_@@_option_layers_seq \c_@@_option_layer_latex_tl
 \cs_new:Nn
   \@@_add_latex_option:nnn
   {
     \@@_add_option:Vnnn
-      \c_@@_option_category_latex_tl
+      \c_@@_option_layer_latex_tl
       { #1 }
       { #2 }
       { #3 }


### PR DESCRIPTION
This pull request closes #124 by making the following changes:

- [x] Define `\g_@@_plain_tex_options_seq`, `\g_@@_plain_tex_option_types_prop`, and `\g_@@_default_plain_tex_options_prop`.
- [x] Define `\@@_plain_tex_define_option_commands:` and use it to replace:
    - [x] [the manual definition of Lua option commands][6] (also [this][7])
    - [x] [the manual definition of plain TeX option commands][4]
- [x] Typecheck command `\markdownIfOption`.
- [x] Define `\g_@@_latex_options_seq`, `\g_@@_latex_option_types_prop`, and `\g_@@_default_latex_options_prop`.
- [x] Define `\@@_latex_define_option_commands_and_keyvals:` and use it to replace:
    - [x] [the manual definition of LaTeX option commands][5]
    - [x] [the manual setting of Lua, plain TeX, and LaTeX option keys for `\markdownSetup`][1]

Miscellaneous:

- [x] Automatically define [default renderer prototypes][3].
- [x] Add `path` and `slice` option types.
- [x] Check that option type is known in `\@@_typecheck_lua_option:n`.
- [x] Fix Lua options of counter type not being defined as such or passed to Lua.
- [x] Replace `\tl_case:*` with `\str_case:*`. See https://github.com/latex3/latex3/issues/1097.
- [x] Replace `\tl_if_eq:*` with `\str_if_eq:*`.
- [x] Replace `\cs_if_free:cTF { ... } { } { ... }` with `\cs_if_free:cF { ... } { ... }`.
- [x] Define `\@@_get_option_value:nN`, `\@@_get_default_option_value:nN`, and `\@@_get_option_type:nN` commands.
- [x] Define `\@@_add_option:nnnn`, `\@@_add_lua_option:nnn`, and `\@@_add_plain_tex_option:nnn` commands.
- [x] Define `\@@_set_option_value:nn` command.

 [1]: https://github.com/Witiko/markdown/blob/1f680a8c5311745473ed3d1e3740b56494adfd2d/markdown.dtx#L12959
 [3]: https://github.com/Witiko/markdown/blob/93246a4ee017e0f2d3095b11b187142b8a42c88c/markdown.dtx#L14026-L14111
 [4]: https://github.com/Witiko/markdown/blob/8c065e66d8395b55f100fb54615cacd1549a46f6/markdown.dtx#L8281
 [5]: https://github.com/Witiko/markdown/blob/8c065e66d8395b55f100fb54615cacd1549a46f6/markdown.dtx#L14629-L14630
 [6]: https://github.com/Witiko/markdown/blob/8c065e66d8395b55f100fb54615cacd1549a46f6/markdown.dtx#L8434-L8487
 [7]: https://github.com/Witiko/markdown/blob/8c065e66d8395b55f100fb54615cacd1549a46f6/markdown.dtx#L8217
 [9]: https://github.com/Witiko/markdown/actions/runs/2472389281