### PR TITLE
Fix missing support for forward slashes in `\markdownSetup{jekyllDataRenderers = {...}}` keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Development:
   `\markdownSetup` and Lua CLI. Accept snake\_case and caseless variants of
   options in `\setupmarkdown`. (#193, #194, #195, #196, #197, #198)
 
+Fixes:
+
+- Fix missing support for forward slashes in
+  `\markdownSetup{jekyllDataRenderers = {...}}` keys. (#199, #200)
+
 ## 2.17.1 (2022-10-03)
 
 Fixes:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25461,9 +25461,27 @@ end
       { markdown/latex-options }
       {
         #1 .code:n = {
-          \keys_set:nn
-            { markdown/latex-options/jekyll-data-renderers }
+          \tl_set:Nn
+            \l_tmpa_tl
             { ##1 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To ensure that keys containing forward slashes get passed correctly, we
+% replace all forward slashes in the nput with backslash tokens with category
+% code letter and then undo the replacement. This means that if any unbraced
+% backslash tokens with category code letter exist in the input, they will be
+% replaced with forward slashes. However, this should be extremely rare.
+%
+% \end{markdown}
+%  \begin{macrocode}
+          \tl_replace_all:NnV
+            \l_tmpa_tl
+            { / }
+            \c_backslash_str
+          \keys_set:nV
+            { markdown/latex-options/jekyll-data-renderers }
+            \l_tmpa_tl
         },
       }
   }
@@ -25474,6 +25492,10 @@ end
       \tl_set_eq:NN
         \l_tmpa_tl
         \l_keys_key_str
+      \tl_replace_all:NVn
+        \l_tmpa_tl
+        \c_backslash_str
+        { / }
       \tl_put_right:Nn
         \l_tmpa_tl
         {
@@ -25487,6 +25509,12 @@ end
 \cs_generate_variant:Nn
   \keys_define:nn
   { nV }
+\cs_generate_variant:Nn
+  \tl_replace_all:Nnn
+  { NVn }
+\cs_generate_variant:Nn
+  \tl_replace_all:Nnn
+  { NnV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -109,14 +109,14 @@
 
 % Set up the catcodes.
 \catcode`\_=12 % We won't be typesetting much math and Lua contains lots of `_`.
-\catcode`\^^B=8 % When we occasionally need subscripts , we will use `^^B` (STX).
+\catcode`\^^B=8 % When we occasionally need subscripts, we will use `^^B` (STX).
 
 % Set up the title page.
 \begin{markdown}
 ---
 title:    A Markdown Interpreter for \TeX
 url:      https://github.com/witiko/markdown
-author:   Vít Novotný
+authors:  [Vít Novotný]
 email:    witiko@mail.muni.cz
 revision: \markdownVersion
 date:     \markdownLastModified
@@ -821,7 +821,7 @@ abbr {
     },
   },
   jekyllDataRenderers = {
-    author = {%
+    /authors/* = {%
       \gdef\ltd@title@author{#1}%
       \hypersetup{pdfauthor={#1}}%
     },


### PR DESCRIPTION
Closes #199.

### Tasks

- [x] Implement and document the hotfix.
- [x] Use `/authors/*` in `markdown.dtx` to test that the fix has been successful,
- [x] Update `CHANGES.md`.