### PR TITLE
Hotfix #144 by disabling the TeX4ht example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ ARCHIVES=$(TDSARCHIVE) $(CTANARCHIVE) $(DISTARCHIVE)
 EXAMPLES_RESOURCES=examples/example.md examples/scientists.csv
 EXAMPLES_SOURCES=examples/context-mkii.tex examples/context-mkiv.tex examples/latex.tex
 EXAMPLES=examples/context-mkii.pdf examples/context-mkiv.pdf \
-  examples/latex-pdftex.pdf examples/latex-luatex.pdf examples/latex-xetex.pdf \
-  examples/latex-tex4ht.html examples/latex-tex4ht.css
+  examples/latex-pdftex.pdf examples/latex-luatex.pdf examples/latex-xetex.pdf
 TESTS=tests/test.sh tests/support/*.tex tests/templates/*/*.tex.m4 \
   tests/templates/*/COMMANDS.m4 tests/testfiles/*/*.test
 MAKES=Makefile $(addsuffix /Makefile, $(SUBDIRECTORIES)) latexmkrc


### PR DESCRIPTION
Hotfixes #144 by disabling the TeX4ht example.