### PR TITLE
Replace calls to xstring with expl3 functions

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -14873,16 +14873,27 @@ would use the following code in the preamble of your document:
 \newif\ifmarkdownLaTeXLoaded
   \markdownLaTeXLoadedfalse
 \AtEndOfPackage{\markdownLaTeXLoadedtrue}
+\ExplSyntaxOn
+\tl_new:N \markdownLaTeXThemePackageName
 \define@key{markdownOptions}{theme}{%
-  \IfSubStr{#1}{/}{}{%
-    \markdownError
-      {Won't load theme with unqualified name #1}%
-      {Theme names must contain at least one forward slash}}%
-  \StrSubstitute{#1}{/}{_}[\markdownLaTeXThemePackageName]%
+  \str_if_in:NnF
+    { #1 }
+    { / }
+    {
+      \markdownError
+      { Won't load theme with unqualified name #1 }
+      { Theme names must contain at least one forward slash }
+    }
+  \tl_set:Nn \markdownLaTeXThemePackageName { #1 }
+  \str_replace_all:Nnn
+    \markdownLaTeXThemePackageName
+    { / }
+    { _ }
   \edef\markdownLaTeXThemePackageName{%
     markdowntheme\markdownLaTeXThemePackageName}%
   \expandafter\markdownLaTeXThemeLoad\expandafter{%
     \markdownLaTeXThemePackageName}{#1/}}%
+\ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -23176,8 +23187,15 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
+\ExplSyntaxOn
 \def\markdownLATEXStrongEmphasis#1{%
-  \IfSubStr\f@series{b}{\textnormal{#1}}{\textbf{#1}}}
+  \str_if_in:NnTF
+    \f@series
+    { b }
+    { \textnormal{#1} }
+    { \textbf{#1} }
+}
+\ExplSyntaxOff
 \markdownSetup{rendererPrototypes={strongEmphasis={%
   \protect\markdownLATEXStrongEmphasis{#1}}}}
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1196,17 +1196,6 @@ local md5 = require("md5")
 % \par
 % \begin{markdown}
 %
-% \pkg{xstring}
-%
-%:    A package that provides useful macros for manipulating strings of tokens.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\RequirePackage{xstring}
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
 % The following packages are soft prerequisites. They are only used to provide
 % default token renderer prototypes (see sections
 % <#sec:texrendererprototypes> and


### PR DESCRIPTION
Replaces the following:
- `\IfSubStr` -> `\str_if_in:NnTF`
- `\StrSubstitute` -> `\str_replace_all:Nnn`

Partially resolves #96.

---

- [x] `\IfSubStr` - L14877 (check slash in theme name)
- [x] `\IfSubStr` - L23180 (`\def\markdownLATEXStrongEmphasis#1`)
- [x] `\StrSubstitute` - L14881 (`\markdownLaTeXThemePackageName` - '/' -> '_')
- [x] Remove all requires and mentions of `xstring`