### PR TITLE
Add support for div and span attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,19 @@
 
 ## 2.19.0
 
-Refactoring:
+Development:
 
-- Sort Lua options, token renderers, and built-in syntax extensions. (#208)
+- Add support for fenced divs and bracketed spans. (#207)
 
 Fixes:
 
 - Fix incorrect category codes in plain TeX renderer prototype definitions.
   (f156f05)
 - Allow backticks in tilde code block infostrings. (#214, #219, #221)
+
+Refactoring:
+
+- Sort Lua options, token renderers, and built-in syntax extensions. (#208)
 
 ## 2.18.0 (2022-10-30)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22694,8 +22694,31 @@ M.extensions = {}
 M.extensions.bracketed_spans = function()
   return {
     name = "built-in bracketed_spans syntax extension",
-    extend_writer = function()
-    end, extend_reader = function()
+    extend_writer = function(self)
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->span} as a function that will transform an input
+% bracketed span `s` with attributes `attr` to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.span(s, attr)
+        return {"\\markdownRendererBracketedSpan{",s,"}{",attr,"}"}
+      end
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local writer = self.writer
+
+      local Span = parsers.between(parsers.Inline,
+                                   parsers.lbracket,
+                                   parsers.rbracket)
+                 * Ct(parsers.attributes)
+                 / writer.span
+
+      self.insert_pattern("Inline after Emph",
+                          Span, "Span")
     end
   }
 end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -3607,7 +3607,7 @@ following content:
 \ExplSyntaxOn
 \markdownSetup{
   renderers = {
-    fencedDivAttributeContextBegin = {
+    bracketedSpanAttributeContextBegin = {
       \group_begin:
       \color_group_begin:
       \markdownSetup{
@@ -3623,7 +3623,7 @@ following content:
         },
       }
     },
-    fencedDivAttributeContextEnd = {
+    bracketedSpanAttributeContextEnd = {
       \color_group_end:
       \group_end:
     },

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22827,17 +22827,30 @@ function M.reader.new(writer, options)
 % \begin{markdown}
 %
 % Define \luamref{reader->update_rule} as a function that receives two
-% arguments: a left-hand side terminal symbol and a \acro{peg} pattern.
-% The function (re)defines \luamref{walkable_syntax}`[`left-hand side terminal
-% symbol`]` to be equal to pattern.
+% arguments: a left-hand side terminal symbol and a function that accepts
+% the current \acro{peg} pattern in \luamref{walkable_syntax}`[`left-hand side
+% terminal symbol`]` if defined or `nil` otherwise and returns a
+% \acro{peg} pattern that will (re)define \luamref{walkable_syntax}`[`left-hand
+% side terminal symbol`]`.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    self.update_rule = function(rule_name, pattern)
+    self.update_rule = function(rule_name, get_pattern)
       assert(current_extension_name ~= nil)
       assert(syntax[rule_name] ~= nil,
         [[Rule ]] .. rule_name .. [[ -> ... does not exist in markdown grammar]])
-      local accountable_pattern = { pattern, current_extension_name, rule_name }
+      local previous_pattern
+      local extension_name
+      if walkable_syntax[rule_name] then
+        local previous_accountable_pattern = walkable_syntax[rule_name][1]
+        previous_pattern = previous_accountable_pattern[1]
+        extension_name = previous_accountable_pattern[2] .. ", " .. current_extension_name
+      else
+        previous_pattern = nil
+        extension_name = current_extension_name
+      end
+      local pattern = get_pattern(previous_pattern)
+      local accountable_pattern = { pattern, extension_name, rule_name }
       walkable_syntax[rule_name] = { accountable_pattern }
     end
 %    \end{macrocode}
@@ -23881,7 +23894,7 @@ M.extensions.fancy_lists = function()
                       * Cc(false) * parsers.skipblanklines
                       ) * Cb("listtype") / fancylist
 
-      self.update_rule("OrderedList", FancyList)
+      self.update_rule("OrderedList", function() return FancyList end)
     end
   }
 end
@@ -23944,8 +23957,12 @@ M.extensions.fenced_code = function(blank_before_code_fence)
                                        parsers.tilde_infostring)
       end
 
-      local EndlineExceptions = parsers.EndlineExceptions + fencestart
-      self.update_rule("EndlineExceptions", EndlineExceptions)
+      self.update_rule("EndlineExceptions", function(previous_pattern)
+        if previous_pattern == nil then
+          previous_pattern = parsers.EndlineExceptions
+        end
+        return previous_pattern + fencestart
+      end)
 
       self.add_special_character("~")
     end
@@ -24074,8 +24091,12 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 
         local is_inside_div = Cmt(Cb("div_level"), check_div_level)
         local fencestart = is_inside_div * fenced_div_end
-        local EndlineExceptions = parsers.EndlineExceptions + fencestart
-        self.update_rule("EndlineExceptions", EndlineExceptions)
+        self.update_rule("EndlineExceptions", function(previous_pattern)
+          if previous_pattern == nil then
+            previous_pattern = parsers.EndlineExceptions
+          end
+          return previous_pattern + fencestart
+        end)
       end
     end
   }
@@ -24141,7 +24162,7 @@ M.extensions.header_attributes = function()
                           / writer.heading
 
       local Heading = AtxHeading + SetextHeading
-      self.update_rule("Heading", Heading)
+      self.update_rule("Heading", function() return Heading end)
     end
   }
 end
@@ -24226,7 +24247,7 @@ M.extensions.notes = function(notes, inline_notes)
                     / register_note
 
         local Blank = NoteBlock + parsers.Blank
-        self.update_rule("Blank", Blank)
+        self.update_rule("Blank", function() return Blank end)
 
         self.insert_pattern("Inline after Emph",
                             NoteRef, "NoteRef")
@@ -24761,7 +24782,7 @@ M.extensions.jekyll_data = function(expect_jekyll_data)
       self.insert_pattern("Block before Blockquote",
                           UnexpectedJekyllData, "UnexpectedJekyllData")
       if expect_jekyll_data then
-        self.update_rule("ExpectedJekyllData", ExpectedJekyllData)
+        self.update_rule("ExpectedJekyllData", function() return ExpectedJekyllData end)
       end
     end
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21246,8 +21246,7 @@ local function captures_geq_length(_,i,a,b)
   return #a >= #b and i
 end
 
-parsers.tilde_infostring
-                     = C((parsers.linechar
+parsers.infostring   = C((parsers.linechar
                         - (parsers.spacechar^1 * parsers.newline))^0)
                      * parsers.optionalspace
                      * (parsers.newline + parsers.eof)
@@ -21535,7 +21534,7 @@ parsers.urlchar      = parsers.anyescaped - parsers.newline - parsers.more
 %  \begin{macrocode}
 parsers.TildeFencedCode
        = parsers.fencehead(parsers.tilde,
-                           parsers.tilde_infostring)
+                           parsers.infostring)
        * Cs(parsers.fencedline(parsers.tilde)^0)
        * parsers.fencetail(parsers.tilde)
 
@@ -23490,7 +23489,7 @@ M.extensions.fenced_code = function(blank_before_code_fence)
         fencestart = parsers.fencehead(parsers.backtick,
                                        parsers.backtick_infostring)
                    + parsers.fencehead(parsers.tilde,
-                                       parsers.tilde_infostring)
+                                       parsers.infostring)
       end
 
       local EndlineExceptions = parsers.EndlineExceptions + fencestart
@@ -23545,7 +23544,7 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       local fenced_div_begin = parsers.nonindentspace
                              * parsers.colon^3
                              * parsers.optionalspace
-                             * Ct(parsers.attributes)
+                             * C(parsers.infostring)
                              * parsers.optionalspace
                              * (parsers.newline + parsers.eof)
 
@@ -23585,7 +23584,13 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                             * (V("Block") - fenced_div_end))^0)
                       * parsers.blanklines
                       * fenced_div_end * increment_div_level(-1)
-                      / function (attr, div) return div, attr end
+                      / function (infostring, div)
+                          local attr = lpeg.match(Ct(parsers.attributes), infostring)
+                          if attr == nil then
+                            attr = {"." .. infostring}
+                          end
+                          return div, attr
+                        end
                       / writer.div
 
       self.insert_pattern("Block after Verbatim",

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -3048,7 +3048,7 @@ following content:
   convert = markdown.new({fencedCode = true})
   input = "A paragraph."   .. newline ..
           "```"            .. newline ..
-          "A code fence."  .. newline ..
+          "A fenced code." .. newline ..
           "```"            .. newline
   tex.sprint(convert(input))
 
@@ -3056,7 +3056,7 @@ following content:
     fencedCode = true, blankBeforeCodeFence = true})
   input = "A paragraph."       .. newline ..
           "```"                .. newline ..
-          "Not a code fence."  .. newline ..
+          "Not a fenced code." .. newline ..
           "```"                .. newline
   tex.sprint(convert(input)) }
 \bye
@@ -3071,10 +3071,10 @@ following text:
 > A paragraph.
 >
 > ```
-> A code fence.
+> A fenced code.
 > ```
 >
-> A paragraph. ``` Not a code fence. ```
+> A paragraph. ``` Not a fenced code. ```
 
 ##### Lua CLI Example {.unnumbered}
 
@@ -3129,7 +3129,7 @@ following content:
 \markdownBegin
 A paragraph.
 ```
-A code fence.
+A fenced code.
 ```
 \markdownEnd
 
@@ -3137,7 +3137,7 @@ A code fence.
 \markdownBegin
 A paragraph.
 ```
-Not a code fence.
+Not a fenced code.
 ```
 \markdownEnd
 
@@ -3153,10 +3153,10 @@ following text:
 > A paragraph.
 >
 > ```
-> A code fence.
+> A fenced code.
 > ```
 >
-> A paragraph. ``` Not a code fence. ```
+> A paragraph. ``` Not a fenced code. ```
 
 ##### \LaTeX{} Example {.unnumbered}
 
@@ -3170,14 +3170,14 @@ following content:
 \begin{markdown}
 A paragraph.
 ```
-A code fence.
+A fenced code.
 ```
 \end{markdown}
 
 \begin{markdown*}{blankBeforeCodeFence}
 A paragraph.
 ```
-Not a code fence.
+Not a fenced code.
 ```
 \end{markdown*}
 
@@ -3193,10 +3193,10 @@ following text:
 > A paragraph.
 >
 > ```
-> A code fence.
+> A fenced code.
 > ```
 >
-> A paragraph. ``` Not a code fence. ```
+> A paragraph. ``` Not a fenced code. ```
 
 ##### \Hologo{ConTeXt} Example {.unnumbered}
 
@@ -3210,7 +3210,7 @@ following content:
 \startmarkdown
 A paragraph.
 ```
-A code fence.
+A fenced code.
 ```
 \stopmarkdown
 
@@ -3218,7 +3218,7 @@ A code fence.
 \startmarkdown
 A paragraph.
 ```
-Not a code fence.
+Not a fenced code.
 ```
 \stopmarkdown
 
@@ -3234,10 +3234,10 @@ following text:
 > A paragraph.
 >
 > ```
-> A code fence.
+> A fenced code.
 > ```
 >
-> A paragraph. ``` Not a code fence. ```
+> A paragraph. ``` Not a fenced code. ```
 
 %</manual-options>
 %<*tex>
@@ -3254,6 +3254,86 @@ following text:
 % \fi
 %  \begin{macrocode}
 defaultOptions.blankBeforeCodeFence = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
+#### Option `blankBeforeDivFence`
+
+`blankBeforeDivFence` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{blankBeforeDivFence}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Require a blank line between a paragraph and the following fenced div.
+
+     false
+
+     :  Do not require a blank line between a paragraph and the following
+        fenced div.
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[fencedDivs]{markdown}
+\begin{document}
+
+\begin{markdown}
+A paragraph.
+::: {.identifier}
+A fenced div.
+:::
+\end{markdown}
+
+\begin{markdown*}{blankBeforeDivFence}
+A paragraph.
+```
+Not a fenced div.
+```
+\end{markdown*}
+
+\end{document}
+````````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> A paragraph.
+>
+> A fenced div.
+>
+> A paragraph. ::: {.identifier} Not a fenced div. :::
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { blankBeforeDivFence }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.blankBeforeDivFence = false
 %    \end{macrocode}
 % \par
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -3270,12 +3270,11 @@ defaultOptions.blankBeforeCodeFence = false
 %
 :    true
 
-     :  Require a blank line between a paragraph and the following fenced div.
+     :  Require a blank line before the closing fence of a fenced div.
 
      false
 
-     :  Do not require a blank line between a paragraph and the following
-        fenced div.
+     :  Do not require a blank line before the closing fence of a fenced div.
 
 % \end{markdown}
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21034,7 +21034,8 @@ parsers.doubletildes           = P("~~")
 parsers.fourspaces             = P("    ")
 
 parsers.any                    = P(1)
-parsers.fail                   = parsers.any - 1
+parsers.succeed                = P(true)
+parsers.fail                   = P(false)
 
 parsers.escapable              = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 parsers.anyescaped             = parsers.backslash / "" * parsers.escapable
@@ -22327,12 +22328,12 @@ function M.reader.new(writer, options)
     local syntax =
       { "Blocks",
 
-        Blocks                = ( V("ExpectedJekyllData")
-                                * (V("Blank")^0 / writer.interblocksep)
-                                )^-1
+        Blocks                = V("InitializeState")
+                              * ( V("ExpectedJekyllData")
+                                * (V("Blank")^0 / writer.interblocksep))^-1
                               * V("Blank")^0
                               * V("Block")^-1
-                              * (V("Blank")^0 / writer.interblocksep
+                              * ( V("Blank")^0 / writer.interblocksep
                                 * V("Block"))^0
                               * V("Blank")^0 * parsers.eof,
 
@@ -22371,6 +22372,7 @@ function M.reader.new(writer, options)
         Smart                 = parsers.Smart,
         Symbol                = parsers.Symbol,
         SpecialChar           = parsers.fail,
+        InitializeState       = parsers.succeed,
       }
 %    \end{macrocode}
 % \par
@@ -22413,6 +22415,19 @@ function M.reader.new(writer, options)
     self.add_special_character("<")
     self.add_special_character("!")
     self.add_special_character("\\")
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Add method \luamdef{reader->initialize_named_group} that defines named groups
+% with a default capture value.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    self.initialize_named_group = function(name, value)
+      syntax.InitializeState = syntax.InitializeState
+                             * Cg(Ct("") / value, name)
+    end
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -22583,7 +22598,10 @@ function M.reader.new(writer, options)
 
     local inlines_t = util.table_copy(syntax)
     inlines_t[1] = "Inlines"
-    inlines_t.Inlines = parsers.Inline^0 * (parsers.spacing^0 * parsers.eof / "")
+    inlines_t.Inlines = V("InitializeState")
+                      * parsers.Inline^0
+                      * ( parsers.spacing^0
+                        * parsers.eof / "")
     parsers.inlines = Ct(inlines_t)
 
     local inlines_no_link_t = util.table_copy(inlines_t)
@@ -23489,7 +23507,7 @@ end
 %#### Fenced Divs
 %
 % The \luamdef{extensions.fenced_divs} function implements the Pandoc fenced
-% divs syntax extension. When the `blank_before_div_fence`parameter is `true`,
+% divs syntax extension. When the `blank_before_div_fence` parameter is `true`,
 % the syntax extension requires a blank line between a paragraph and the
 % following fenced code block.
 %
@@ -23516,31 +23534,86 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       end
     end, extend_reader = function(self)
       local parsers = self.parsers
-      local parse_blocks = self.parser_functions.parse_blocks
       local writer = self.writer
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define basic patterns for matching the opening and the closing tag of a div.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      local fenced_div_begin = parsers.nonindentspace
+                             * parsers.colon^3
+                             * parsers.optionalspace
+                             * Ct(parsers.attributes)
+                             * parsers.optionalspace
+                             * (parsers.newline + parsers.eof)
 
-      local FencedDiv = parsers.fencehead_with_attributes(parsers.colon)
-                      * Cs(parsers.fencedline(parsers.colon)^0)
-                      * parsers.fencetail(parsers.colon)
-                      / function(attr, s)
-                        local content = parse_blocks(s)
-                        return writer.div(content, attr)
-                      end
+      local fenced_div_end = parsers.nonindentspace
+                           * parsers.colon^3
+                           * parsers.optionalspace
+                           * (parsers.newline + parsers.eof)
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Initialize a named group named `div_level` for tracking how deep we are
+% nested in divs.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      self.initialize_named_group("div_level", "0")
+
+      local function increment_div_level(increment)
+        local function update_div_level(s, i, current_level) -- luacheck: ignore s i
+          current_level = tonumber(current_level)
+          local next_level = tostring(current_level + increment)
+          return true, next_level
+        end
+
+        return Cg( Cmt(Cb("div_level"), update_div_level)
+                 , "div_level")
+      end
+
+      local FencedDiv = fenced_div_begin * increment_div_level(1)
+                      * parsers.blanklines
+                      * Ct( (V("Block") - fenced_div_end)^-1
+                          * ( parsers.blanklines
+                            / function()
+                                return writer.interblocksep
+                              end
+                            * (V("Block") - fenced_div_end))^0)
+                      * parsers.blanklines
+                      * fenced_div_end * increment_div_level(-1)
+                      / function (attr, div) return div, attr end
+                      / writer.div
 
       self.insert_pattern("Block after Verbatim",
                           FencedDiv, "FencedDiv")
 
-      local fencestart
-      if blank_before_div_fence then
-        fencestart = parsers.fail
-      else
-        fencestart = parsers.fencehead_with_attributes(parsers.colon)
-      end
-
-      local EndlineExceptions = parsers.EndlineExceptions + fencestart
-      self.update_rule("EndlineExceptions", EndlineExceptions)
-
       self.add_special_character(":")
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% If the `blank_before_div_fence` parameter is `false`, we will have the
+% closing div at the beginning of a line break the current paragraph if
+% we are currently nested in a div.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      if not blank_before_div_fence then
+        local function check_div_level(s, i, current_level) -- luacheck: ignore s i
+          current_level = tonumber(current_level)
+          return current_level > 0
+        end
+
+        local is_inside_div = Cmt(Cb("div_level"), check_div_level)
+        local fencestart = is_inside_div * fenced_div_end
+        local EndlineExceptions = parsers.EndlineExceptions + fencestart
+        self.update_rule("EndlineExceptions", EndlineExceptions)
+      end
     end
   }
 end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24791,6 +24791,11 @@ function M.new(options)
 %  \begin{macrocode}
   local extensions = {}
 
+  if options.bracketedSpans then
+    local bracketed_spans_extension = M.extensions.bracketed_spans()
+    table.insert(extensions, bracketed_spans_extension)
+  end
+
   if options.contentBlocks then
     local content_blocks_extension = M.extensions.content_blocks(
       options.contentBlocksLanguageMap)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23205,7 +23205,7 @@ M.extensions.bracketed_spans = function()
       function self.span(s, attr)
         return {"\\markdownRendererBracketedSpanAttributeContextBegin",
                 self.attributes(attr),
-                "\\markdownRendererBracketedSpan{",s,"}",
+                s,
                 "\\markdownRendererBracketedSpanAttributeContextEnd{}"}
       end
     end, extend_reader = function(self)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -24809,6 +24809,12 @@ function M.new(options)
     table.insert(extensions, fenced_code_extension)
   end
 
+  if options.fencedDivs then
+    local fenced_div_extension = M.extensions.fenced_divs(
+      options.blankBeforeDivFence)
+    table.insert(extensions, fenced_div_extension)
+  end
+
   if options.headerAttributes then
     local header_attributes_extension = M.extensions.header_attributes()
     table.insert(extensions, header_attributes_extension)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -5317,6 +5317,83 @@ defaultOptions.fencedCode = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `fencedDivs`
+
+`fencedDivs` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{fencedDivs}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc fenced divs extension:
+
+        ``` md
+        ::::: {#special .sidebar}
+        Here is a paragraph.
+
+        And another.
+        :::::
+        ``````
+
+:    false
+
+     :  Disable the Pandoc fenced divs extension:
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[fencedDivs]{markdown}
+\begin{document}
+\begin{markdown}{slice=special}
+Here is a regular paragraph.
+
+::::: {#special}
+Here is a special paragraph.
+:::::
+
+And here is another regular paragraph.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Here is a special paragraph.
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { fencedDivs }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.fencedDivs = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `finalizeCache`
 
 `finalizeCache` (default value: `false`)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -3572,6 +3572,100 @@ defaultOptions.blankBeforeHeading = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `bracketedSpans`
+
+`bracketedSpans` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{bracketedSpans}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc bracketed spans extension:
+
+        ``` md
+        [This is *some text*]{.class key="val"}
+        ``````
+
+:    false
+
+     :  Disable the Pandoc bracketed spans extension:
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[bracketedSpans]{markdown}
+\usepackage{expl3}
+\ExplSyntaxOn
+\markdownSetup{
+  renderers = {
+    fencedDivAttributeContextBegin = {
+      \group_begin:
+      \color_group_begin:
+      \markdownSetup{
+        renderers = {
+          attributeKeyValue = {
+            \str_if_eq:nnT
+              { #1 }
+              { color }
+              {
+                 \color_select:n { #2 }
+              }
+          },
+        },
+      }
+    },
+    fencedDivAttributeContextEnd = {
+      \color_group_end:
+      \group_end:
+    },
+  },
+}
+\ExplSyntaxOff
+\begin{document}
+\begin{markdown}
+Here is some [colored text]{color=red}.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Here is some [colored text]{color=red}.
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { bracketedSpans }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.bracketedSpans = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `breakableBlockquotes`
 
 `breakableBlockquotes` (default value: `false`)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23575,14 +23575,14 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       end
 
       local FencedDiv = fenced_div_begin * increment_div_level(1)
-                      * parsers.blanklines
+                      * parsers.skipblanklines
                       * Ct( (V("Block") - fenced_div_end)^-1
                           * ( parsers.blanklines
                             / function()
                                 return writer.interblocksep
                               end
                             * (V("Block") - fenced_div_end))^0)
-                      * parsers.blanklines
+                      * parsers.skipblanklines
                       * fenced_div_end * increment_div_level(-1)
                       / function (infostring, div)
                           local attr = lpeg.match(Ct(parsers.attributes), infostring)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -10000,6 +10000,86 @@ following text:
 %
 % \begin{markdown}
 
+#### Bracketed Spans Context Renderers
+The following macros are only produced, when the \Opt{bracketedSpans} option is
+enabled.
+
+The \mdef{markdownRendererBracketedSpanAttributeContextBegin} and
+\mdef{markdownRendererBracketedSpanAttributeContextEnd} macros represent the
+beginning and the end of an inline bracketed span in which the attributes of
+the span apply. The macros receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[bracketedSpans]{markdown}
+\markdownSetup{
+  renderers = {
+    fencedDivAttributeContextBegin = {(},
+    fencedDivAttributeContextEnd = {)},
+  },
+}
+\begin{document}
+\begin{markdown}
+
+[foo [bar]{#identifier}]{key=value} [baz]{.class_name}
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> (foo (bar)) (baz)
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererFracketedSpanAttributeContextBegin{%
+  \markdownRendererFracketedSpanAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { fracketedSpanAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { fracketedSpanAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererFracketedSpanAttributeContextEnd{%
+  \markdownRendererFracketedSpanAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { fracketedSpanAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { fracketedSpanAttributeContextEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 #### Bullet List Renderers
 The \mdef{markdownRendererUlBegin} macro represents the beginning of a
 bulleted list that contains an item with several paragraphs of text (the

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21246,6 +21246,14 @@ parsers.fencehead    = function(char)
                      * parsers.optionalspace * (parsers.newline + parsers.eof)
 end
 
+parsers.fencehead_with_attributes
+                     = function(char)
+  return               C(parsers.nonindentspace) / function(s) fenceindent = #s end
+                     * Cg(char^3, "fencelength")
+                     * parsers.optionalspace * Ct(parsers.attributes)
+                     * parsers.optionalspace * (parsers.newline + parsers.eof)
+end
+
 parsers.fencetail    = function(char)
   return               parsers.nonindentspace
                      * Cmt(C(char^3) * Cb("fencelength"), captures_geq_length)
@@ -23468,15 +23476,55 @@ end
 % extension that enables the division of content into block-level extents.
 % The beginnings and ends of extents are aligned to block-level elements.
 % Extents are hierarchical in that they may be nested but cannot partially
-% overlap.
+% overlap. When the `blank_before_div_fence`parameter is `true`, the syntax
+% extension requires a blank line between a paragraph and the following fenced
+% code block.
 %
 % \end{markdown}
 %  \begin{macrocode}
-M.extensions.fenced_divs = function()
+M.extensions.fenced_divs = function(blank_before_div_fence)
   return {
     name = "built-in fenced_divs syntax extension",
-    extend_writer = function()
-    end, extend_reader = function()
+    extend_writer = function(self)
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->div} as a function that will transform an input
+% fenced div with content `c` and with attributes `attr` to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.div(c, attr)
+        return {"\\markdownRendererFencedDiv{",c,"}{",attr,"}"}
+      end
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local parse_blocks = self.parser_functions.parse_blocks
+      local writer = self.writer
+
+      local FencedDiv = parsers.fencehead_with_attributes(parsers.colon)
+                      * Cs(parsers.fencedline(parsers.colon)^0)
+                      * parsers.fencetail(parsers.colon)
+                      / function(attr, s)
+                        local content = parse_blocks(s)
+                        return writer.div(content, attr)
+                      end
+
+      self.insert_pattern("Block after Verbatim",
+                          FencedDiv, "FencedDiv")
+
+      local fencestart
+      if blank_before_div_fence then
+        fencestart = parsers.fail
+      else
+        fencestart = parsers.fencehead_with_attributes(parsers.colon)
+      end
+
+      local EndlineExceptions = parsers.EndlineExceptions + fencestart
+      self.update_rule("EndlineExceptions", EndlineExceptions)
+
+      self.add_special_character(":")
     end
   }
 end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20762,6 +20762,36 @@ function M.writer.new(options)
 % \par
 % \begin{markdown}
 %
+% Define \luamdef{writer->attributes} as a function that will transform
+% input attributes `attr` to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  function self.attributes(attr)
+    local buf = {}
+
+    table.sort(attr)
+    local key, value
+    for i = 1, #attr do
+      if attr[i]:sub(1, 1) == "#" then
+        table.insert(buf, {"\\markdownRendererAttributeIdentifier{",
+                           attr[i]:sub(2), "}"})
+      elseif attr[i]:sub(1, 1) == "." then
+        table.insert(buf, {"\\markdownRendererAttributeClassName{",
+                           attr[i]:sub(2), "}"})
+      else
+        key, value = attr[i]:match("([^= ]+)%s*=%s*(.*)")
+        table.insert(buf, {"\\markdownRendererAttributeKeyValue{",
+                           key, "}{", value, "}"})
+      end
+    end
+
+    return buf
+  end
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 % Define \luamdef{writer->active\_attributes} as a stack of attributes
 % of the headings that are currently active. The
 % \luamref{writer->active\_headings} member variable is mutable.
@@ -20856,21 +20886,7 @@ function M.writer.new(options)
     end
 
     if self.is_writing then
-      table.sort(attributes)
-      local key, value
-      for i = 1, #attributes do
-        if attributes[i]:sub(1, 1) == "#" then
-          table.insert(buf, {"\\markdownRendererAttributeIdentifier{",
-                             attributes[i]:sub(2), "}"})
-        elseif attributes[i]:sub(1, 1) == "." then
-          table.insert(buf, {"\\markdownRendererAttributeClassName{",
-                             attributes[i]:sub(2), "}"})
-        else
-          key, value = attributes[i]:match("([^= ]+)%s*=%s*(.*)")
-          table.insert(buf, {"\\markdownRendererAttributeKeyValue{",
-                             key, "}{", value, "}"})
-        end
-      end
+      table.insert(buf, self.attributes(attributes))
     end
 
     local cmd
@@ -22710,7 +22726,10 @@ M.extensions.bracketed_spans = function()
 % \end{markdown}
 %  \begin{macrocode}
       function self.span(s, attr)
-        return {"\\markdownRendererBracketedSpan{",s,"}{",attr,"}"}
+        return {"\\markdownRendererBracketedSpanAttributeContextBegin",
+                self.attributes(attr),
+                "\\markdownRendererBracketedSpan{",s,"}",
+                "\\markdownRendererBracketedSpanAttributeContextEnd{}"}
       end
     end, extend_reader = function(self)
       local parsers = self.parsers
@@ -23490,7 +23509,10 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 % \end{markdown}
 %  \begin{macrocode}
       function self.div(c, attr)
-        return {"\\markdownRendererFencedDiv{",c,"}{",attr,"}"}
+        return {"\\markdownRendererFencedDivAttributeContextBegin",
+                self.attributes(attr),
+                "\\markdownRendererFencedDiv{",c,"}",
+                "\\markdownRendererFencedDivAttributeContextEnd"}
       end
     end, extend_reader = function(self)
       local parsers = self.parsers

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23076,9 +23076,9 @@ end
 %
 %#### Definition Lists
 %
-% The \luamdef{extensions.definition_lists} function implements the definition
-% list syntax extension. If the `tight_lists` parameter is `true`, tight lists
-% will produce special right item renderers.
+% The \luamdef{extensions.definition_lists} function implements the Pandoc
+% definition list syntax extension. If the `tight_lists` parameter is `true`,
+% tight lists will produce special right item renderers.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23177,7 +23177,7 @@ end
 %#### Fancy Lists
 %
 % The \luamdef{extensions.fancy_lists} function implements the Pandoc fancy
-% list extension.
+% list syntax extension.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23462,8 +23462,8 @@ end
 %
 %#### Header Attributes
 %
-% The \luamdef{extensions.header_attributes} function implements a syntax
-% extension that enables the assignment of HTML attributes to headings.
+% The \luamdef{extensions.header_attributes} function implements the Pandoc
+% header attributes syntax extension.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23619,7 +23619,7 @@ end
 %#### Pipe Tables
 %
 % The \luamdef{extensions.pipe_table} function implements the \acro{PHP}
-% Markdown table syntax extension (affectionately known as pipe tables). When
+% Markdown table syntax extension (also known as pipe tables in Pandoc). When
 % the `table_captions` parameter is `true`, the function also implements the
 % Pandoc `table_captions` syntax extension for table captions.
 %
@@ -23993,10 +23993,9 @@ end
 %#### YAML Metadata
 %
 % The \luamdef{extensions.jekyll_data} function implements the Pandoc
-% `yaml_metadata_block` syntax extension for entering metadata in \acro{yaml}.
-% When the `expect_jekyll_data` parameter is `true`, then a markdown document
-% may begin directly with \acro{yaml} metadata and may contain nothing but
-% \acro{yaml} metadata
+% `yaml_metadata_block` syntax extension. When the `expect_jekyll_data`
+% parameter is `true`, then a markdown document may begin directly with
+% \acro{yaml} metadata and may contain nothing but \acro{yaml} metadata.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22691,11 +22691,8 @@ M.extensions = {}
 %
 %#### Bracketed Spans
 %
-% The \luamdef{extensions.bracketed_spans} function implements a syntax
-% extension that enables the division of content into inline extents.
-% The beginnings and ends of extents are aligned to inline elements.
-% Extents are hierarchical in that they may be nested but cannot partially
-% overlap.
+% The \luamdef{extensions.bracketed_spans} function implements the Pandoc
+% bracketed spans syntax extension.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23472,13 +23469,10 @@ end
 %
 %#### Fenced Divs
 %
-% The \luamdef{extensions.fenced_divs} function implements a syntax
-% extension that enables the division of content into block-level extents.
-% The beginnings and ends of extents are aligned to block-level elements.
-% Extents are hierarchical in that they may be nested but cannot partially
-% overlap. When the `blank_before_div_fence`parameter is `true`, the syntax
-% extension requires a blank line between a paragraph and the following fenced
-% code block.
+% The \luamdef{extensions.fenced_divs} function implements the Pandoc fenced
+% divs syntax extension. When the `blank_before_div_fence`parameter is `true`,
+% the syntax extension requires a blank line between a paragraph and the
+% following fenced code block.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21697,7 +21697,8 @@ local function captures_geq_length(_,i,a,b)
   return #a >= #b and i
 end
 
-parsers.infostring   = C((parsers.linechar
+parsers.tilde_infostring
+                     = C((parsers.linechar
                         - (parsers.spacechar^1 * parsers.newline))^0)
                      * parsers.optionalspace
                      * (parsers.newline + parsers.eof)
@@ -21985,7 +21986,7 @@ parsers.urlchar      = parsers.anyescaped - parsers.newline - parsers.more
 %  \begin{macrocode}
 parsers.TildeFencedCode
        = parsers.fencehead(parsers.tilde,
-                           parsers.infostring)
+                           parsers.tilde_infostring)
        * Cs(parsers.fencedline(parsers.tilde)^0)
        * parsers.fencetail(parsers.tilde)
 
@@ -23940,7 +23941,7 @@ M.extensions.fenced_code = function(blank_before_code_fence)
         fencestart = parsers.fencehead(parsers.backtick,
                                        parsers.backtick_infostring)
                    + parsers.fencehead(parsers.tilde,
-                                       parsers.infostring)
+                                       parsers.tilde_infostring)
       end
 
       local EndlineExceptions = parsers.EndlineExceptions + fencestart
@@ -23992,10 +23993,17 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 %
 % \end{markdown}
 %  \begin{macrocode}
+      local fenced_div_infostring
+                             = C((parsers.linechar
+                                - ( parsers.spacechar^1
+                                  * parsers.colon^1))^1)
+
       local fenced_div_begin = parsers.nonindentspace
                              * parsers.colon^3
                              * parsers.optionalspace
-                             * C(parsers.infostring)
+                             * fenced_div_infostring
+                             * ( parsers.spacechar^1
+                               * parsers.colon^1)^0
                              * parsers.optionalspace
                              * (parsers.newline + parsers.eof)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23994,7 +23994,7 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       function self.div(c, attr)
         return {"\\markdownRendererFencedDivAttributeContextBegin",
                 self.attributes(attr),
-                "\\markdownRendererFencedDiv{",c,"}",
+                c,
                 "\\markdownRendererFencedDivAttributeContextEnd"}
       end
     end, extend_reader = function(self)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11828,6 +11828,126 @@ corresponds to the emphasized span of text.
 %
 % \begin{markdown}
 
+#### Fenced Div Context Renderers
+The following macros are only produced, when the \Opt{fencedDiv} option is
+enabled.
+
+The \mdef{markdownRendererFencedDivAttributeContextBegin} and
+\mdef{markdownRendererFencedDivAttributeContextEnd} macros represent the beginning
+and the end of a div in which the attributes of the div apply. The macros
+receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[fencedDiv]{markdown}
+\markdownSetup{
+  renderers = {
+    fencedDivAttributeContextBegin = {%
+      \par
+      \emph{(The beginning of a fenced div attribute context)}
+      \par
+    },
+    fencedDivAttributeContextEnd = {%
+      \par
+      \emph{(The end of a fenced div attribute context)}
+      \par
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+
+::: {key=value}
+
+foo
+
+:::: {#identifier}
+
+bar
+
+::::
+
+:::
+
+::: {.class_name}
+
+baz
+
+:::
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> *(The beginning of a fenced div attribute context)*
+>
+> foo
+>
+> *(The beginning of a fenced div attribute context)*
+>
+> bar
+>
+> *(The end of a fenced div attribute context)*
+>
+> *(The end of a fenced div attribute context)*
+>
+> *(The beginning of a fenced div attribute context)*
+>
+> baz
+>
+> *(The end of a fenced div attribute context)*
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererFencedDivAttributeContextBegin{%
+  \markdownRendererFencedDivAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { fencedDivAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { fencedDivAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererFencedDivAttributeContextEnd{%
+  \markdownRendererFencedDivAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { fencedDivAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { fencedDivAttributeContextEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 #### Header Attribute Context Renderers
 The following macros are only produced, when the \Opt{headerAttributes} option
 is enabled.
@@ -11855,7 +11975,7 @@ following content:
       \emph{(The beginning of a header attribute context)}
       \par
     },
-    headerAttributeContextBegin = {%
+    headerAttributeContextEnd = {%
       \par
       \emph{(The end of a header attribute context)}
       \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -10299,26 +10299,26 @@ following text:
 % \fi
 %
 %  \begin{macrocode}
-\def\markdownRendererFracketedSpanAttributeContextBegin{%
-  \markdownRendererFracketedSpanAttributeContextBeginPrototype}%
+\def\markdownRendererBracketedSpanAttributeContextBegin{%
+  \markdownRendererBracketedSpanAttributeContextBeginPrototype}%
 \ExplSyntaxOn
 \seq_gput_right:Nn
   \g_@@_renderers_seq
-  { fracketedSpanAttributeContextBegin }
+  { bracketedSpanAttributeContextBegin }
 \prop_gput:Nnn
   \g_@@_renderer_arities_prop
-  { fracketedSpanAttributeContextBegin }
+  { bracketedSpanAttributeContextBegin }
   { 0 }
 \ExplSyntaxOff
-\def\markdownRendererFracketedSpanAttributeContextEnd{%
-  \markdownRendererFracketedSpanAttributeContextEndPrototype}%
+\def\markdownRendererBracketedSpanAttributeContextEnd{%
+  \markdownRendererBracketedSpanAttributeContextEndPrototype}%
 \ExplSyntaxOn
 \seq_gput_right:Nn
   \g_@@_renderers_seq
-  { fracketedSpanAttributeContextEnd }
+  { bracketedSpanAttributeContextEnd }
 \prop_gput:Nnn
   \g_@@_renderer_arities_prop
-  { fracketedSpanAttributeContextEnd }
+  { bracketedSpanAttributeContextEnd }
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22681,6 +22681,27 @@ M.extensions = {}
 %    \end{macrocode}
 % \begin{markdown}
 %
+%#### Bracketed Spans
+%
+% The \luamdef{extensions.bracketed_spans} function implements a syntax
+% extension that enables the division of content into inline extents.
+% The beginnings and ends of extents are aligned to inline elements.
+% Extents are hierarchical in that they may be nested but cannot partially
+% overlap.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.bracketed_spans = function()
+  return {
+    name = "built-in bracketed_spans syntax extension",
+    extend_writer = function()
+    end, extend_reader = function()
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
 %#### Citations
 %
 % The \luamdef{extensions.citations} function implements the Pandoc citation
@@ -23412,6 +23433,27 @@ M.extensions.fenced_code = function(blank_before_code_fence)
       self.update_rule("EndlineExceptions", EndlineExceptions)
 
       self.add_special_character("~")
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### Fenced Divs
+%
+% The \luamdef{extensions.fenced_divs} function implements a syntax
+% extension that enables the division of content into block-level extents.
+% The beginnings and ends of extents are aligned to block-level elements.
+% Extents are hierarchical in that they may be nested but cannot partially
+% overlap.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.fenced_divs = function()
+  return {
+    name = "built-in fenced_divs syntax extension",
+    extend_writer = function()
+    end, extend_reader = function()
     end
   }
 end

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -9,6 +9,14 @@
       \TYPE{- key:                 #1}%
       \TYPE{- value:               #2}%
       \TYPE{END attributeKeyValue}},
+    fencedDivAttributeContextBegin = {%
+      \TYPE{fencedDivAttributeContextBegin}},
+    fencedDivAttributeContextEnd = {%
+      \TYPE{fencedDivAttributeContextEnd}},
+    bracketedSpanAttributeContextBegin = {%
+      \TYPE{bracketedSpanAttributeContextBegin}},
+    bracketedSpanAttributeContextEnd = {%
+      \TYPE{bracketedSpanAttributeContextEnd}},
     documentBegin = {%
       \TYPE{documentBegin}},
     documentEnd = {%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -7,6 +7,10 @@
   \TYPE{- key:                 #1}%
   \TYPE{- value:               #2}%
   \TYPE{END attributeKeyValue}}%
+\def\markdownRendererFencedDivAttributeContextBegin{%
+  \TYPE{fencedDivAttributeContextBegin}}%
+\def\markdownRendererFencedDivAttributeContextEnd{%
+  \TYPE{fencedDivAttributeContextEnd}}%
 \def\markdownRendererDocumentBegin{%
   \TYPE{documentBegin}}%
 \def\markdownRendererDocumentBegin{%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -11,6 +11,10 @@
   \TYPE{fencedDivAttributeContextBegin}}%
 \def\markdownRendererFencedDivAttributeContextEnd{%
   \TYPE{fencedDivAttributeContextEnd}}%
+\def\markdownRendererBracketedSpanAttributeContextBegin{%
+  \TYPE{bracketedSpanAttributeContextBegin}}%
+\def\markdownRendererBracketedSpanAttributeContextEnd{%
+  \TYPE{bracketedSpanAttributeContextEnd}}%
 \def\markdownRendererDocumentBegin{%
   \TYPE{documentBegin}}%
 \def\markdownRendererDocumentBegin{%

--- a/tests/testfiles/lunamark-markdown/blank-before-div-fence.test
+++ b/tests/testfiles/lunamark-markdown/blank-before-div-fence.test
@@ -1,0 +1,31 @@
+\def\markdownOptionFencedDivs{true}
+\def\markdownOptionBlankBeforeDivFence{true}
+<<<
+This test ensures that the Lua `fencedDivs` and `blankBeforeDivFence` options
+correctly propagate through the plain TeX interface.
+
+The following fenced div should resolve to a paragraph:
+
+::: foo
+bar
+:::
+
+The following fenced div should be recognized as such:
+
+::: foo
+
+bar
+
+:::
+>>>
+documentBegin
+codeSpan: fencedDivs
+codeSpan: blankBeforeDivFence
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: foo
+fencedDivAttributeContextEnd
+documentEnd

--- a/tests/testfiles/lunamark-markdown/bracketed-spans.test
+++ b/tests/testfiles/lunamark-markdown/bracketed-spans.test
@@ -1,0 +1,19 @@
+\def\markdownOptionBracketedSpans{true}
+<<<
+This test ensures that the Lua `bracketedSpans` option correctly
+propagates through the plain TeX interface.
+
+[This is *some text*]{.class key="val"}
+>>>
+documentBegin
+codeSpan: bracketedSpans
+interblockSeparator
+bracketedSpanAttributeContextBegin
+attributeClassName: class
+BEGIN attributeKeyValue
+- key: key
+- value: val
+END attributeKeyValue
+emphasis: some text
+bracketedSpanAttributeContextEnd
+documentEnd

--- a/tests/testfiles/lunamark-markdown/fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/fenced-divs.test
@@ -1,0 +1,220 @@
+\def\markdownOptionFencedDivs{true}
+\def\markdownOptionFencedCode{true}
+<<<
+:::
+This is not a div
+:::
+
+ ::: {.myclass lang=fr}
+Some better div
+  :::
+
+:::: {.level1}
+Fenced divs can be nested
+
+::::: {.level2-more-colons}
+This is a nested div
+:::::
+
+::: {.level2-fewer-colons}
+This is also a nested div that contains
+
+several paragraphs of text
+:::
+
+:::: {.level2-same-number-of-colons}
+This is another nested div
+
+::::: {.level3}
+with another nested div inside
+:::::
+::::
+::::
+
+::: Warning ::::::
+This is a warning.
+
+::: Danger
+This is a warning within a warning.
+:::
+::::::::::::::::::
+
+::: {.some-classname}
+::: {#some-id}
+::: {lang=some}
+Divs can be nested directly inside one another without surrounding text.
+:::
+:::
+:::
+
+::: {.level1}
+This is the beginning of a div
+
+> This is a blockquote
+>
+> ::: {.level2-inside-blockquote}
+> This is a div inside a blockquote
+> :::
+
+:::
+
+::: {#some-identifier}
+This is the beginning of a div
+
+> This is a blockquote that contains three colons:
+> :::
+
+This is the end of a div
+:::
+
+Here are some extra colons that will be shown as just text:
+
+::::
+
+::: {.not-a-div}
+here is a code span `
+:::
+` that contains three colons
+
+::: {.some-classname}
+This is a div with a fenced code inside
+
+```
+:::
+```
+:::
+
+::: {.cit custom-style=raggedleft}
+I am a _fenced_ div
+:::
+
+::: {.cit custom-style=raggedleft}
+
+I am a _fenced_ div
+
+:::
+
+::: {.some-classname}
+This is not a div
+```
+:::
+```
+
+::: {.some-classname}
+This is not a div
+>>>
+documentBegin
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: myclass
+BEGIN attributeKeyValue
+- key: lang
+- value: fr
+END attributeKeyValue
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level1
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level2-more-colons
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level2-fewer-colons
+interblockSeparator
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level2-same-number-of-colons
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level3
+fencedDivAttributeContextEnd
+fencedDivAttributeContextEnd
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: Warning
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: Danger
+fencedDivAttributeContextEnd
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: some-classname
+fencedDivAttributeContextBegin
+attributeIdentifier: some-id
+fencedDivAttributeContextBegin
+BEGIN attributeKeyValue
+- key: lang
+- value: some
+END attributeKeyValue
+fencedDivAttributeContextEnd
+fencedDivAttributeContextEnd
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level1
+interblockSeparator
+blockQuoteBegin
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: level2-inside-blockquote
+fencedDivAttributeContextEnd
+blockQuoteEnd
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeIdentifier: some-identifier
+interblockSeparator
+blockQuoteBegin
+blockQuoteEnd
+interblockSeparator
+fencedDivAttributeContextEnd
+interblockSeparator
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+codeSpan:  ::: 
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: some-classname
+interblockSeparator
+BEGIN fencedCode
+- src: ./_markdown_test/e441fcf4a7686817fe868bf38a5c2c07.verbatim
+- infostring: 
+END fencedCode
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: cit
+BEGIN attributeKeyValue
+- key: custom-style
+- value: raggedleft
+END attributeKeyValue
+emphasis: fenced
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: cit
+BEGIN attributeKeyValue
+- key: custom-style
+- value: raggedleft
+END attributeKeyValue
+emphasis: fenced
+fencedDivAttributeContextEnd
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+BEGIN fencedCode
+- src: ./_markdown_test/e441fcf4a7686817fe868bf38a5c2c07.verbatim
+- infostring: 
+END fencedCode
+interblockSeparator
+leftBrace
+rightBrace
+documentEnd

--- a/tests/testfiles/lunamark-markdown/fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/fenced-divs.test
@@ -1,6 +1,9 @@
 \def\markdownOptionFencedDivs{true}
 \def\markdownOptionFencedCode{true}
 <<<
+This test ensures that the Lua `fencedDivs` and `fencedCode` options correctly
+propagates through the plain TeX interface.
+
 :::
 This is not a div
 :::
@@ -104,6 +107,9 @@ This is not a div
 This is not a div
 >>>
 documentBegin
+codeSpan: fencedDivs
+codeSpan: fencedCode
+interblockSeparator
 interblockSeparator
 fencedDivAttributeContextBegin
 attributeClassName: myclass

--- a/tests/testfiles/lunamark-markdown/no-blank-before-div-fence.test
+++ b/tests/testfiles/lunamark-markdown/no-blank-before-div-fence.test
@@ -1,0 +1,31 @@
+\def\markdownOptionFencedDivs{true}
+<<<
+This test ensures that the Lua `fencedDivs` option correctly propagates through
+the plain TeX interface and that the Lua `blankBeforeDivFence` option is
+disabled by default.
+
+The following fenced divs should be recognized as such:
+
+::: foo
+bar
+:::
+
+::: foo
+
+bar
+
+:::
+>>>
+documentBegin
+codeSpan: fencedDivs
+codeSpan: blankBeforeDivFence
+interblockSeparator
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: foo
+fencedDivAttributeContextEnd
+interblockSeparator
+fencedDivAttributeContextBegin
+attributeClassName: foo
+fencedDivAttributeContextEnd
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-bracketed-spans.test
+++ b/tests/testfiles/lunamark-markdown/no-bracketed-spans.test
@@ -1,0 +1,12 @@
+<<<
+This test ensures that the Lua `bracketedSpans` option is disabled by default.
+
+[This is *some text*]{.class key="val"}
+>>>
+documentBegin
+codeSpan: bracketedSpans
+interblockSeparator
+emphasis: some text
+leftBrace
+rightBrace
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/no-fenced-divs.test
@@ -1,0 +1,196 @@
+\def\markdownOptionFencedCode{true}
+<<<
+This test ensures that the Lua `fencedDivs` option is disabled by default
+and that the `fencedCode` option correctly propagates through the plain TeX
+interface.
+
+:::
+This is not a div
+:::
+
+ ::: {.myclass lang=fr}
+Some better div
+  :::
+
+:::: {.level1}
+Fenced divs can be nested
+
+::::: {.level2-more-colons}
+This is a nested div
+:::::
+
+::: {.level2-fewer-colons}
+This is also a nested div that contains
+
+several paragraphs of text
+:::
+
+:::: {.level2-same-number-of-colons}
+This is another nested div
+
+::::: {.level3}
+with another nested div inside
+:::::
+::::
+::::
+
+::: Warning ::::::
+This is a warning.
+
+::: Danger
+This is a warning within a warning.
+:::
+::::::::::::::::::
+
+::: {.some-classname}
+::: {#some-id}
+::: {lang=some}
+Divs can be nested directly inside one another without surrounding text.
+:::
+:::
+:::
+
+::: {.level1}
+This is the beginning of a div
+
+> This is a blockquote
+>
+> ::: {.level2-inside-blockquote}
+> This is a div inside a blockquote
+> :::
+
+:::
+
+::: {#some-identifier}
+This is the beginning of a div
+
+> This is a blockquote that contains three colons:
+> :::
+
+This is the end of a div
+:::
+
+Here are some extra colons that will be shown as just text:
+
+::::
+
+::: {.not-a-div}
+here is a code span `
+:::
+` that contains three colons
+
+::: {.some-classname}
+This is a div with a fenced code inside
+
+```
+:::
+```
+:::
+
+::: {.cit custom-style=raggedleft}
+I am a _fenced_ div
+:::
+
+::: {.cit custom-style=raggedleft}
+
+I am a _fenced_ div
+
+:::
+
+::: {.some-classname}
+This is not a div
+```
+:::
+```
+
+::: {.some-classname}
+This is not a div
+>>>
+documentBegin
+codeSpan: fencedDivs
+codeSpan: fencedCode
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+leftBrace
+hash
+rightBrace
+leftBrace
+rightBrace
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+blockQuoteBegin
+interblockSeparator
+leftBrace
+rightBrace
+blockQuoteEnd
+interblockSeparator
+interblockSeparator
+leftBrace
+hash
+rightBrace
+interblockSeparator
+blockQuoteBegin
+blockQuoteEnd
+interblockSeparator
+interblockSeparator
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+codeSpan:  ::: 
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+BEGIN fencedCode
+- src: ./_markdown_test/e441fcf4a7686817fe868bf38a5c2c07.verbatim
+- infostring: 
+END fencedCode
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+emphasis: fenced
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+emphasis: fenced
+interblockSeparator
+interblockSeparator
+leftBrace
+rightBrace
+interblockSeparator
+BEGIN fencedCode
+- src: ./_markdown_test/e441fcf4a7686817fe868bf38a5c2c07.verbatim
+- infostring: 
+END fencedCode
+interblockSeparator
+leftBrace
+rightBrace
+documentEnd


### PR DESCRIPTION
Closes #126.

### Tasks

1. [x] Port *fenced divs* and *bracketed spans* syntax extensions (see also [Pandoc documentation][2]) from [jgm#36][1].
    1. [x] Port *fenced div* and *bracketed span* readers.
    2. [x] Make *fenced div* and *bracketed span* writers produce attribute context renderers.
    3. [x] Enable the nesting of *fenced divs* (adapt from https://github.com/jgm/lunamark/pull/52).
    4. [x] Enable *fenced divs* with implicit classnames and trailing colons (see https://github.com/jgm/lunamark/pull/59).
2. [x] Add *fenced div* and *bracketed span* attribute context renderers.
3. [x] Add `blankBeforeDivFence`, `fencedDivs`, and `bracketedSpans` Lua options.
4. [x] Load *fenced divs* and *bracketed spans* syntax extensions in `M.new()`.
7. [x] Add tests
    1. [x] Port [unit tests][6] from [jgm#36][1] and [jgm#52][7]
        - [x] Add `testfiles/lunamark-markdown/fenced-divs.test`
        - [x] Fix the `blankBeforeCodeFence` option:
              The `no-blank-before-code-fence.test` test works, but `fenced-divs.test` fails.
        - [x] Add `testfiles/lunamark-markdown/no-fenced-divs.test`
        - [x] Add `testfiles/lunamark-markdown/bracketed-spans.test`
        - [x] Add `testfiles/lunamark-markdown/no-bracketed-spans.test`
    3. [x] Test the interplay between the `fencedDivs` and `blankBeforeDivFence` Lua options.
8. [x] Update `CHANGES.md`

 [1]: https://github.com/jgm/lunamark/pull/36
 [2]: https://pandoc.org/MANUAL.html#divs-and-spans
 [4]: https://github.com/jgm/lunamark/pull/36/files#diff-5fb2154f296ca8ff1b7f894e3538b512f889876cdb439fae78dd5c513573a5b4R3-R9
 [5]: https://github.com/jgm/lunamark/pull/36/files#diff-7027d9dae0bc4dd87c8f08bad12cbf696c6636e26101b03055824af82062ba36R3-R13
 [6]: https://github.com/jgm/lunamark/blob/master/tests/lunamark/ext_fenced_divs.test
 [7]: https://github.com/jgm/lunamark/pull/52