### PR TITLE
Add strike-through syntax extension

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,7 +8,7 @@ AUXDIRS=_markdown_*/
 LUACLI_OPTIONS=cacheDir=_markdown_example hashEnumerators=true \
   definitionLists=true footnotes=true inlineFootnotes=true \
   smartEllipses=true fencedCode=true contentBlocks=true pipeTables=true \
-  tableCaptions=true taskLists=true
+  tableCaptions=true taskLists=true strikeThrough=true
 OUTPUT=context-mkii.pdf context-mkiv.pdf latex-pdftex.pdf \
   latex-luatex.pdf latex-xetex.pdf latex-tex4ht.html latex-tex4ht.css
 

--- a/examples/context-mkii.tex
+++ b/examples/context-mkii.tex
@@ -17,6 +17,7 @@
 \def\markdownOptionPipeTables{true}
 \def\markdownOptionTableCaptions{true}
 \def\markdownOptionTaskLists{true}
+\def\markdownOptionStrikeThrough{true}
 
 % Set renderers of the Markdown module.
 \definetyping

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -17,6 +17,7 @@
 \def\markdownOptionPipeTables{true}
 \def\markdownOptionTableCaptions{true}
 \def\markdownOptionTaskLists{true}
+\def\markdownOptionStrikeThrough{true}
 
 % Set renderers of the Markdown module.
 \definehighlight

--- a/examples/example.md
+++ b/examples/example.md
@@ -102,7 +102,7 @@ This is a definition list:
 
 Term 1
 
-:   Definition 1
+:   Definition 1 with some ~~removed text~~
 
 Term 2
 

--- a/examples/latex.tex
+++ b/examples/latex.tex
@@ -27,6 +27,7 @@
   pipeTables,
   tableCaptions,
   taskLists,
+  strikeThrough,
 ]{markdown}
 \begin{markdown*}{hybrid}
 ---

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -18848,6 +18848,7 @@ parsers.internal_punctuation   = S(":;,.?")
 
 parsers.doubleasterisks        = P("**")
 parsers.doubleunderscores      = P("__")
+parsers.doubletildes           = P("~~")
 parsers.fourspaces             = P("    ")
 
 parsers.any                    = P(1)
@@ -20107,6 +20108,7 @@ function M.reader.new(writer, options, extensions)
                             + V("UlOrStarLine")
                             + V("Strong")
                             + V("Emph")
+                            + V("StrikeThrough")
                             + V("InlineNote")
                             + V("NoteRef")
                             + V("Citations")
@@ -20150,6 +20152,7 @@ function M.reader.new(writer, options, extensions)
       UlOrStarLine          = parsers.UlOrStarLine,
       Strong                = parsers.Strong,
       Emph                  = parsers.Emph,
+      StrikeThrough         = parsers.fail,
       InlineNote            = parsers.fail,
       NoteRef               = parsers.fail,
       Citations             = parsers.fail,
@@ -21415,6 +21418,48 @@ M.extensions.pipe_tables = function(table_captions)
 end
 %    \end{macrocode}
 % \begin{markdown}
+%
+%#### Strike-Through
+%
+% The \luamdef{extensions.strike_through} function implements the Pandoc
+% strike-through syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.strike_through = function()
+  return {
+    extend_writer = function(self)
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->strike_through} as a function that will transform
+% a strike-through span `s` of input text to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.strike_through(s)
+        return {"\\markdownRendererStrikeThrough{",s,"}"}
+      end
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local syntax = self.syntax
+      local writer = self.writer
+
+      local StrikeThrough = (
+        parsers.between(parsers.Inline, parsers.doubletildes,
+                        parsers.doubletildes)
+      ) / writer.strike_through
+
+      syntax.StrikeThrough = StrikeThrough
+
+      self.add_special_character("~")
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
 %
 %### Conversion from Markdown to Plain \TeX{}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -13977,6 +13977,120 @@ following text:
 %
 % \begin{markdown}
 
+#### Strike-Through Renderer
+The \mdef{markdownRendererStrikeThrough} macro represents a strike-through span of
+text. The macro receives a single argument that corresponds to the striked-out
+span of text. This macro will only be produced, when the \Opt{strikeThrough}
+option is enabled.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionStrikeThrough{true}
+\input soulutf8.sty
+\def\markdownRendererStrikeThrough#1{\st{#1}}
+\markdownBegin
+This is ~~a lunar roving vehicle~~ strike-through text.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[strikeThrough]{markdown}
+\usepackage{soulutf8}
+\markdownSetup{
+  renderers = {
+    strikeThrough = {\st{#1}},
+  },
+}
+\begin{document}
+\begin{markdown}
+This is ~~a lunar roving vehicle~~ strike-through text.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input soul.sty
+\def\markdownRendererStrikeThrough#1{\st{#1}}
+\markdownBegin
+
+\usemodule[t][markdown]
+\def\markdownOptionStrikeThrough{true}
+\def\markdownRendererStrikeThrough#1{\overstrikes{#1}}
+\starttext
+\startmarkdown
+This is ~~a lunar roving vehicle~~ strike-through text.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererStrikeThrough{%
+  \markdownRendererStrikeThroughPrototype}%
+\ExplSyntaxOn
+\seq_put_right:Nn
+  \g_@@_renderers_seq
+  { strikeThrough }
+\prop_put:Nnn
+  \g_@@_renderer_arities_prop
+  { strikeThrough }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 ### Token Renderer Prototypes {#texrendererprototypes}
 
 % \end{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24338,6 +24338,7 @@ end
 \def\markdownRendererTickedBoxPrototype{$\boxtimes$}
 \def\markdownRendererHalfTickedBoxPrototype{$\boxdot$}
 \def\markdownRendererUntickedBoxPrototype{$\square$}
+\def\markdownRendererStrikeThroughPrototype#1{\overstrikes{#1}}
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1258,6 +1258,11 @@ local md5 = require("md5")
 %     <#sec:latexyamlmetadata>, and also in the default renderer prototype
 %     for attribute identifiers.
 %
+% \pkg{soulutf8}
+%
+%:    A package that is used in the default renderer prototype for
+%     strike-throughs.
+%
 % \end{markdown}
 %  \begin{macrocode}
 \RequirePackage{expl3}
@@ -24061,6 +24066,26 @@ end
   },
 }
 \ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+%#### Strike-Through
+% If the \Opt{strikeThrough} option is enabled, we will load the
+% \pkg{soulutf8} package and use it to implement strike-throughs.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\markdownIfOption{strikeThrough}{%
+  \RequirePackage{soulutf8}%
+  \markdownSetup{
+    rendererPrototypes = {
+      strikeThrough = {%
+        \st{#1}%
+      },
+    }
+  }
+}{}
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -7005,6 +7005,129 @@ defaultOptions.startNumber = true
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `strikeThrough`
+
+`strikeThrough` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{strikeThrough}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :   Enable the Pandoc strike-through syntax extension:
+
+         ``` md
+         This ~~is deleted text.~~
+         ``````
+
+:    false
+
+     :   Disable the Pandoc strike-through syntax extension:
+
+% \end{markdown}
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionStrikeThrough{true}
+\input soulutf8.sty
+\def\markdownRendererStrikeThrough#1{\st{#1}}
+\markdownBegin
+This is ~~a lunar roving vehicle~~ strike-through text.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[strikeThrough]{markdown}
+\usepackage{soulutf8}
+\markdownSetup{
+  renderers = {
+    strikeThrough = {\st{#1}},
+  },
+}
+\begin{document}
+\begin{markdown}
+This is ~~a lunar roving vehicle~~ strike-through text.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input soul.sty
+\def\markdownRendererStrikeThrough#1{\st{#1}}
+\markdownBegin
+
+\usemodule[t][markdown]
+\def\markdownOptionStrikeThrough{true}
+\def\markdownRendererStrikeThrough#1{\overstrikes{#1}}
+\starttext
+\startmarkdown
+This is ~~a lunar roving vehicle~~ strike-through text.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { strikeThrough }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.strikeThrough = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `stripIndent`
 
 `stripIndent` (default value: `false`)
@@ -21649,6 +21772,11 @@ function M.new(options)
     local pipe_tables_extension = M.extensions.pipe_tables(
       options.tableCaptions)
     table.insert(extensions, pipe_tables_extension)
+  end
+
+  if options.strikeThrough then
+    local strike_through_extension = M.extensions.strike_through()
+    table.insert(extensions, strike_through_extension)
   end
 
   local writer = M.writer.new(options)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21963,6 +21963,7 @@ end
 \def\markdownRendererTickedBoxPrototype{[X]}%
 \def\markdownRendererHalfTickedBoxPrototype{[/]}%
 \def\markdownRendererUntickedBoxPrototype{[ ]}%
+\def\markdownRendererStrikeThroughPrototype#1{#1}%
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -228,5 +228,7 @@
       \TYPE{END jekyllDataMappingBegin}},
     jekyllDataMappingEnd = {%
       \TYPE{jekyllDataMappingEnd}},
+    strikeThrough = {%
+      \TYPE{strikeThrough:         #1}},
   }%
 }%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -210,3 +210,5 @@
   \TYPE{END jekyllDataMappingBegin}}%
 \def\markdownRendererJekyllDataMappingEnd{%
   \TYPE{jekyllDataMappingEnd}}%
+\def\markdownRendererStrikeThrough#1{%
+  \TYPE{strikeThrough:         #1}}%

--- a/tests/testfiles/lunamark-markdown/no-strike-through.test
+++ b/tests/testfiles/lunamark-markdown/no-strike-through.test
@@ -1,0 +1,17 @@
+<<<
+This test ensures that the Lua `strikeThrough` option is disabled by default.
+
+Some ~~deleted text~~ and some \~~regular text with tildes~~.
+>>>
+documentBegin
+codeSpan: strikeThrough
+interblockSeparator
+tilde
+tilde
+tilde
+tilde
+tilde
+tilde
+tilde
+tilde
+documentEnd

--- a/tests/testfiles/lunamark-markdown/strike-through.test
+++ b/tests/testfiles/lunamark-markdown/strike-through.test
@@ -1,0 +1,16 @@
+\def\markdownOptionStrikeThrough{true}
+<<<
+This test ensures that the Lua `strikeThrough` option correctly propagates
+through the plain TeX interface.
+
+Some ~~deleted text~~ and some \~~regular text with tildes~~.
+>>>
+documentBegin
+codeSpan: strikeThrough
+interblockSeparator
+strikeThrough: deleted text
+tilde
+tilde
+tilde
+tilde
+documentEnd


### PR DESCRIPTION
Progresses #149.

### Tasks

- [x] Add [strike-through syntax extension][1].
- [x] Add strike-through renderer.
- [x] Add strike-through Lua option.
- [x] Add default strike-through renderer prototypes for plain TeX, [LaTeX][2], and [ConTeXt][3].
- [x] Add strike-though to example documents for LaTeX and ConTeXt.
- [x] Add [unit tests for strike-through][4].

 [1]: https://github.com/jgm/lunamark/pull/36/commits/33cd998bae99baf1b627b9163f85632f50eb2c85
 [2]: https://ctan.org/pkg/soulutf8
 [3]: http://www.pragma-ade.nl/general/manuals/ma-cb-en.pdf#page=108
 [4]: https://github.com/jgm/lunamark/pull/36/files#diff-f122d9063d2f9370cf3ac86b93a927cd3bb16da53b24e5a353cbc7fca3ef5d10