### PR TITLE
Accept snake_case and snakecase variants of options in `\markdownSetup` and `\setupmarkdown`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2.18.0
+
+Development:
+
+- Accept snake_case and snakecase variants of options in `\markdownSetup` and
+  `\setupmarkdown`. (#193, #194)
+
 ## 2.17.1 (2022-10-03)
 
 Fixes:

--- a/examples/context-mkii.tex
+++ b/examples/context-mkii.tex
@@ -20,10 +20,10 @@
     pipeTables = yes,
     tableCaptions = yes,
     taskLists = yes,
-    strikeThrough = yes,
+    strikethrough = yes,
     superscripts = yes,
     subscripts = yes,
-    fancyLists = yes,
+    fancy_lists = yes,
   ]
 
 % Set renderers of the Markdown module.

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -20,10 +20,10 @@
     pipeTables = yes,
     tableCaptions = yes,
     taskLists = yes,
-    strikeThrough = yes,
+    strikethrough = yes,
     superscripts = yes,
     subscripts = yes,
-    fancyLists = yes,
+    fancy_lists = yes,
   ]
 
 % Set renderers of the Markdown module.

--- a/examples/latex.tex
+++ b/examples/latex.tex
@@ -28,10 +28,10 @@
   pipeTables,
   tableCaptions,
   taskLists,
-  strikeThrough,
+  strikethrough,
   superscripts,
   subscripts,
-  fancyLists,
+  fancy_lists,
 ]{markdown}
 \begin{markdown*}{hybrid}
 ---

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -17007,16 +17007,20 @@ The following ordered list will be preceded by roman numerals:
   }
 \cs_new:Nn \@@_latex_define_renderer_prototype:nNn
   {
-    \keys_define:nn
-      { markdown/latex-options/renderer-prototypes }
+    \@@_with_various_cases:nn
+      { #1 }
       {
-        #1 .code:n = {
-          \cs_generate_from_arg_count:NNnn
-            #2
-            \cs_set:Npn
-            { #3 }
-            { ##1 }
-        },
+        \keys_define:nn
+          { markdown/latex-options/renderer-prototypes }
+          {
+            ##1 .code:n = {
+              \cs_generate_from_arg_count:NNnn
+                #2
+                \cs_set:Npn
+                { #3 }
+                { ####1 }
+            },
+          }
       }
   }
 \cs_generate_variant:Nn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -2110,6 +2110,59 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
         \tl_tail:n { #1 }
       }
   }
+\cs_new:Nn \@@_with_various_cases:nn
+  {
+    \seq_clear:N
+      \l_tmpa_seq
+    \clist_map_inline:nn
+      {
+        @@_camel_case:N,
+        @@_snake_case:N,
+      }
+      {
+        \tl_set:Nn
+          \l_tmpa_tl
+          { #1 }
+        \use:c { ##1 }
+          \l_tmpa_tl
+        \seq_put_right:NV
+          \l_tmpa_seq
+          \l_tmpa_tl
+      }
+    \seq_map_inline:Nn
+      \l_tmpa_seq
+      { #2 }
+  }
+\cs_new:Nn \@@_camel_case:N
+  {
+    \regex_replace_all:nnN
+      { _ ([a-z]) }
+      { \c { str_uppercase:n } \cB\{ \1 \cE\} }
+      #1
+    \tl_set:Nx
+      #1
+      { #1 }
+  }
+\cs_new:Nn \@@_snake_case:N
+  {
+    \regex_replace_all:nnN
+      { ([a-z])([A-Z]) }
+      { \1 _ \c { str_lowercase:n } \cB\{ \2 \cE\} }
+      #1
+    \tl_set:Nx
+      #1
+      { #1 }
+  }
+\cs_new:Nn \@@_snake_case_without_underscores:N
+  {
+    \regex_replace_all:nnN
+      { ([a-z])([A-Z]) }
+      { \1 \c { str_lowercase:n } \cB\{ \2 \cE\} }
+      #1
+    \tl_set:Nx
+      #1
+      { #1 }
+  }
 %    \end{macrocode}
 % \iffalse
 %</tex>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -16939,16 +16939,20 @@ The following ordered list will be preceded by roman numerals:
   }
 \cs_new:Nn \@@_latex_define_renderer:nNn
   {
-    \keys_define:nn
-      { markdown/latex-options/renderers }
+    \@@_with_various_cases:nn
+      { #1 }
       {
-        #1 .code:n = {
-          \cs_generate_from_arg_count:NNnn
-            #2
-            \cs_set:Npn
-            { #3 }
-            { ##1 }
-        },
+        \keys_define:nn
+          { markdown/latex-options/renderers }
+          {
+            ##1 .code:n = {
+              \cs_generate_from_arg_count:NNnn
+                #2
+                \cs_set:Npn
+                { #3 }
+                { ####1 }
+            },
+          }
       }
   }
 \cs_generate_variant:Nn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -709,6 +709,13 @@ abbr {
   version   = {v2.5},
   url       = {https://mirrors.ctan.org/macros/latex/contrib/minted/minted.pdf},
   urldate   = {2020-09-01}}
+@online{macfarlane22,
+  title     = {Pandoc},
+  subtitle  = {a universal document converter},
+  author    = {John MacFarlane},
+  year      = {2022},
+  url       = {https://pandoc.org/},
+  urldate   = {2022-10-05}}
 @online{novotny15,
   author    = {Novotný, Vít},
   year      = {2015},
@@ -16714,13 +16721,27 @@ The following ordered list will be preceded by roman numerals:
         \seq_map_inline:cn
           { g_@@_ ##1 _options_seq }
           {
-              \@@_latex_define_option_keyval:nn
-                { ##1 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To make it easier to copy-and-paste options from Pandoc [@macfarlane22] such
+% as `fancy_lists`, `header_attributes`, and `pipe_tables`, we accept both
+% snake\\\_case and camelCase variants of options.
+%
+% \end{markdown}
+%  \begin{macrocode}
+              \@@_with_various_cases:nn
                 { ####1 }
+                {
+                  \@@_latex_define_option_keyval:nnn
+                    { ##1 }
+                    { ####1 }
+                    { ########1 }
+                }
           }
       }
   }
-\cs_new:Nn \@@_latex_define_option_keyval:nn
+\cs_new:Nn \@@_latex_define_option_keyval:nnn
   {
     \prop_get:cnN
       { g_@@_ #1 _option_types_prop }
@@ -16729,7 +16750,7 @@ The following ordered list will be preceded by roman numerals:
     \keys_define:nn
       { markdown/latex-options }
       {
-        #2 .code:n = {
+        #3 .code:n = {
           \@@_set_option_value:nn
             { #2 }
             { ##1 }
@@ -16742,7 +16763,7 @@ The following ordered list will be preceded by roman numerals:
         \keys_define:nn
           { markdown/latex-options }
           {
-            #2 .default:n = { true },
+            #3 .default:n = { true },
           }
       }
 %    \end{macrocode}
@@ -16763,7 +16784,7 @@ The following ordered list will be preceded by roman numerals:
       {
         \tl_set:Nn
           \l_tmpa_tl
-          { #2 }
+          { #3 }
         \tl_reverse:N
           \l_tmpa_tl
         \str_if_eq:enF
@@ -16776,7 +16797,7 @@ The following ordered list will be preceded by roman numerals:
               \msg_error:nnn
                 { @@ }
                 { malformed-name-for-clist-option }
-                { #2 }
+                { #3 }
           }
         \tl_set:Nx
           \l_tmpa_tl

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -2125,6 +2125,7 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
       {
         @@_camel_case:N,
         @@_snake_case:N,
+        @@_snake_case_without_underscores:N,
       }
       {
         \tl_set:Nn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25354,11 +25354,20 @@ end
         { markdown/latex-options/renderers }
         { #1 }
     },
-    rendererPrototypes .code:n = {
-      \keys_set:nn
-        { markdown/latex-options/renderer-prototypes }
-        { #1 }
-    },
+  }
+\@@_with_various_cases:nn
+  { rendererPrototypes }
+  {
+    \keys_define:nn
+      { markdown/latex-options }
+      {
+        #1 .code:n = {
+          \keys_set:nn
+            { markdown/latex-options/renderer-prototypes }
+            { ##1 }
+        },
+      }
+  }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -25367,7 +25376,11 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
+\keys_define:nn
+  { markdown/latex-options }
+  {
     code .code:n = { #1 },
+  }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -25377,11 +25390,18 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    jekyllDataRenderers .code:n = {
-      \keys_set:nn
-        { markdown/latex-options/jekyll-data-renderers }
-        { #1 }
-    },
+\@@_with_various_cases:nn
+  { jekyllDataRenderers }
+  {
+    \keys_define:nn
+      { markdown/latex-options }
+      {
+        #1 .code:n = {
+          \keys_set:nn
+            { markdown/latex-options/jekyll-data-renderers }
+            { ##1 }
+        },
+      }
   }
 \keys_define:nn
   { markdown/latex-options/jekyll-data-renderers }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -17234,13 +17234,27 @@ texexec --passon=--shell-escape document.tex
         \seq_map_inline:cn
           { g_@@_ ##1 _options_seq }
           {
-              \@@_context_define_option_keyval:nn
-                { ##1 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To make it easier to copy-and-paste options from Pandoc [@macfarlane22] such
+% as `fancy_lists`, `header_attributes`, and `pipe_tables`, we accept both
+% snake\\\_case and camelCase variants of options.
+%
+% \end{markdown}
+%  \begin{macrocode}
+              \@@_with_various_cases:nn
                 { ####1 }
+                {
+                  \@@_context_define_option_keyval:nnn
+                    { ##1 }
+                    { ####1 }
+                    { ########1 }
+                }
           }
       }
   }
-\cs_new:Nn \@@_context_define_option_keyval:nn
+\cs_new:Nn \@@_context_define_option_keyval:nnn
   {
     \prop_get:cnN
       { g_@@_ #1 _option_types_prop }
@@ -17249,7 +17263,7 @@ texexec --passon=--shell-escape document.tex
     \keys_define:nn
       { markdown/context-options }
       {
-        #2 .code:n = {
+        #3 .code:n = {
           \tl_set:Nx
             \l_tmpa_tl
             {
@@ -17273,7 +17287,7 @@ texexec --passon=--shell-escape document.tex
         \keys_define:nn
           { markdown/context-options }
           {
-            #2 .default:n = { true },
+            #3 .default:n = { true },
           }
       }
   }


### PR DESCRIPTION
Closes #193.