### PR TITLE
Make tilde (`~`) special when `fencedCode` is enabled

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21184,6 +21184,8 @@ M.extensions.fenced_code = function(blank_before_code_fence)
 
       parsers.EndlineExceptions = parsers.EndlineExceptions + fencestart
       syntax.EndlineExceptions = parsers.EndlineExceptions
+
+      self.add_special_character("~")
     end
   }
 end

--- a/tests/testfiles/lunamark-markdown/fenced-code.test
+++ b/tests/testfiles/lunamark-markdown/fenced-code.test
@@ -12,6 +12,12 @@ bar
 ~~~ foo
 bar
 ~~~
+
+The following fenced code block is escaped:
+
+\~\~\~ foo
+bar
+\~\~\~
 >>>
 documentBegin
 codeSpan: fencedCode
@@ -26,4 +32,12 @@ BEGIN fencedCode
 - src: ./_markdown_test/37b51d194a7513e45b56f6524f2d51f2.verbatim
 - infostring: foo
 END fencedCode
+interblockSeparator
+interblockSeparator
+tilde
+tilde
+tilde
+tilde
+tilde
+tilde
 documentEnd

--- a/tests/testfiles/lunamark-markdown/no-fenced-code.test
+++ b/tests/testfiles/lunamark-markdown/no-fenced-code.test
@@ -9,6 +9,12 @@ bar
 ~~~ foo
 bar
 ~~~
+
+The following fenced code block is escaped:
+
+\~\~\~ foo
+bar
+\~\~\~
 >>>
 documentBegin
 codeSpan: fencedCode
@@ -20,5 +26,19 @@ tilde
 tilde
 tilde
 tilde
+tilde
+interblockSeparator
+interblockSeparator
+backslash
+tilde
+backslash
+tilde
+backslash
+tilde
+backslash
+tilde
+backslash
+tilde
+backslash
 tilde
 documentEnd


### PR DESCRIPTION
Tilde is not special when `fencedCode` is enabled, which makes it impossible to escape fenced code blocks.