### PR TITLE
Add support for raw attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Development:
   - Rename the `HorizontalRule` rule to `ThematicBreak` and increment
     `grammar_version` to `2`. This change is not backwards-compatible with the
     `grammar_version` of `1`.
+- Add `\markdownEscape` macro that inputs a TeX document in the middle of a
+  markdown document fragment. (1478f7b)
 
 Fixes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Fixes:
 
 - Fix missing support for forward slashes in
   `\markdownSetup{jekyllDataRenderers = {...}}` keys. (#199, #200)
+- Fix `plain` LaTeX option not preventing changes to renderer prototypes.
+  (013abbb)
 
 Contributed Software:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Development:
     `grammar_version` of `1`.
 - Add `\markdownEscape` macro that inputs a TeX document in the middle of a
   markdown document fragment. (1478f7b)
+- Add support for raw attributes. (#173, #202)
 
 Fixes:
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,6 +16,7 @@ LUACLI_OPTIONS=\
   inlineNotes=true \
   notes=true \
   pipeTables=true \
+  rawAttribute=true \
   smartEllipses=true \
   strikeThrough=true \
   subscripts=true \

--- a/examples/context-mkii.tex
+++ b/examples/context-mkii.tex
@@ -18,6 +18,7 @@
     inlineNotes = yes,
     notes = yes,
     pipeTables = yes,
+    rawAttribute = yes,
     smartEllipses = yes,
     strikethrough = yes,
     subscripts = yes,

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -18,6 +18,7 @@
     inlineNotes = yes,
     notes = yes,
     pipeTables = yes,
+    rawAttribute = yes,
     smartEllipses = yes,
     strikethrough = yes,
     subscripts = yes,

--- a/examples/example.md
+++ b/examples/example.md
@@ -152,16 +152,22 @@ Here is a note reference[^1] and another.[^longnote]
 Here is an inline note.^[Inlines notes are easier to
 write, since you don't have to pick an identifier and
 move down to type the note.]
-  
+
 [^1]: Here is the note.
 
 [^longnote]: Here's one with multiple blocks.
-  
+
     Subsequent paragraphs are indented to show that they
 belong to the previous note.
-  
+
         Some code
 
     The whole paragraph can be indented, or just the first
     line.  In this way, multi-paragraph notes work like
     multi-paragraph list items.
+
+This is raw `\TeX`{=tex} code:
+
+``` {=tex}
+$$ x^n + y^n = z^n $$
+```

--- a/examples/latex.tex
+++ b/examples/latex.tex
@@ -26,6 +26,7 @@
   jekyllData,
   notes,
   pipeTables,
+  rawAttribute,
   smartEllipses,
   strikeThrough,
   subscripts,

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -10677,8 +10677,8 @@ following text, where the middot (`·`) denotes a non-breaking space:
 % \begin{markdown}
 
 #### Code Span Renderer
-The \mdef{markdownRendererCodeSpan} macro represents inlined code span in the
-input text. It receives a single argument that corresponds to the inlined
+The \mdef{markdownRendererCodeSpan} macro represents inline code span in the
+input text. It receives a single argument that corresponds to the inline
 code span.
 
 % \end{markdown}
@@ -15675,10 +15675,10 @@ following text:
 % \begin{markdown}
 
 #### Raw Content Renderers
-The \mdef{markdownRendererInputRawInline} macro represents an inlined raw span.
-The macro receives two arguments: the filename of a file contaning the inlined
+The \mdef{markdownRendererInputRawInline} macro represents an inline raw span.
+The macro receives two arguments: the filename of a file contaning the inline
 raw span contents and the raw attribute that designates the format of the
-inlined raw span. This macro will only be produced, when the \Opt{rawAttribute}
+inline raw span. This macro will only be produced, when the \Opt{rawAttribute}
 option is enabled.
 
 % \end{markdown}
@@ -20473,7 +20473,7 @@ function M.writer.new(options)
 % \begin{markdown}
 %
 % Define \luamdef{writer->code} as a function that will transform an input
-% inlined code span `s` to the output format.
+% inline code span `s` to the output format.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23708,7 +23708,7 @@ M.extensions.raw_attribute = function()
 % \begin{markdown}
 %
 % Define \luamdef{writer->rawInline} as a function that will transform an
-% input inlined raw span `s` with the raw attribute `i` to the output format.
+% input inline raw span `s` with the raw attribute `i` to the output format.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26923,6 +26923,34 @@ end
 % \par
 % \begin{markdown}
 %
+%#### Raw Attribute Renderer Prototypes
+%
+% In the raw block and inline raw span renderer prototypes, execute the content
+% with TeX when the raw attribute is `tex` or `latex`, display the content as
+% markdown when the raw attribute is `md`, and ignore the content otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset:Npn
+  \markdownRendererRawInlinePrototype#1#2
+  {
+    \str_case:nnF
+      { #2 }
+      {
+        { tex   } { \markdownEscape{#1} }
+        { latex } { \markdownEscape{#1} }
+        { md    } { \markdownInput{#1}  }
+      }
+  }
+\cs_gset_eq:NN
+  \markdownRendererRawBlockPrototype
+  \markdownRendererRawInlinePrototype
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 %### Miscellanea
 % When buffering user input, we should disable the bytes with the high bit set,
 % since these are made active by the \pkg{inputenc} package. We will do this by

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22944,7 +22944,8 @@ M.extensions.fenced_code = function(blank_before_code_fence)
         if not self.is_writing then return "" end
         s = string.gsub(s, '[\r\n%s]*$', '')
         local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
-        return {"\\markdownRendererInputFencedCode{",name,"}{",i,"}"}
+        return {"\\markdownRendererInputFencedCode{",
+                name,"}{",self.string(i),"}"}
       end
     end, extend_reader = function(self)
       local parsers = self.parsers
@@ -22955,7 +22956,7 @@ M.extensions.fenced_code = function(blank_before_code_fence)
                          / function(infostring, code)
                              local expanded_code = self.expandtabs(code)
                              return writer.fencedCode(expanded_code,
-                                                      writer.string(infostring))
+                                                      infostring)
                            end
 
       self.insert_pattern("Block after Verbatim",
@@ -23497,7 +23498,8 @@ M.extensions.raw_attribute = function()
           if not self.is_writing then return "" end
           s = string.gsub(s, '[\r\n%s]*$', '')
           local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
-          return {"\\markdownRendererInputRawBlock{",name,"}{",attr,"}"}
+          return {"\\markdownRendererInputRawBlock{",
+                  name,"}{", self.string(attr),"}"}
         end
       end
     end, extend_reader = function(self)
@@ -23525,11 +23527,10 @@ M.extensions.raw_attribute = function()
                              local expanded_code = self.expandtabs(code)
                              local attr = lpeg.match(raw_attribute, infostring)
                              if attr then
-                               return writer.rawBlock(expanded_code,
-                                                      writer.string(attr))
+                               return writer.rawBlock(expanded_code, attr)
                              else
                                return writer.fencedCode(expanded_code,
-                                                        writer.string(infostring))
+                                                        infostring)
                              end
                            end
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23470,8 +23470,8 @@ M.extensions.raw_attribute = function()
       -- luacheck: push ignore raw_attribute
       local raw_attribute = parsers.lbrace
                           * parsers.optionalspace
-                          * C(parsers.equal
-                             * parsers.attribute_key)
+                          * parsers.equal
+                          * C(parsers.attribute_key)
                           * parsers.optionalspace
                           * parsers.rbrace
       -- luacheck: pop

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23468,6 +23468,21 @@ M.extensions.raw_attribute = function()
     extend_writer = function(self)
       local options = self.options
 
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->rawInline} as a function that will transform an
+% input inlined raw span `s` with the raw attribute `i` to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.rawInline(s, attr)
+        return {"\\markdownRendererInputRawInline{",
+                self.escape_minimal(s),"}{",
+                self.string(attr),"}"}
+      end
+
       if options.fencedCode then
 %    \end{macrocode}
 % \par
@@ -23495,6 +23510,13 @@ M.extensions.raw_attribute = function()
                           * C(parsers.attribute_key)
                           * parsers.optionalspace
                           * parsers.rbrace
+
+      local RawInline = parsers.inticks
+                      * raw_attribute
+                      / writer.rawInline
+
+      self.insert_pattern("Inline before Code",
+                          RawInline, "RawInline")
 
       if options.fencedCode then
         local RawBlock = (parsers.TildeFencedCode

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21474,8 +21474,8 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
       if toplevel and (options.texComments or options.hybrid) then
-          str = lpeg.match(Ct(parsers.commented_line^1), str)
-          str = util.rope_to_string(str)
+        str = lpeg.match(Ct(parsers.commented_line^1), str)
+        str = util.rope_to_string(str)
       end
       local res = lpeg.match(grammar(), str)
       if res == nil then

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21272,20 +21272,20 @@ parsers.heading_attribute = (parsers.dash * Cc(".unnumbered"))
                           + Cs( parsers.attribute_key
                               * parsers.optionalspace * parsers.equal * parsers.optionalspace
                               * parsers.attribute_value)
-parsers.HeadingAttributes = parsers.lbrace
-                          * parsers.optionalspace
-                          * parsers.heading_attribute
-                          * (parsers.spacechar^1
-                            * parsers.heading_attribute)^0
-                          * parsers.optionalspace
-                          * parsers.rbrace
+parsers.heading_attributes = parsers.lbrace
+                           * parsers.optionalspace
+                           * parsers.heading_attribute
+                           * (parsers.spacechar^1
+                             * parsers.heading_attribute)^0
+                           * parsers.optionalspace
+                           * parsers.rbrace
 
 -- parse Atx heading start and return level
-parsers.HeadingStart = #parsers.hash * C(parsers.hash^-6)
-                     * -parsers.hash / length
+parsers.heading_start = #parsers.hash * C(parsers.hash^-6)
+                      * -parsers.hash / length
 
 -- parse setext header ending and return level
-parsers.HeadingLevel = parsers.equal^1 * Cc(1) + parsers.dash^1 * Cc(2)
+parsers.heading_level = parsers.equal^1 * Cc(1) + parsers.dash^1 * Cc(2)
 
 local function strip_atx_end(s)
   return s:gsub("[#%s]*\n$","")
@@ -21940,7 +21940,7 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   -- parse atx header
-  parsers.AtxHeading = Cg(parsers.HeadingStart,"level")
+  parsers.AtxHeading = Cg(parsers.heading_start, "level")
                      * parsers.optionalspace
                      * (C(parsers.line)
                        / strip_atx_end
@@ -21952,7 +21952,7 @@ function M.reader.new(writer, options)
                         * Ct(parsers.linechar^1
                             / self.parser_functions.parse_inlines)
                         * parsers.newline
-                        * parsers.HeadingLevel
+                        * parsers.heading_level
                         * parsers.optionalspace
                         * parsers.newline
                         / writer.heading
@@ -23127,13 +23127,13 @@ M.extensions.header_attributes = function()
       local parsers = self.parsers
       local writer = self.writer
 
-      parsers.AtxHeading = Cg(parsers.HeadingStart,"level")
+      parsers.AtxHeading = Cg(parsers.heading_start, "level")
                          * parsers.optionalspace
                          * (C(((parsers.linechar
                                - ((parsers.hash^1
                                   * parsers.optionalspace
-                                  * parsers.HeadingAttributes^-1
-                                  + parsers.HeadingAttributes)
+                                  * parsers.heading_attributes^-1
+                                  + parsers.heading_attributes)
                                  * parsers.optionalspace
                                  * parsers.newline))
                               * (parsers.linechar
@@ -23143,8 +23143,8 @@ M.extensions.header_attributes = function()
                          * Cg(Ct(parsers.newline
                                 + (parsers.hash^1
                                   * parsers.optionalspace
-                                  * parsers.HeadingAttributes^-1
-                                  + parsers.HeadingAttributes)
+                                  * parsers.heading_attributes^-1
+                                  + parsers.heading_attributes)
                                 * parsers.optionalspace
                                 * parsers.newline), "attributes")
                          * Cb("level")
@@ -23153,17 +23153,17 @@ M.extensions.header_attributes = function()
 
       parsers.SetextHeading = #(parsers.line * S("=-"))
                             * (C(((parsers.linechar
-                                  - (parsers.HeadingAttributes
+                                  - (parsers.heading_attributes
                                     * parsers.optionalspace
                                     * parsers.newline))
                                  * (parsers.linechar
                                    - parsers.lbrace)^0)^1)
                                 / self.parser_functions.parse_inlines)
                             * Cg(Ct(parsers.newline
-                                   + (parsers.HeadingAttributes
+                                   + (parsers.heading_attributes
                                      * parsers.optionalspace
                                      * parsers.newline)), "attributes")
-                            * parsers.HeadingLevel
+                            * parsers.heading_level
                             * Cb("attributes")
                             * parsers.optionalspace
                             * parsers.newline

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -8955,8 +8955,8 @@ pdftex --shell-escape document.tex
 %
 %### Typesetting Markdown {#textypesetting}
 %
-% The interface exposes the \mdef{markdownBegin}, \mdef{markdownEnd}, and
-% \mdef{markdownInput} macros.
+% The interface exposes the \mdef{markdownBegin}, \mdef{markdownEnd},
+% \mdef{markdownInput}, and \mdef{markdownEscape} macros.
 %
 % The \mref{markdownBegin} macro marks the beginning of a markdown document
 % fragment and the \mref{markdownEnd} macro marks its end.
@@ -9014,9 +9014,9 @@ pdftex --shell-escape document.tex
 % \bye
 % ```````
 %
-% The \mref{markdownInput} macro accepts a single parameter containing the
-% filename of a markdown document and expands to the result of the conversion
-% of the input markdown document to plain \TeX{}.
+% The \mref{markdownInput} macro accepts a single parameter with the filename
+% of a markdown document and expands to the result of the conversion of the
+% input markdown document to plain \TeX{}.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -9036,6 +9036,19 @@ pdftex --shell-escape document.tex
 % \markdownInput{hello.md}
 % \bye
 % ```````
+%
+% The \mref{markdownEscape} macro accepts a single parameter with the filename
+% of a \TeX{} document and executes the \TeX{} document in the middle of a
+% markdown document fragment. Unlike the `\input` built-in of \TeX,
+% \mref{markdownEscape} guarantees that the standard catcode regime of your
+% \TeX{} format will be used.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\let\markdownEscape\relax
+%    \end{macrocode}
+% \par
+% \begin{markdown}
 %
 %### Options {#texoptions}
 %
@@ -25206,6 +25219,22 @@ end
   }%
 |endgroup
 %    \end{macrocode}
+% \par
+% \begin{markdown}
+% The \mref{markdownEscape} macro resets the category codes of the percent sign
+% and the hash sign back to comment and parameter, respectively, before using
+% the `\input` built-in of \TeX{} to execute a \TeX{} document in the middle of
+% a markdown document fragment.
+% \end{markdown}
+%  \begin{macrocode}
+\gdef\markdownEscape#1{%
+  \catcode`\%=14\relax
+  \catcode`\#=6\relax
+  \input #1\relax
+  \catcode`\%=12\relax
+  \catcode`\#=12\relax
+}%
+%    \end{macrocode}
 % \iffalse
 %</tex>
 %<*latex>
@@ -25940,11 +25969,7 @@ end
       \end{table}%
     }{%
       \ifthenelse{\equal{#1}{tex}}{%
-        \catcode`\%=14\relax
-        \catcode`\#=6\relax
-        \input #3\relax
-        \catcode`\%=12\relax
-        \catcode`\#=12\relax
+        \markdownEscape{#3}%
       }{%
         \markdownInput{#3}%
       }%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23908,6 +23908,11 @@ function M.new(options)
     table.insert(extensions, pipe_tables_extension)
   end
 
+  if options.rawAttribute then
+    local raw_attribute_extension = M.extensions.raw_attribute()
+    table.insert(extensions, raw_attribute_extension)
+  end
+
   if options.strikeThrough then
     local strike_through_extension = M.extensions.strike_through()
     table.insert(extensions, strike_through_extension)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23500,7 +23500,7 @@ end
 %#### Raw Attributes
 %
 % The \luamdef{extensions.raw_attribute} function implements the Pandoc
-% raw attributes syntax extension.
+% raw attribute syntax extension.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23510,7 +23510,14 @@ M.extensions.raw_attribute = function()
     extend_writer = function()
       -- TODO
     end, extend_reader = function()
-      -- TODO
+      -- luacheck: push ignore raw_attribute
+      local raw_attribute = parsers.lbrace
+                          * parsers.optionalspace
+                          * C(parsers.equal
+                             * parsers.attribute_key)
+                          * parsers.optionalspace
+                          * parsers.rbrace
+      -- luacheck: pop
     end
   }
 end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24527,7 +24527,7 @@ end
 \cs_gset:Npn
   \markdownRendererInputRawInlinePrototype#1#2
   {
-    \str_case:nnF
+    \str_case:nn
       { #2 }
       {
         { tex } { \markdownEscape{#1} }
@@ -26934,7 +26934,7 @@ end
 \cs_gset:Npn
   \markdownRendererInputRawInlinePrototype#1#2
   {
-    \str_case:nnF
+    \str_case:nn
       { #2 }
       {
         { tex   } { \markdownEscape{#1} }
@@ -27297,7 +27297,7 @@ end
 \cs_gset:Npn
   \markdownRendererInputRawInlinePrototype#1#2
   {
-    \str_case:nnF
+    \str_case:nn
       { #2 }
       {
         { tex     } { \markdownEscape{#1} }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24515,6 +24515,33 @@ end
 % \par
 % \begin{markdown}
 %
+%#### Raw Attribute Renderer Prototypes
+%
+% In the raw block and inline raw span renderer prototypes, execute the content
+% with TeX when the raw attribute is `tex`, display the content as markdown when
+% the raw attribute is `md`, and ignore the content otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset:Npn
+  \markdownRendererRawInlinePrototype#1#2
+  {
+    \str_case:nnF
+      { #2 }
+      {
+        { tex } { \markdownEscape{#1} }
+        { md  } { \markdownInput{#1}  }
+      }
+  }
+\cs_gset_eq:NN
+  \markdownRendererRawBlockPrototype
+  \markdownRendererRawInlinePrototype
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 %#### YAML Metadata Renderer Prototypes {#expl3yamlmetadataimplementation}
 %
 % To keep track of the current type of structure we inhabit when we are

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23464,17 +23464,54 @@ end
 M.extensions.raw_attribute = function()
   return {
     name = "built-in raw_attribute syntax extension",
-    extend_writer = function()
-      -- TODO
-    end, extend_reader = function()
-      -- luacheck: push ignore raw_attribute
+    extend_writer = function(self)
+      local options = self.options
+
+      if options.fencedCode then
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->rawBlock} as a function that will transform an
+% input raw block `s` with the raw attribute `i` to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        function self.rawBlock(attr, s)
+          if not self.is_writing then return "" end
+          s = string.gsub(s, '[\r\n%s]*$', '')
+          local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
+          return {"\\markdownRendererInputRawBlock{",name,"}{",attr,"}"}
+        end
+      end
+    end, extend_reader = function(self)
+      local options = self.options
+      local writer = self.writer
+
       local raw_attribute = parsers.lbrace
                           * parsers.optionalspace
                           * parsers.equal
                           * C(parsers.attribute_key)
                           * parsers.optionalspace
                           * parsers.rbrace
-      -- luacheck: pop
+
+      if options.fencedCode then
+        local RawBlock = (parsers.TildeFencedCode
+                           + parsers.BacktickFencedCode)
+                         / function(infostring, code)
+                             local attr = lpeg.match(raw_attribute, infostring)
+                             if attr then
+                               return writer.rawBlock(writer.string(attr),
+                                                      self.expandtabs(code))
+                             else
+                               return writer.fencedCode(writer.string(infostring),
+                                                        self.expandtabs(code))
+                             end
+                           end
+
+        self.insert_pattern("Block after Verbatim",
+                            RawBlock, "RawBlock")
+      end
     end
   }
 end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -17600,6 +17600,21 @@ end
 % \par
 % \begin{markdown}
 %
+% The \luamdef{util.cache_verbatim} method strips whitespaces from the
+% end of `string` and calls \luamref{util.cache} with `dir`, `string`,
+% no salt or transformations, and the `.verbatim` suffix.
+%
+% \end{markdown}
+%  \begin{macrocode}
+function util.cache_verbatim(dir, string)
+  string = string:gsub('[\r\n%s]*$', '')
+  local name = util.cache(dir, string, nil, nil, ".verbatim")
+  return name
+end
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 % The \luamdef{util.table_copy} method creates a shallow copy of a table `t`
 % and its metatable.
 %
@@ -20501,8 +20516,7 @@ function M.writer.new(options)
 %  \begin{macrocode}
   function self.verbatim(s)
     if not self.is_writing then return "" end
-    s = string.gsub(s, '[\r\n%s]*$', '')
-    local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
+    local name = util.cache_verbatim(options.cacheDir, s)
     return {"\\markdownRendererInputVerbatim{",name,"}"}
   end
 %    \end{macrocode}
@@ -22955,8 +22969,7 @@ M.extensions.fenced_code = function(blank_before_code_fence)
 %  \begin{macrocode}
       function self.fencedCode(s, i)
         if not self.is_writing then return "" end
-        s = string.gsub(s, '[\r\n%s]*$', '')
-        local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
+        local name = util.cache_verbatim(options.cacheDir, s)
         return {"\\markdownRendererInputFencedCode{",
                 name,"}{",self.string(i),"}"}
       end
@@ -23493,8 +23506,7 @@ M.extensions.raw_attribute = function()
 %  \begin{macrocode}
       function self.rawInline(s, attr)
         if not self.is_writing then return "" end
-        s = string.gsub(s, '[\r\n%s]*$', '')
-        local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
+        local name = util.cache_verbatim(options.cacheDir, s)
         return {"\\markdownRendererInputRawInline{",
                 name,"}{", self.string(attr),"}"}
       end
@@ -23511,8 +23523,7 @@ M.extensions.raw_attribute = function()
 %  \begin{macrocode}
         function self.rawBlock(s, attr)
           if not self.is_writing then return "" end
-          s = string.gsub(s, '[\r\n%s]*$', '')
-          local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
+          local name = util.cache_verbatim(options.cacheDir, s)
           return {"\\markdownRendererInputRawBlock{",
                   name,"}{", self.string(attr),"}"}
         end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22940,7 +22940,7 @@ M.extensions.fenced_code = function(blank_before_code_fence)
 %
 % \end{markdown}
 %  \begin{macrocode}
-      function self.fencedCode(i, s)
+      function self.fencedCode(s, i)
         if not self.is_writing then return "" end
         s = string.gsub(s, '[\r\n%s]*$', '')
         local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
@@ -22953,8 +22953,9 @@ M.extensions.fenced_code = function(blank_before_code_fence)
       local FencedCode = (parsers.TildeFencedCode
                            + parsers.BacktickFencedCode)
                          / function(infostring, code)
-                             return writer.fencedCode(writer.string(infostring),
-                                                      self.expandtabs(code))
+                             local expanded_code = self.expandtabs(code)
+                             return writer.fencedCode(expanded_code,
+                                                      writer.string(infostring))
                            end
 
       self.insert_pattern("Block after Verbatim",
@@ -23477,7 +23478,7 @@ M.extensions.raw_attribute = function()
 %
 % \end{markdown}
 %  \begin{macrocode}
-        function self.rawBlock(attr, s)
+        function self.rawBlock(s, attr)
           if not self.is_writing then return "" end
           s = string.gsub(s, '[\r\n%s]*$', '')
           local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
@@ -23499,13 +23500,14 @@ M.extensions.raw_attribute = function()
         local RawBlock = (parsers.TildeFencedCode
                            + parsers.BacktickFencedCode)
                          / function(infostring, code)
+                             local expanded_code = self.expandtabs(code)
                              local attr = lpeg.match(raw_attribute, infostring)
                              if attr then
-                               return writer.rawBlock(writer.string(attr),
-                                                      self.expandtabs(code))
+                               return writer.rawBlock(expanded_code,
+                                                      writer.string(attr))
                              else
-                               return writer.fencedCode(writer.string(infostring),
-                                                        self.expandtabs(code))
+                               return writer.fencedCode(expanded_code,
+                                                        writer.string(infostring))
                              end
                            end
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24525,7 +24525,7 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \cs_gset:Npn
-  \markdownRendererRawInlinePrototype#1#2
+  \markdownRendererInputRawInlinePrototype#1#2
   {
     \str_case:nnF
       { #2 }
@@ -24535,8 +24535,8 @@ end
       }
   }
 \cs_gset_eq:NN
-  \markdownRendererRawBlockPrototype
-  \markdownRendererRawInlinePrototype
+  \markdownRendererInputRawBlockPrototype
+  \markdownRendererInputRawInlinePrototype
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par
@@ -26932,7 +26932,7 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \cs_gset:Npn
-  \markdownRendererRawInlinePrototype#1#2
+  \markdownRendererInputRawInlinePrototype#1#2
   {
     \str_case:nnF
       { #2 }
@@ -26943,8 +26943,8 @@ end
       }
   }
 \cs_gset_eq:NN
-  \markdownRendererRawBlockPrototype
-  \markdownRendererRawInlinePrototype
+  \markdownRendererInputRawBlockPrototype
+  \markdownRendererInputRawInlinePrototype
 \ExplSyntaxOff
 \fi % Closes `\markdownIfOption{Plain}{\iffalse}{iftrue}`
 %    \end{macrocode}
@@ -27295,7 +27295,7 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \cs_gset:Npn
-  \markdownRendererRawInlinePrototype#1#2
+  \markdownRendererInputRawInlinePrototype#1#2
   {
     \str_case:nnF
       { #2 }
@@ -27306,8 +27306,8 @@ end
       }
   }
 \cs_gset_eq:NN
-  \markdownRendererRawBlockPrototype
-  \markdownRendererRawInlinePrototype
+  \markdownRendererInputRawBlockPrototype
+  \markdownRendererInputRawInlinePrototype
 \ExplSyntaxOff
 \stopmodule\protect
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26843,7 +26843,6 @@ end
     \addto@hook\markdownLaTeXTable{#1\\}%
     \expandafter\@gobble
   \fi\markdownLaTeXRenderTableCell}
-\fi
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -26947,6 +26946,7 @@ end
   \markdownRendererRawBlockPrototype
   \markdownRendererRawInlinePrototype
 \ExplSyntaxOff
+\fi % Closes `\markdownIfOption{Plain}{\iffalse}{iftrue}`
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1220,7 +1220,7 @@ local md5 = require("md5")
 %
 %:    A package that provides a concise syntax for the inspection of macro
 %     values. It is used in the `witiko/dot` \LaTeX{} theme (see Section
-%     <#sec:latexthemes>), and to provide default token renderer prototypes.
+%     <#sec:latexthemes>).
 %
 % \pkg{fancyvrb}
 %
@@ -26118,7 +26118,7 @@ end
     dlEndTight = {\markdownRendererDlEnd}}}
 }
 \ExplSyntaxOff
-\RequirePackage{amsmath,ifthen}
+\RequirePackage{amsmath}
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -26175,25 +26175,33 @@ end
     \else
       \texttt{#1}%
     \fi
+  }}}
+\ExplSyntaxOn
+\markdownSetup{
+  rendererPrototypes = {
+    contentBlock = {
+      \str_case:nnF
+        { #1 }
+        {
+          { csv }
+            {
+              \begin{table}
+                \begin{center}
+                  \csvautotabular{#3}
+                \end{center}
+                \tl_if_empty:nF
+                  { #4 }
+                  { \caption{#4} }
+              \end{table}
+            }
+          { tex } { \markdownEscape{#3} }
+        }
+        { \markdownInput{#3} }
+    },
   },
-  contentBlock = {%
-    \ifthenelse{\equal{#1}{csv}}{%
-      \begin{table}%
-        \begin{center}%
-          \csvautotabular{#3}%
-        \end{center}
-        \ifx\empty#4\empty\else
-          \caption{#4}%
-        \fi
-      \end{table}%
-    }{%
-      \ifthenelse{\equal{#1}{tex}}{%
-        \markdownEscape{#3}%
-      }{%
-        \markdownInput{#3}%
-      }%
-    }%
-  },
+}
+\ExplSyntaxOff
+\markdownSetup{rendererPrototypes={
   image = {%
     \begin{figure}%
       \begin{center}%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -6812,6 +6812,97 @@ defaultOptions.preserveTabs = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `rawAttribute`
+
+`rawAttribute` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{rawAttribute}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc raw attribute syntax extension:
+
+        ``` md
+        `$H_2 O$`{=tex} is a liquid.
+        ```
+
+        To enable raw blocks, the \Opt{fencedCode} option must also be enabled:
+
+        ~~~~~~~~ md
+        Here is a mathematical formula:
+        ``` {=tex}
+        \[distance[i] =
+            \begin{dcases}
+                a & b \\
+                c & d
+            \end{dcases}
+        \]
+        ```
+        ~~~~~~~~~~~
+
+        The \Opt{rawAttribute} option is a good alternative to the \Opt{hybrid}
+        option. Unlike the \Opt{hybrid} option, which affects the entire
+        document, the \Opt{rawAttribute} option allows you to isolate the parts
+        of your documents that use TeX:
+
+:    false
+
+     :  Disable the Pandoc raw attribute syntax extension.
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+~~~~~~~~ tex
+\documentclass{article}
+\usepackage[rawAttribute, fencedCode]{markdown}
+\usepackage{expl3}
+\begin{document}
+\begin{markdown}
+`$H_2 O$`{=tex} is a liquid.
+
+``` {=html}
+<p>Here is some HTML content that will be ignored.</p>
+```````````
+\end{markdown}
+\end{document}
+~~~~~~~~~~~
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> H~2~O is a liquid.
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { rawAttribute }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.rawAttribute = true
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `relativeReferences`
 
 `relativeReferences` (default value: `false`)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -15573,6 +15573,123 @@ following text:
   \g_@@_renderer_arities_prop
   { subscript }
   { 1 }
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Raw Content Renderers
+The \mdef{markdownRendererInputRawInline} macro represents an inlined raw span.
+The macro receives two arguments: the filename of a file contaning the inlined
+raw span contents and the raw attribute that designates the format of the
+inlined raw span. This macro will only be produced, when the \Opt{rawAttribute}
+option is enabled.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInputRawInline{%
+  \markdownRendererInputRawInlinePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inputRawInline }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inputRawInline }
+  { 2 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererInputRawBlock} macro represents a raw block. The
+macro receives two arguments: the filename of a file contaning the raw block
+and the raw attribute that designates the format of the raw block. This macro
+will only be produced, when the \Opt{rawAttribute} and \Opt{fencedCode} options
+are enabled.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+~~~~~~~~ tex
+\documentclass{article}
+\usepackage[rawAttribute, fencedCode]{markdown}
+\usepackage{expl3}
+\ExplSyntaxOn
+\cs_new:Nn
+  \display_raw_content:nn
+  {
+    % If the raw attribute is TeX, execute the content as a TeX document.
+    \str_if_eq:nnTF
+      { #2 }
+      { tex }
+      { \markdownEscape { #1 } }
+      % Otherwise, ignore the content.
+      { }
+  }
+\markdownSetup{
+  renderers = {
+    rawInline = { \display_raw_content:nn { #1 } { #2 } },
+    rawBlock  = { \display_raw_content:nn { #1 } { #2 } }
+  },
+}
+\ExplSyntaxOff
+\begin{document}
+\begin{markdown}
+`$H_2 O$`{=tex} is a liquid.
+
+``` {=html}
+<p>Here is some HTML content that will be ignored.</p>
+```````````
+\end{markdown}
+\end{document}
+~~~~~~~~~~~
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> H~2~O is a liquid.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInputRawBlock{%
+  \markdownRendererInputRawBlockPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inputRawBlock }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inputRawBlock }
+  { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20997,8 +20997,8 @@ local function captures_geq_length(_,i,a,b)
   return #a >= #b and i
 end
 
-parsers.infostring     = (parsers.linechar - (parsers.backtick
-                       + parsers.space^1 * (parsers.newline + parsers.eof)))^0
+parsers.infostring   = (parsers.linechar - (parsers.backtick
+                     + parsers.space^1 * (parsers.newline + parsers.eof)))^0
 
 local fenceindent
 parsers.fencehead    = function(char)
@@ -21267,6 +21267,16 @@ parsers.urlchar      = parsers.anyescaped - parsers.newline - parsers.more
 %
 % \end{markdown}
 %  \begin{macrocode}
+parsers.TildeFencedCode
+       = parsers.fencehead(parsers.tilde)
+       * Cs(parsers.fencedline(parsers.tilde)^0)
+       * parsers.fencetail(parsers.tilde)
+
+parsers.BacktickFencedCode
+       = parsers.fencehead(parsers.backtick)
+       * Cs(parsers.fencedline(parsers.backtick)^0)
+       * parsers.fencetail(parsers.backtick)
+
 parsers.lineof = function(c)
     return (parsers.leader * (P(c) * parsers.optionalspace)^3
            * (parsers.newline * parsers.blankline^1
@@ -22940,61 +22950,8 @@ M.extensions.fenced_code = function(blank_before_code_fence)
       local parsers = self.parsers
       local writer = self.writer
 
-      local function captures_geq_length(_,i,a,b)
-        return #a >= #b and i
-      end
-
-      local infostring   = (parsers.linechar - (parsers.backtick
-                         + parsers.space^1 * (parsers.newline + parsers.eof)))^0
-
-      local fenceindent
-      local fencehead    = function(char)
-        return             C(parsers.nonindentspace) / function(s) fenceindent = #s end
-                         * Cg(char^3, "fencelength")
-                         * parsers.optionalspace * C(infostring)
-                         * parsers.optionalspace * (parsers.newline + parsers.eof)
-      end
-
-      local fencetail    = function(char)
-        return             parsers.nonindentspace
-                         * Cmt(C(char^3) * Cb("fencelength"), captures_geq_length)
-                         * parsers.optionalspace * (parsers.newline + parsers.eof)
-                         + parsers.eof
-      end
-
-      local fencedline   = function(char)
-        return             C(parsers.line - fencetail(char))
-                         / function(s)
-                             local i = 1
-                             local remaining = fenceindent
-                             while true do
-                               local c = s:sub(i, i)
-                               if c == " " and remaining > 0 then
-                                 remaining = remaining - 1
-                                 i = i + 1
-                               elseif c == "\t" and remaining > 3 then
-                                 remaining = remaining - 4
-                                 i = i + 1
-                               else
-                                 break
-                               end
-                             end
-                             return s:sub(i)
-                           end
-      end
-
-      local TildeFencedCode
-             = fencehead(parsers.tilde)
-             * Cs(fencedline(parsers.tilde)^0)
-             * fencetail(parsers.tilde)
-
-      local BacktickFencedCode
-             = fencehead(parsers.backtick)
-             * Cs(fencedline(parsers.backtick)^0)
-             * fencetail(parsers.backtick)
-
-      local FencedCode = (TildeFencedCode
-                           + BacktickFencedCode)
+      local FencedCode = (parsers.TildeFencedCode
+                           + parsers.BacktickFencedCode)
                          / function(infostring, code)
                              return writer.fencedCode(writer.string(infostring),
                                                       self.expandtabs(code))
@@ -23007,8 +22964,8 @@ M.extensions.fenced_code = function(blank_before_code_fence)
       if blank_before_code_fence then
         fencestart = parsers.fail
       else
-        fencestart = fencehead(parsers.backtick)
-                   + fencehead(parsers.tilde)
+        fencestart = parsers.fencehead(parsers.backtick)
+                   + parsers.fencehead(parsers.tilde)
       end
 
       local EndlineExceptions = parsers.EndlineExceptions + fencestart

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23497,6 +23497,26 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
+%#### Raw Attributes
+%
+% The \luamdef{extensions.raw_attribute} function implements the Pandoc
+% raw attributes syntax extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.raw_attribute = function()
+  return {
+    name = "built-in raw_attribute syntax extension",
+    extend_writer = function()
+      -- TODO
+    end, extend_reader = function()
+      -- TODO
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
 %#### Strike-Through
 %
 % The \luamdef{extensions.strike_through} function implements the Pandoc

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27253,6 +27253,34 @@ end
   \ifnum\markdownConTeXtColumnCounter<\markdownConTeXtColumnTotal\relax\else
     \expandafter\gobbleoneargument
   \fi\markdownConTeXtRenderTableCell}
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+%#### Raw Attribute Renderer Prototypes
+%
+% In the raw block and inline raw span renderer prototypes, execute the content
+% with TeX when the raw attribute is `tex` or `context`, display the content as
+% markdown when the raw attribute is `md`, and ignore the content otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset:Npn
+  \markdownRendererRawInlinePrototype#1#2
+  {
+    \str_case:nnF
+      { #2 }
+      {
+        { tex     } { \markdownEscape{#1} }
+        { context } { \markdownEscape{#1} }
+        { md      } { \markdownInput{#1}  }
+      }
+  }
+\cs_gset_eq:NN
+  \markdownRendererRawBlockPrototype
+  \markdownRendererRawInlinePrototype
+\ExplSyntaxOff
 \stopmodule\protect
 %    \end{macrocode}
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20909,6 +20909,20 @@ parsers.attribute_value        = ( (parsers.dquote / "")
                                + ( parsers.anyescaped - parsers.dquote - parsers.rbrace
                                  - parsers.space)^0
 
+parsers.attribute = (parsers.dash * Cc(".unnumbered"))
+                  + C((parsers.hash + parsers.period)
+                     * parsers.attribute_key)
+                  + Cs( parsers.attribute_key
+                      * parsers.optionalspace * parsers.equal * parsers.optionalspace
+                      * parsers.attribute_value)
+parsers.attributes = parsers.lbrace
+                   * parsers.optionalspace
+                   * parsers.attribute
+                   * (parsers.spacechar^1
+                     * parsers.attribute)^0
+                   * parsers.optionalspace
+                   * parsers.rbrace
+
 -- block followed by 0 or more optionally
 -- indented blocks with first line indented.
 parsers.indented_blocks = function(bl)
@@ -21266,20 +21280,6 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-parsers.heading_attribute = (parsers.dash * Cc(".unnumbered"))
-                          + C((parsers.hash + parsers.period)
-                             * parsers.attribute_key)
-                          + Cs( parsers.attribute_key
-                              * parsers.optionalspace * parsers.equal * parsers.optionalspace
-                              * parsers.attribute_value)
-parsers.heading_attributes = parsers.lbrace
-                           * parsers.optionalspace
-                           * parsers.heading_attribute
-                           * (parsers.spacechar^1
-                             * parsers.heading_attribute)^0
-                           * parsers.optionalspace
-                           * parsers.rbrace
-
 -- parse Atx heading start and return level
 parsers.heading_start = #parsers.hash * C(parsers.hash^-6)
                       * -parsers.hash / length
@@ -23132,8 +23132,8 @@ M.extensions.header_attributes = function()
                        * (C(((parsers.linechar
                              - ((parsers.hash^1
                                 * parsers.optionalspace
-                                * parsers.heading_attributes^-1
-                                + parsers.heading_attributes)
+                                * parsers.attributes^-1
+                                + parsers.attributes)
                                * parsers.optionalspace
                                * parsers.newline))
                             * (parsers.linechar
@@ -23143,8 +23143,8 @@ M.extensions.header_attributes = function()
                        * Cg(Ct(parsers.newline
                               + (parsers.hash^1
                                 * parsers.optionalspace
-                                * parsers.heading_attributes^-1
-                                + parsers.heading_attributes)
+                                * parsers.attributes^-1
+                                + parsers.attributes)
                               * parsers.optionalspace
                               * parsers.newline), "attributes")
                        * Cb("level")
@@ -23153,14 +23153,14 @@ M.extensions.header_attributes = function()
 
       local SetextHeading = #(parsers.line * S("=-"))
                           * (C(((parsers.linechar
-                                - (parsers.heading_attributes
+                                - (parsers.attributes
                                   * parsers.optionalspace
                                   * parsers.newline))
                                * (parsers.linechar
                                  - parsers.lbrace)^0)^1)
                               / self.parser_functions.parse_inlines)
                           * Cg(Ct(parsers.newline
-                                 + (parsers.heading_attributes
+                                 + (parsers.attributes
                                    * parsers.optionalspace
                                    * parsers.newline)), "attributes")
                           * parsers.heading_level

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23479,9 +23479,11 @@ M.extensions.raw_attribute = function()
 % \end{markdown}
 %  \begin{macrocode}
       function self.rawInline(s, attr)
+        if not self.is_writing then return "" end
+        s = string.gsub(s, '[\r\n%s]*$', '')
+        local name = util.cache(options.cacheDir, s, nil, nil, ".verbatim")
         return {"\\markdownRendererInputRawInline{",
-                self.escape_minimal(s),"}{",
-                self.string(attr),"}"}
+                name,"}{", self.string(attr),"}"}
       end
 
       if options.fencedCode then

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23127,49 +23127,49 @@ M.extensions.header_attributes = function()
       local parsers = self.parsers
       local writer = self.writer
 
-      parsers.AtxHeading = Cg(parsers.heading_start, "level")
-                         * parsers.optionalspace
-                         * (C(((parsers.linechar
-                               - ((parsers.hash^1
-                                  * parsers.optionalspace
-                                  * parsers.heading_attributes^-1
-                                  + parsers.heading_attributes)
-                                 * parsers.optionalspace
-                                 * parsers.newline))
-                              * (parsers.linechar
-                                - parsers.hash
-                                - parsers.lbrace)^0)^1)
-                             / self.parser_functions.parse_inlines)
-                         * Cg(Ct(parsers.newline
-                                + (parsers.hash^1
-                                  * parsers.optionalspace
-                                  * parsers.heading_attributes^-1
-                                  + parsers.heading_attributes)
+      local AtxHeading = Cg(parsers.heading_start, "level")
+                       * parsers.optionalspace
+                       * (C(((parsers.linechar
+                             - ((parsers.hash^1
                                 * parsers.optionalspace
-                                * parsers.newline), "attributes")
-                         * Cb("level")
-                         * Cb("attributes")
-                         / writer.heading
+                                * parsers.heading_attributes^-1
+                                + parsers.heading_attributes)
+                               * parsers.optionalspace
+                               * parsers.newline))
+                            * (parsers.linechar
+                              - parsers.hash
+                              - parsers.lbrace)^0)^1)
+                           / self.parser_functions.parse_inlines)
+                       * Cg(Ct(parsers.newline
+                              + (parsers.hash^1
+                                * parsers.optionalspace
+                                * parsers.heading_attributes^-1
+                                + parsers.heading_attributes)
+                              * parsers.optionalspace
+                              * parsers.newline), "attributes")
+                       * Cb("level")
+                       * Cb("attributes")
+                       / writer.heading
 
-      parsers.SetextHeading = #(parsers.line * S("=-"))
-                            * (C(((parsers.linechar
-                                  - (parsers.heading_attributes
-                                    * parsers.optionalspace
-                                    * parsers.newline))
-                                 * (parsers.linechar
-                                   - parsers.lbrace)^0)^1)
-                                / self.parser_functions.parse_inlines)
-                            * Cg(Ct(parsers.newline
-                                   + (parsers.heading_attributes
-                                     * parsers.optionalspace
-                                     * parsers.newline)), "attributes")
-                            * parsers.heading_level
-                            * Cb("attributes")
-                            * parsers.optionalspace
-                            * parsers.newline
-                            / writer.heading
+      local SetextHeading = #(parsers.line * S("=-"))
+                          * (C(((parsers.linechar
+                                - (parsers.heading_attributes
+                                  * parsers.optionalspace
+                                  * parsers.newline))
+                               * (parsers.linechar
+                                 - parsers.lbrace)^0)^1)
+                              / self.parser_functions.parse_inlines)
+                          * Cg(Ct(parsers.newline
+                                 + (parsers.heading_attributes
+                                   * parsers.optionalspace
+                                   * parsers.newline)), "attributes")
+                          * parsers.heading_level
+                          * Cb("attributes")
+                          * parsers.optionalspace
+                          * parsers.newline
+                          / writer.heading
 
-      local Heading = parsers.AtxHeading + parsers.SetextHeading
+      local Heading = AtxHeading + SetextHeading
       self.update_rule("Heading", Heading)
     end
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -15506,7 +15506,7 @@ luatex document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> H (2 moles) and O is liquid.
+> H (2 moles) and O is a liquid.
 
 ##### \LaTeX{} Example {.unnumbered}
 
@@ -15533,7 +15533,7 @@ lualatex document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> H (2 moles) and O is liquid.
+> H (2 moles) and O is a liquid.
 
 ##### \Hologo{ConTeXt} Example {.unnumbered}
 
@@ -15556,7 +15556,7 @@ context document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> H (2 moles) and O is liquid.
+> H (2 moles) and O is a liquid.
 
 %</manual-tokens>
 %<*tex>

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -254,5 +254,15 @@
       \TYPE{superscript:           #1}},
     subscript = {%
       \TYPE{subscript:             #1}},
+    inputRawInline = {%
+      \TYPE{BEGIN rawInline}%
+      \TYPE{- src:                 #1}%
+      \TYPE{- raw attribute:       #2}%
+      \TYPE{END rawInline}},
+    inputRawBlock = {%
+      \TYPE{BEGIN rawBlock}%
+      \TYPE{- src:                 #1}%
+      \TYPE{- raw attribute:       #2}%
+      \TYPE{END rawBlock}},
   }%
 }%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -236,3 +236,13 @@
   \TYPE{superscript:           #1}}%
 \def\markdownRendererSubscript#1{%
   \TYPE{subscript:             #1}}%
+\def\markdownRendererInputRawInline#1#2{%
+  \TYPE{BEGIN rawInline}%
+  \TYPE{- src:                 #1}%
+  \TYPE{- raw attribute:       #2}%
+  \TYPE{END rawInline}}%
+\def\markdownRendererInputRawBlock#1#2{%
+  \TYPE{BEGIN rawBlock}%
+  \TYPE{- src:                 #1}%
+  \TYPE{- raw attribute:       #2}%
+  \TYPE{END rawBlock}}%

--- a/tests/testfiles/lunamark-markdown/no-fenced-code.test
+++ b/tests/testfiles/lunamark-markdown/no-fenced-code.test
@@ -1,6 +1,6 @@
 <<<
 This test ensures that the Lua `fencedCode` option is disabled by default. The
-following fenced code block should resolve to a code spans.
+following fenced code block should resolve to code spans.
 
 ``` foo
 bar

--- a/tests/testfiles/lunamark-markdown/no-raw-attribute.test
+++ b/tests/testfiles/lunamark-markdown/no-raw-attribute.test
@@ -1,0 +1,36 @@
+\def\markdownOptionFencedCode{true}
+<<<
+This test ensures that the Lua `fencedCode` option correctly propagates through
+the plain TeX interface and that the `rawAttribute` option is disabled by
+default.
+
+The following fenced code block should resolve to a fenced code block:
+
+```{=openxml}
+<w:p>
+  <w:r>
+    <w:br w:type="page"/>
+  </w:r>
+</w:p>
+```
+
+The following inline raw span should be recognized as a code span followed by
+braced text:
+
+This is `<a>html</a>`{=html}
+>>>
+documentBegin
+codeSpan: fencedCode
+codeSpan: rawAttribute
+interblockSeparator
+interblockSeparator
+BEGIN fencedCode
+- src: ./_markdown_test/b43c6cb44864821760ccce3596fbc5e2.verbatim
+- infostring: (leftBrace)=openxml(rightBrace)
+END fencedCode
+interblockSeparator
+interblockSeparator
+codeSpan: <a>html</a>
+leftBrace
+rightBrace
+documentEnd

--- a/tests/testfiles/lunamark-markdown/raw-attribute.test
+++ b/tests/testfiles/lunamark-markdown/raw-attribute.test
@@ -1,0 +1,36 @@
+\def\markdownOptionFencedCode{true}
+\def\markdownOptionRawAttribute{true}
+<<<
+This test ensures that the Lua `fencedCode` and `rawAttribute` options
+correctly propagate through the plain TeX interface.
+
+The following raw blocks should be recognized as such:
+
+```{=openxml}
+<w:p>
+  <w:r>
+    <w:br w:type="page"/>
+  </w:r>
+</w:p>
+```
+
+The following inline raw span should be recognized as such:
+
+This is `<a>html</a>`{=html}
+>>>
+documentBegin
+codeSpan: fencedCode
+codeSpan: rawAttribute
+interblockSeparator
+interblockSeparator
+BEGIN rawBlock
+- src: ./_markdown_test/b43c6cb44864821760ccce3596fbc5e2.verbatim
+- raw attribute: openxml
+END rawBlock
+interblockSeparator
+interblockSeparator
+BEGIN rawInline
+- src: ./_markdown_test/fd6a1b0756c054889635f876357a8ca1.verbatim
+- raw attribute: html
+END rawInline
+documentEnd


### PR DESCRIPTION
Progresses #61. Closes #173.

Like Pandoc and unlike @Omikhleia upstream (https://github.com/jgm/lunamark/pull/36), we don't allow mixed attribute lists that contain both raw attributes and regular HTML attributes.

### Tasks

- [x] Rename `parsers.HeadingAttributes` to `parsers.attributes`.
- [x] Add raw attribute syntax extension.
  - [x] Define `extensions.raw_attribute`.
  - [x] Define a pattern that matches a raw attribute (see [upstream code][4]).
  - [x] Add reader and writer for raw blocks (see [upstream code][5]).
  - [x] Add reader and writer for inlined raw spans (see upstream code: [1][2], [2][3]).
  - [x] Load `extensions.raw_attribute` in `M.new()`.
- [x] Add raw attribute renderers and renderer prototypes.
- [x] Add raw attribute Lua option.
- [x] Add default renderer prototype for plain TeX, LaTeX, and ConTeXt.
  - [x] In plain TeX, always render fenced/inline code with raw attribute `tex` (case-insensitive).
  - [x] In LaTeX, always render fenced/inline code with raw attribute `tex` or `latex` (case-insensitive).
  - [x] In ConTeXt, always render fenced/inline code with raw attribute `tex` or `context` (case-insensitive).
- [x] Add unit tests for raw attribute.
- [x] Check that example given in https://github.com/Witiko/markdown/issues/61#issuecomment-1256128061 works.
- [x] Add raw attributes to example documents for LaTeX and ConTeXt.
- [x] Update `CHANGES.md`.

 [2]: https://github.com/Omikhleia/lunamark/blob/60ba0bd1d5c0581472667bd7131ae5e6998b6993/lunamark/reader/markdown.lua#L1050-L1051
 [3]: https://github.com/Omikhleia/lunamark/blob/60ba0bd1d5c0581472667bd7131ae5e6998b6993/lunamark/reader/markdown.lua#L1538
 [4]: https://github.com/Omikhleia/lunamark/blob/60ba0bd1d5c0581472667bd7131ae5e6998b6993/lunamark/reader/markdown.lua#L177-L181
 [5]: https://github.com/Omikhleia/lunamark/blob/60ba0bd1d5c0581472667bd7131ae5e6998b6993/lunamark/reader/markdown.lua#L1233-L1252