### PR TITLE
Use all available CPU cores for unit tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.17.0 (2022-09-30)
+
+Continuous Integration:
+
+- Use all available CPU cores for unit tests. (#178)
+
 ## 2.16.0 (2022-08-26)
 
 Development:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,4 +2,5 @@
 
 # This is the default pseudo-target. It runs all the tests.
 all:
-	find testfiles/ -type f -name '*.test' | parallel --jobs 1 --halt 2 --ungroup ./test.sh
+	./test.sh testfiles/Markdown_1.0.3/auto-links.test  # Populate cache before running parallel
+	find testfiles/ -type f -name '*.test' | parallel --halt 2 ./test.sh


### PR DESCRIPTION
[GitHub-hosted runners][1] nowadays have multiple CPUs and our continuous integration pipeline takes about an hour with the great majority of time taken by unit tests. This pull request uses all available CPUs to run unit tests.

 [1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources