### PR TITLE
Add `\setupmarkdown` and `\inputmarkdown` commands to the ConTeXt interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Development:
 - Add support for strike-throughs, fenced divs, inline spans, subscripts,
   superscripts, and fancy lists. (#149, #160, #162, #168, #170)
 - Add facade in front of expl3 inferface for YAML metadata. (#118, #175)
+- Add `\setupmarkdown` and `\inputmarkdown` commands to ConTeXt. (#17, #176)
 
 Fixes:
 

--- a/examples/context-mkii.tex
+++ b/examples/context-mkii.tex
@@ -7,20 +7,23 @@
 \usemodule[t][markdown]
 
 % Set options of the Markdown module.
-\def\markdownOptionHashEnumerators{true}
-\def\markdownOptionDefinitionLists{true}
-\def\markdownOptionSmartEllipses{true}
-\def\markdownOptionFootnotes{true}
-\def\markdownOptionInlineFootnotes{true}
-\def\markdownOptionFencedCode{true}
-\def\markdownOptionContentBlocks{true}
-\def\markdownOptionPipeTables{true}
-\def\markdownOptionTableCaptions{true}
-\def\markdownOptionTaskLists{true}
-\def\markdownOptionStrikeThrough{true}
-\def\markdownOptionSuperscripts{true}
-\def\markdownOptionSubscripts{true}
-\def\markdownOptionFancyLists{true}
+\setupmarkdown
+  [
+    hashEnumerators = yes,
+    definitionLists = yes,
+    smartEllipses = yes,
+    footnotes = yes,
+    inlineFootnotes = yes,
+    fencedCode = yes,
+    contentBlocks = yes,
+    pipeTables = yes,
+    tableCaptions = yes,
+    taskLists = yes,
+    strikeThrough = yes,
+    superscripts = yes,
+    subscripts = yes,
+    fancyLists = yes,
+  ]
 
 % Set renderers of the Markdown module.
 \definetyping
@@ -34,7 +37,7 @@
 
 % Typeset the document `example.md` by letting the Markdown package handle
 % the conversion internally.
-\markdownInput{./example.md}
+\inputmarkdown{./example.md}
 
 % Typeset the document `example.tex` that we prepared separately using the
 % Lua command-line interface and that contains a plain TeX representation

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -7,20 +7,23 @@
 \usemodule[t][markdown]
 
 % Set options of the Markdown module.
-\def\markdownOptionHashEnumerators{true}
-\def\markdownOptionDefinitionLists{true}
-\def\markdownOptionSmartEllipses{true}
-\def\markdownOptionFootnotes{true}
-\def\markdownOptionInlineFootnotes{true}
-\def\markdownOptionFencedCode{true}
-\def\markdownOptionContentBlocks{true}
-\def\markdownOptionPipeTables{true}
-\def\markdownOptionTableCaptions{true}
-\def\markdownOptionTaskLists{true}
-\def\markdownOptionStrikeThrough{true}
-\def\markdownOptionSuperscripts{true}
-\def\markdownOptionSubscripts{true}
-\def\markdownOptionFancyLists{true}
+\setupmarkdown
+  [
+    hashEnumerators = yes,
+    definitionLists = yes,
+    smartEllipses = yes,
+    footnotes = yes,
+    inlineFootnotes = yes,
+    fencedCode = yes,
+    contentBlocks = yes,
+    pipeTables = yes,
+    tableCaptions = yes,
+    taskLists = yes,
+    strikeThrough = yes,
+    superscripts = yes,
+    subscripts = yes,
+    fancyLists = yes,
+  ]
 
 % Set renderers of the Markdown module.
 \definehighlight
@@ -46,7 +49,7 @@
 
 % Typeset the document `example.md` by letting the Markdown package handle
 % the conversion internally.
-\markdownInput{./example.md}
+\inputmarkdown{./example.md}
 
 % Typeset the document `example.tex` that we prepared separately using the
 % Lua command-line interface and that contains a plain TeX representation

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -2175,7 +2175,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionCacheDir{cache}
+\setupmarkdown[cacheDir = cache]
 \starttext
 \startmarkdown
 Hello *world*!
@@ -2380,8 +2380,11 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionFinalizeCache{true}
-\def\markdownOptionFrozenCacheFileName{cache.tex}
+\setupmarkdown
+  [
+    finalizeCache = yes,
+    frozenCacheFileName = cache.tex,
+  ]
 \starttext
 \startmarkdown
 Hello *world*!
@@ -2401,8 +2404,11 @@ Next, create a new text document `frozen-document.tex` with the following
 content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionFrozenCache{true}
-\def\markdownOptionFrozenCacheFileName{cache.tex}
+\setupmarkdown
+  [
+    frozenCache = yes,
+    frozenCacheFileName = cache.tex,
+  ]
 \starttext
 \startmarkdown
 Hi *world*!
@@ -2622,7 +2628,7 @@ A paragraph.
 > A quote.
 \stopmarkdown
 
-\def\markdownOptionBlankBeforeBlockquote{true}
+\setupmarkdown[blankBeforeBlockquote = yes]
 \startmarkdown
 A paragraph.
 > Not a quote.
@@ -2857,7 +2863,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ```` tex
 \usemodule[t][markdown]
-\def\markdownOptionFencedCode{true}
+\setupmarkdown[fencedCode = yes]
 \starttext
 
 \startmarkdown
@@ -2867,7 +2873,7 @@ A code fence.
 ```
 \stopmarkdown
 
-\def\markdownOptionBlankBeforeCodeFence{true}
+\setupmarkdown[blankBeforeCodeFence = yes]
 \startmarkdown
 A paragraph.
 ```
@@ -3101,7 +3107,7 @@ A heading.
 ==========
 \stopmarkdown
 
-\def\markdownOptionBlankBeforeHeading{true}
+\setupmarkdown[blankBeforeHeading = yes]
 \startmarkdown
 A paragraph.
 Not a heading.
@@ -3326,7 +3332,7 @@ following content:
 > block quote.
 \stopmarkdown
 
-\def\markdownOptionBreakableBlockquotes{true}
+\setupmarkdown[breakableBlockquotes = yes]
 \startmarkdown
 > A block quote.
 
@@ -3742,7 +3748,7 @@ following content:
 ``This is no longer a code span.''
 \stopmarkdown
 
-\def\markdownOptionCodeSpans{false}
+\setupmarkdown[codeSpans = no]
 \startmarkdown
 ``This is a quote.''
 ``This is another quote.''
@@ -3903,7 +3909,7 @@ This is a *transcluded markdown document*.
 Create also a text document named `document.tex` with the following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionContentBlocks{true}
+\setupmarkdown[contentBlocks = yes]
 \definetyping [ConTeXt]
 \setuptyping  [ConTeXt] [option=TEX]
 \starttext
@@ -4062,8 +4068,11 @@ This is a *transcluded markdown document*.
 Create also a text document named `document.tex` with the following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionContentBlocks{true}
-\def\markdownOptionContentBlocksLanguageMap{language-map.json}
+\setupmarkdown
+  [
+    contentBlocks = yes,
+    contentBlocksLanguageMap = language-map.json,
+  ]
 \definetyping [ConTeXt]
 \setuptyping  [ConTeXt] [option=TEX]
 \starttext
@@ -4198,7 +4207,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionDefinitionLists{true}
+\setupmarkdown[definitionLists = yes]
 \starttext
 \startmarkdown
 Term 1
@@ -4539,7 +4548,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ```` tex
 \usemodule[t][markdown]
-\def\markdownOptionFancyLists{true}
+\setupmarkdown[fancyLists = yes]
 \starttext
 \startmarkdown
 a) first item
@@ -4678,7 +4687,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ```` tex
 \usemodule[t][markdown]
-\def\markdownOptionFencedCode{true}
+\setupmarkdown[fencedCode = yes]
 \definetyping [js]
 \definetyping [html]
 \setuptyping  [html] [option=XML]
@@ -4856,7 +4865,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionFinalizeCache{true}
+\setupmarkdown[finalizeCache = yes]
 \starttext
 \startmarkdown
 Hello *world*!
@@ -4874,7 +4883,7 @@ output file as we requested using the `finalizeCache` option.
 Next, change the content of `document.tex` as follows:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionFrozenCache{true}
+\setupmarkdown[frozenCache = yes]
 \starttext
 \startmarkdown
 Hi *world*!
@@ -5012,7 +5021,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionFootnotes{true}
+\setupmarkdown[footnotes = yes]
 \starttext
 \startmarkdown
 Here is a footnote reference,[^1] and another.[^longnote]
@@ -5268,15 +5277,15 @@ following content:
 \begin{document}
 
 \begin{markdown}
-. Bird
-. McHale
-. Parish
+#. Bird
+#. McHale
+#. Parish
 \end{markdown}
 
 \begin{markdown*}{hashEnumerators}
-. Bird
-. McHale
-. Parish
+#. Bird
+#. McHale
+#. Parish
 \end{markdown*}
 
 \end{document}
@@ -5308,16 +5317,16 @@ following content:
 \starttext
 
 \startmarkdown
-. Bird
-. McHale
-. Parish
+#. Bird
+#. McHale
+#. Parish
 \stopmarkdown
 
-\def\markdownOptionHashEnumerators{true}
+\setupmarkdown[hashEnumerators = yes]
 \startmarkdown
-. Bird
-. McHale
-. Parish
+#. Bird
+#. McHale
+#. Parish
 \stopmarkdown
 
 \stoptext
@@ -5631,7 +5640,7 @@ _There is no <!-- comment --> support._
 _There is no <? HTML instruction ?> support._
 \stopmarkdown
 
-\def\markdownOptionHtml{true}
+\setupmarkdown[html = yes]
 \startmarkdown
 <div>
 *There is block tag support.*
@@ -5850,7 +5859,7 @@ following content:
 $\sqrt{-1}$ *equals* $i$.
 \stopmarkdown
 
-\def\markdownOptionHybrid{true}
+\setupmarkdown[hybrid = yes]
 \startmarkdown
 $\sqrt{-1}$ *equals* $i$.
 \stopmarkdown
@@ -5947,7 +5956,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionInlineFootnotes{true}
+\setupmarkdown[inlineFootnotes = yes]
 \starttext
 \startmarkdown
 Here is an inline note.^[Inlines notes are easier to
@@ -6100,7 +6109,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionJekyllData{true}
+\setupmarkdown[jekyllData = yes]
 \ExplSyntaxOn
 \keys_define:nn
   { markdown/jekyllData }
@@ -6216,7 +6225,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionPipeTables{true}
+\setupmarkdown[pipeTables = yes]
 \starttext
 \startmarkdown
 | Right | Left | Default | Center |
@@ -6492,14 +6501,9 @@ following content:
 \usemodule[t][markdown]
 \starttext
 
-\def\markdownOptionShiftHeadings{-1}
-\markdownInput{example.md}
-
-\def\markdownOptionShiftHeadings{0}
-\markdownInput{example.md}
-
-\def\markdownOptionShiftHeadings{+1}
-\markdownInput{example.md}
+\inputmarkdown[shiftHeadings = -1]{example.md}
+\inputmarkdown[shiftHeadings =  0]{example.md}
+\inputmarkdown[shiftHeadings = +1]{example.md}
 
 \stoptext
 ````````
@@ -6699,17 +6703,12 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionHeaderAttributes{true}
+\setupmarkdown[headerAttributes = yes]
 \starttext
 
-\def\markdownOptionSlice{^ ^act-3}
-\markdownInput{hamlet.md}
-
-\def\markdownOptionSlice{act-1}
-\markdownInput{hamlet.md}
-
-\def\markdownOptionSlice{act-3 act-5}
-\markdownInput{hamlet.md}
+\inputmarkdown[slice = ^ ^act-3]{example.md}
+\inputmarkdown[slice = act-1]{example.md}
+\inputmarkdown[slice = act-3 act-5]{example.md}
 
 \stoptext
 ````````
@@ -6921,7 +6920,7 @@ following content:
 These are just three regular dots ...
 \stopmarkdown
 
-\def\markdownOptionSmartEllipses{true}
+\setupmarkdown[smartEllipses = yes]
 \startmarkdown
 ... and this is a victorian ellipsis.
 \stopmarkdown
@@ -7046,7 +7045,7 @@ The following list respects the numbers specified in the markup:
 5. fifth item
 \stopmarkdown
 
-\def\markdownOptionStartNumber{false}
+\setupmarkdown[startNumber = no]
 \startmarkdown
 The following list respects the numbers specified in the markup:
 
@@ -7177,7 +7176,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionStrikeThrough{true}
+\setupmarkdown[strikeThrough = yes]
 \def\markdownRendererStrikeThrough#1{\overstrikes{#1}}
 \starttext
 \startmarkdown
@@ -7293,7 +7292,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionStripIndent{true}
+\setupmarkdown[stripIndent = yes]
 \starttext
     \startmarkdown
         Hello *world*!
@@ -7380,7 +7379,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionSubscripts{true}
+\setupmarkdown[subscripts = yes]
 \starttext
 \startmarkdown
 H~2~O is a liquid.
@@ -7469,7 +7468,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionSuperscripts{true}
+\setupmarkdown[superscripts = yes]
 \starttext
 \startmarkdown
 2^10^ is 1024.
@@ -7580,8 +7579,11 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionPipeTables{true}
-\def\markdownOptionTableCaptions{true}
+\setupmarkdown
+  [
+    pipeTables = yes,
+    tableCaptions = yes,
+  ]
 \starttext
 \startmarkdown
 | Right | Left | Default | Center |
@@ -7696,7 +7698,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionTaskLists{true}
+\setupmarkdown[taskLists = yes]
 \def\markdownRendererUntickedBox{No}
 \def\markdownRendererHalftickedBox{Maybe}
 \def\markdownRendererTickedBox{Yes}
@@ -7820,7 +7822,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionTexComments{true}
+\setupmarkdown[texComments = yes]
 \starttext
 \startmarkdown
 Hel%  this is a comment
@@ -8074,14 +8076,14 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionHybrid{true}
+\setupmarkdown[hybrid = yes]
 \starttext
 
 \startmarkdown
 This is _emphasized text_ and this is a math subscript: $m\_n$.
 \stopmarkdown
 
-\def\markdownOptionUnderscores{false}
+\setupmarkdown[underscores = yes]
 \startmarkdown
 This is *emphasized text* and this is a math subscript: $m_n$.
 \stopmarkdown
@@ -9095,7 +9097,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionTaskLists{true}
+\setupmarkdown[taskLists = yes]
 \def\markdownRendererUntickedBox{No}
 \def\markdownRendererTickedBox{Yes}
 \starttext
@@ -9660,7 +9662,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionSmartEllipses{true}
+\setupmarkdown[smartEllipses = yes]
 \def\markdownRendererEllipsis{\emph{SHAZAM}!}
 \starttext
 \startmarkdown
@@ -10126,7 +10128,7 @@ following content:
 $\sqrt{-1}$ *equals* $i$
 \stopmarkdown
 
-\def\markdownOptionHybrid{true}
+\setupmarkdown[hybrid = yes]
 \startmarkdown
 $\sqrt{-1}$ *equals* $i$
 \stopmarkdown
@@ -10583,7 +10585,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionContentBlocks{true}
+\setupmarkdown[contentBlocks = yes]
 \def\markdownRendererContentBlock#1#2#3#4{%
   This is {\tt #2}, #4.
 }
@@ -10966,7 +10968,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionTightLists{true}
+\setupmarkdown[tightLists = yes]
 \starttext
 
 \def\markdownRendererInterblockSeparator{}
@@ -11685,8 +11687,11 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionTightLists{true}
-\def\markdownOptionStartNumber{true}
+\setupmarkdown
+  [
+    tightLists = yes,
+    startNumber = yes,
+  ]
 \starttext
 
 \def\markdownRendererInterblockSeparator{}
@@ -12261,8 +12266,11 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionDefinitionLists{true}
-\def\markdownOptionTightLists{true}
+\setupmarkdown
+  [
+    definitionLists = yes,
+    tightLists = yes,
+  ]
 \starttext
 
 \def\markdownRendererInterblockSeparator{%
@@ -13283,7 +13291,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionJekyllData{true}
+\setupmarkdown[jekyllData = yes]
 \def\markdownRendererJekyllDataString#1#2{\gdef\name{#2}}
 \def\markdownRendererJekyllDataNumber#1#2{\gdef\age{#2}}
 \def\markdownRendererJekyllDataEnd{%
@@ -13813,7 +13821,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionFootnotes{true}
+\setupmarkdown[footnotes = yes]
 \def\markdownRendererFootnote#1{ (and \lowercase{#1})}
 \starttext
 \startmarkdown
@@ -14681,7 +14689,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionStrikeThrough{true}
+\setupmarkdown[strikeThrough = yes]
 \def\markdownRendererStrikeThrough#1{\overstrikes{#1}}
 \starttext
 \startmarkdown
@@ -14789,7 +14797,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionSuperscripts{true}
+\setupmarkdown[superscripts = yes]
 \def\markdownRendererSuperscript#1{ taken to the power of #1}
 \starttext
 \startmarkdown
@@ -14897,7 +14905,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionSubscripts{true}
+\setupmarkdown[subscripts = yes]
 \def\markdownRendererSubscript#1{ (#1 moles) and }
 \starttext
 \startmarkdown
@@ -15139,7 +15147,7 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownOptionJekyllData{true}
+\setupmarkdown[jekyllData = yes]
 \ExplSyntaxOn
 \keys_define:nn
   { markdown/jekyllData }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -15435,11 +15435,11 @@ pdflatex --shell-escape document.tex
 % \begin{markdown}
 %
 % The \LaTeX{} interface provides \LaTeX{} environments for the typesetting of
-% markdown input from within \LaTeX{}, facilities for setting Lua interface
-% options (see Section <#sec:luaoptions>) used during the conversion from
-% markdown to plain \TeX{}, and facilities for changing the way markdown tokens
-% are rendered. The rest of the interface is inherited from the plain \TeX{}
-% interface (see Section <#sec:texinterface>).
+% markdown input from within \LaTeX{}, facilities for setting Lua, plain \TeX,
+% and \LaTeX{} options used during the conversion from markdown to plain
+% \TeX{}, and facilities for changing the way markdown tokens are rendered. The
+% rest of the interface is inherited from the plain \TeX{} interface (see
+% Section <#sec:texinterface>).
 %
 % The \LaTeX{} implementation redefines the plain \TeX{} logging macros (see
 % Section <#sec:texinterfacelogging>) to use the \LaTeX{} \mref{PackageInfo},
@@ -16216,7 +16216,7 @@ The following ordered list will be preceded by roman numerals:
 % \begin{markdown}
 %
 % Furthermore, we also define the \meta{key}`=`\meta{value} interface
-% for all option macros recognized by the Lua plain \TeX{} interfaces.
+% for all option macros recognized by the Lua and plain \TeX{} interfaces.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -16464,7 +16464,7 @@ The following ordered list will be preceded by roman numerals:
 The \Hologo{ConTeXt} interface provides the same level of functionality as the
 plain \TeX{} interface by using the plain \TeX{} interface behind the scenes.
 Unlike the plain \TeX{} interface, the \Hologo{ConTeXt} interface uses familiar
-\Hologo{ConTeXt} idioms, such as environments.
+\Hologo{ConTeXt} idioms as syntactic sugar.
 
 The \Hologo{ConTeXt} interface accepts the same options as the plain \TeX{}
 interface.
@@ -16479,7 +16479,7 @@ following content:
 $\sqrt{-1}$ *equals* $i$.
 \stopmarkdown
 
-\def\markdownOptionHybrid{true}
+\setupmarkdown[hybrid = yes]
 \startmarkdown
 $\sqrt{-1}$ *equals* $i$.
 \stopmarkdown
@@ -16507,15 +16507,31 @@ texexec --passon=--shell-escape document.tex
 % \fi
 %
 % The \Hologo{ConTeXt} interface provides a start-stop macro pair for the
-% typesetting of markdown input from within \Hologo{ConTeXt}. The rest of the
-% interface is inherited from the plain \TeX{} interface (see Section
-% <#sec:texinterface>).
+% typesetting of markdown input from within \Hologo{ConTeXt} and facilities for
+% setting Lua, plain \TeX, and \Hologo{ConTeXt} options used during the
+% conversion from markdown to plain \TeX{}. The rest of the interface is
+% inherited from the plain \TeX{} interface (see Section <#sec:texinterface>).
 %
 % \end{markdown}
 %  \begin{macrocode}
 \writestatus{loading}{ConTeXt User Module / markdown}%
 \startmodule[markdown]
 \unprotect
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The \Hologo{ConTeXt} implementation redefines the plain \TeX{} logging macros
+% (see Section <#sec:texinterfacelogging>) to use the \Hologo{ConTeXt}
+% \mref{writestatus} macro.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\def\markdownInfo#1{\writestatus{markdown}{#1.}}%
+\def\markdownWarning#1{\writestatus{markdown\space warn}{#1.}}%
+\def\dospecials{\do\ \do\\\do\{\do\}\do\$\do\&%
+  \do\#\do\^\do\_\do\%\do\~}%
+\input markdown/markdown
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -16530,12 +16546,14 @@ texexec --passon=--shell-escape document.tex
 %
 %### Typesetting Markdown
 % The interface exposes the \mdef{startmarkdown} and \mdef{stopmarkdown} macro
-% pair for the typesetting of a markdown document fragment.
+% pair for the typesetting of a markdown document fragment, and defines the
+% \mdef{inputmarkdown} command.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \let\startmarkdown\relax
 \let\stopmarkdown\relax
+\let\inputmarkdown\relax
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -16558,6 +16576,127 @@ texexec --passon=--shell-escape document.tex
 % \stopmarkdown
 % \stoptext
 % ```````
+%
+% The \mref{inputmarkdown} macro accepts a single mandatory parameter
+% containing the filename of a markdown document and expands to the result of
+% the conversion of the input markdown document to plain \TeX{}. Unlike the
+% \mref{markdownInput} macro provided by the plain \TeX{} interface, this macro
+% also accepts \Hologo{ConTeXt} interface options (see Section
+% <#sec:contextoptions>) as its optional argument. These options will only
+% influnce this markdown document.
+%
+% The following example \LaTeX{} code showcases the usage of the
+% \mref{markdownInput} macro:
+% ``` tex
+% \usemodule[t][markdown]
+% \starttext
+% % ...
+% \inputmarkdown[smartEllipses]{hello.md}
+% % ...
+% \stoptext
+% ```````
+%
+%### Options {#contextoptions}
+%
+% The \Hologo{ConTeXt} options are represented by a comma-delimited list of
+% \meta{key}`=`\meta{value} pairs. For boolean options, the `=`\meta{value}
+% part is optional, and \meta{key} will be interpreted as \meta{key}`=true`
+% (or, equivalently, \meta{key}`=yes`) if the `=`\meta{value} part has been
+% omitted.
+%
+% \Hologo{ConTeXt} options map directly to the options recognized by the plain
+% \TeX{} interface (see Section <#sec:texoptions>).
+%
+% The \Hologo{ConTeXt} options may be specified when using the
+% \mref{inputmarkdown} macro (see Section <#sec:contextinterface>), or via the
+% \mdef{setupmarkdown} macro. The \mref{setupmarkdown} macro receives the
+% options to set up as its only argument:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Nn
+  \@@_setup:n
+  {
+    \keys_set:nn
+      { markdown/context-options }
+      { #1 }
+  }
+\long\def\setupmarkdown[#1]
+  {
+    \@@_setup:n
+      { #1 }
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### \Hologo{ConTeXt} Interface Options
+% We define the \meta{key}`=`\meta{value} interface for all option macros
+% recognized by the Lua and plain \TeX{} interfaces.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Nn \@@_context_define_option_commands_and_keyvals:
+  {
+    \seq_map_inline:Nn
+      \g_@@_option_layers_seq
+      {
+        \seq_map_inline:cn
+          { g_@@_ ##1 _options_seq }
+          {
+              \@@_context_define_option_keyval:nn
+                { ##1 }
+                { ####1 }
+          }
+      }
+  }
+\cs_new:Nn \@@_context_define_option_keyval:nn
+  {
+    \prop_get:cnN
+      { g_@@_ #1 _option_types_prop }
+      { #2 }
+      \l_tmpa_tl
+    \keys_define:nn
+      { markdown/context-options }
+      {
+        #2 .code:n = {
+          \tl_set:Nx
+            \l_tmpa_tl
+            {
+              \str_case:nnF
+                { ##1 }
+                {
+                  { yes } { true }
+                  { no } { false }
+                }
+                { ##1 }
+            }
+          \@@_set_option_value:nV
+            { #2 }
+            \l_tmpa_tl
+        },
+      }
+    \str_if_eq:VVT
+      \l_tmpa_tl
+      \c_@@_option_type_boolean_tl
+      {
+        \keys_define:nn
+          { markdown/context-options }
+          {
+            #2 .default:n = { true },
+          }
+      }
+  }
+\cs_generate_variant:Nn
+  \@@_set_option_value:nn
+  { nV }
+\@@_context_define_option_commands_and_keyvals:
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
 %
 % Implementation {#implementation}
 %================
@@ -25303,21 +25442,6 @@ end
 % consequence, we can directly reuse the existing plain \TeX{} implementation
 % after supplying the missing plain \TeX{} macros.
 %
-% The \Hologo{ConTeXt} implementation redefines the plain \TeX{} logging macros
-% (see Section <#sec:texinterfacelogging>) to use the \Hologo{ConTeXt}
-% \mref{writestatus} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\def\markdownInfo#1{\writestatus{markdown}{#1.}}%
-\def\markdownWarning#1{\writestatus{markdown\space warn}{#1.}}%
-\def\dospecials{\do\ \do\\\do\{\do\}\do\$\do\&%
-  \do\#\do\^\do\_\do\%\do\~}%
-\input markdown/markdown
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
 % When buffering user input, we should disable the bytes with the high bit set,
 % since these are made active by the \mref{enableregime} macro. We will do this
 % by redefining the \mref{markdownMakeOther} macro accordingly. The code is
@@ -25347,6 +25471,26 @@ end
 % \begin{markdown}
 %
 %### Typesetting Markdown
+% The \mref{inputmarkdown} is defined to accept an optional argument with
+% options recognized by the \Hologo{ConTeXt} interface (see Section
+% <#sec:contextoptions>).
+%
+% \end{markdown}
+%  \begin{macrocode}
+\long\def\inputmarkdown{%
+  \dosingleempty
+  \doinputmarkdown}%
+\long\def\doinputmarkdown[#1]#2{%
+  \begingroup
+    \iffirstargument
+      \setupmarkdown{#1}%
+    \fi
+    \markdownInput{#2}%
+  \endgroup}%
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 % The \mref{startmarkdown} and \mref{stopmarkdown} macros are implemented using the
 % \mref{markdownReadAndConvert} macro.
 %

--- a/tests/templates/context/input.tex.m4
+++ b/tests/templates/context/input.tex.m4
@@ -7,5 +7,5 @@
 \input TEST_SETUP_FILENAME\relax
 % Perform the test.
 \starttext
-  \markdownInput{TEST_INPUT_FILENAME}%
+  \inputmarkdown{TEST_INPUT_FILENAME}%
 \stoptext


### PR DESCRIPTION
Closes #17.

### Tasks

- [x] Update documentation and example documents.
- [x] Implement `\setupmarkdown` and `\inputmarkdown`.