### PR TITLE
Sort Lua options, token renderers, and built-in syntax extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.19.0
+
+Refactoring:
+
+- Sort Lua options, token renderers, and built-in syntax extensions. (#208)
+
 ## 2.18.0 (2022-10-30)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -4694,6 +4694,130 @@ defaultOptions.eagerCache = true
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `expectJekyllData`
+
+`expectJekyllData` (default value: `false`)
+
+% \fi
+% \markdownBegin
+%
+% \Optitem[false]{expectJekyllData}{\opt{true}, \opt{false}}
+%
+:    false
+
+     :  When the \Opt{jekyllData} option is enabled, then a markdown document
+        may begin with \acro{yaml} metadata if and only if the metadata begin
+        with the end-of-directives marker (`---`) and they end with either the
+        end-of-directives or the end-of-document marker (`...`):
+
+        ~~~~~ latex
+        \documentclass{article}
+        \usepackage[jekyllData]{markdown}
+        \begin{document}
+        \begin{markdown}
+        ---
+        - this
+        - is
+        - YAML
+        ...
+        - followed
+        - by
+        - Markdown
+        \end{markdown}
+        \begin{markdown}
+        - this
+        - is
+        - Markdown
+        \end{markdown}
+        \end{document}
+        ~~~~~~~~~~~
+
+:    true
+
+     :  When the \Opt{jekyllData} option is enabled, then a markdown document may
+        begin directly with \acro{yaml} metadata and may contain nothing but
+        \acro{yaml} metadata.
+
+        ~~~~~ latex
+        \documentclass{article}
+        \usepackage[jekyllData, expectJekyllData]{markdown}
+        \begin{document}
+        \begin{markdown}
+        - this
+        - is
+        - YAML
+        ...
+        - followed
+        - by
+        - Markdown
+        \end{markdown}
+        \begin{markdown}
+        - this
+        - is
+        - YAML
+        \end{markdown}
+        \end{document}
+        ~~~~~~~~~~~
+
+% \markdownEnd
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `jane-doe.yml` with the
+following content:
+``` yaml
+name: Jane Doe
+age:  99
+```
+Using a text editor, create also a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[jekyllData]{markdown}
+\markdownSetup{
+  jekyllDataRenderers = {
+    name = {\gdef\name{#1}},
+    code = {\gdef\age{#1}},
+  },
+  renderers = {
+    jekyllDataEnd = {\name{} is \age{} years old.},
+  }
+}
+\begin{document}
+\markdownInput[expectJekyllData]{jane-doe.yml}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Jane Doe is 99 years old.
+
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { expectJekyllData }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.expectJekyllData = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `extensions`
 
 `extensions` (default value: `{}`)
@@ -4839,130 +4963,6 @@ following text:
 % \fi
 %  \begin{macrocode}
 defaultOptions.extensions = {}
-%    \end{macrocode}
-% \par
-% \iffalse
-%</lua,lua-cli>
-%<*manual-options>
-
-#### Option `expectJekyllData`
-
-`expectJekyllData` (default value: `false`)
-
-% \fi
-% \markdownBegin
-%
-% \Optitem[false]{expectJekyllData}{\opt{true}, \opt{false}}
-%
-:    false
-
-     :  When the \Opt{jekyllData} option is enabled, then a markdown document
-        may begin with \acro{yaml} metadata if and only if the metadata begin
-        with the end-of-directives marker (`---`) and they end with either the
-        end-of-directives or the end-of-document marker (`...`):
-
-        ~~~~~ latex
-        \documentclass{article}
-        \usepackage[jekyllData]{markdown}
-        \begin{document}
-        \begin{markdown}
-        ---
-        - this
-        - is
-        - YAML
-        ...
-        - followed
-        - by
-        - Markdown
-        \end{markdown}
-        \begin{markdown}
-        - this
-        - is
-        - Markdown
-        \end{markdown}
-        \end{document}
-        ~~~~~~~~~~~
-
-:    true
-
-     :  When the \Opt{jekyllData} option is enabled, then a markdown document may
-        begin directly with \acro{yaml} metadata and may contain nothing but
-        \acro{yaml} metadata.
-
-        ~~~~~ latex
-        \documentclass{article}
-        \usepackage[jekyllData, expectJekyllData]{markdown}
-        \begin{document}
-        \begin{markdown}
-        - this
-        - is
-        - YAML
-        ...
-        - followed
-        - by
-        - Markdown
-        \end{markdown}
-        \begin{markdown}
-        - this
-        - is
-        - YAML
-        \end{markdown}
-        \end{document}
-        ~~~~~~~~~~~
-
-% \markdownEnd
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `jane-doe.yml` with the
-following content:
-``` yaml
-name: Jane Doe
-age:  99
-```
-Using a text editor, create also a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[jekyllData]{markdown}
-\markdownSetup{
-  jekyllDataRenderers = {
-    name = {\gdef\name{#1}},
-    code = {\gdef\age{#1}},
-  },
-  renderers = {
-    jekyllDataEnd = {\name{} is \age{} years old.},
-  }
-}
-\begin{document}
-\markdownInput[expectJekyllData]{jane-doe.yml}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Jane Doe is 99 years old.
-
-%</manual-options>
-%<*tex>
-% \fi
-%  \begin{macrocode}
-\@@_add_lua_option:nnn
-  { expectJekyllData }
-  { boolean }
-  { false }
-%    \end{macrocode}
-% \iffalse
-%</tex>
-%<*lua,lua-cli>
-% \fi
-%  \begin{macrocode}
-defaultOptions.expectJekyllData = false
 %    \end{macrocode}
 % \par
 % \iffalse
@@ -5395,186 +5395,6 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 % \fi
 %  \begin{macrocode}
 defaultOptions.finalizeCache = false
-%    \end{macrocode}
-% \par
-% \iffalse
-%</lua,lua-cli>
-%<*manual-options>
-
-#### Option `notes`
-
-`notes` (default value: `false`)
-
-% \fi
-% \begin{markdown}
-%
-% \Optitem[false]{notes}{\opt{true}, \opt{false}}
-%
-:    true
-
-     :  Enable the Pandoc note syntax extension:
-
-        ``` md
-        Here is a note reference,[^1] and another.[^longnote]
-
-        [^1]: Here is the note.
-
-        [^longnote]: Here's one with multiple blocks.
-
-            Subsequent paragraphs are indented to show that they
-        belong to the previous note.
-
-                { some.code }
-
-            The whole paragraph can be indented, or just the
-            first line.  In this way, multi-paragraph notes
-            work like multi-paragraph list items.
-
-        This paragraph won't be part of the note, because it
-        isn't indented.
-        ``````
-
-:    false
-
-     :    Disable the Pandoc note syntax extension.
-
-% \end{markdown}
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[notes]{markdown}
-\begin{document}
-\begin{markdown}
-Here is a note reference,[^1] and another.[^longnote]
-
-[^1]: Here is the note.
-
-[^longnote]: Here's one with multiple blocks.
-
-    Subsequent paragraphs are indented to show that they
-belong to the previous note.
-
-        { some.code }
-
-    The whole paragraph can be indented, or just the
-    first line.  In this way, multi-paragraph notes
-    work like multi-paragraph list items.
-
-This paragraph won't be part of the note, because it
-isn't indented.
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Here is a note reference,[^1] and another.[^longnote]
-> 
-> [^1]: Here is the note.
-> 
-> [^longnote]: Here's one with multiple blocks.
-> 
->     Subsequent paragraphs are indented to show that they
-> belong to the previous note.
-> 
->         { some.code }
-> 
->     The whole paragraph can be indented, or just the
->     first line.  In this way, multi-paragraph notes
->     work like multi-paragraph list items.
-> 
-> This paragraph won't be part of the note, because it
-> isn't indented.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[notes = yes]
-\starttext
-\startmarkdown
-Here is a note reference,[^1] and another.[^longnote]
-
-[^1]: Here is the note.
-
-[^longnote]: Here's one with multiple blocks.
-
-    Subsequent paragraphs are indented to show that they
-belong to the previous note.
-
-        { some.code }
-
-    The whole paragraph can be indented, or just the
-    first line.  In this way, multi-paragraph notes
-    work like multi-paragraph list items.
-
-This paragraph won't be part of the note, because it
-isn't indented.
-\stopmarkdown
-\stoptext
-````````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-`````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Here is a note reference,[^1] and another.[^longnote]
-> 
-> [^1]: Here is the note.
-> 
-> [^longnote]: Here's one with multiple blocks.
-> 
->     Subsequent paragraphs are indented to show that they
-> belong to the previous note.
-> 
->         { some.code }
-> 
->     The whole paragraph can be indented, or just the
->     first line.  In this way, multi-paragraph notes
->     work like multi-paragraph list items.
-> 
-> This paragraph won't be part of the note, because it
-> isn't indented.
-
-%</manual-options>
-%<*tex>
-% \fi
-% \begin{markdown}
-%
-% The footnotes option has been deprecated and will be removed in
-% Markdown 3.0.0.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\@@_add_lua_option:nnn
-  { footnotes }
-  { boolean }
-  { false }
-\@@_add_lua_option:nnn
-  { notes }
-  { boolean }
-  { false }
-%    \end{macrocode}
-% \iffalse
-%</tex>
-%<*lua,lua-cli>
-% \fi
-%  \begin{macrocode}
-defaultOptions.footnotes = false
-defaultOptions.notes = false
 %    \end{macrocode}
 % \par
 % \iffalse
@@ -6657,6 +6477,186 @@ following text:
 % \fi
 %  \begin{macrocode}
 defaultOptions.jekyllData = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
+#### Option `notes`
+
+`notes` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{notes}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc note syntax extension:
+
+        ``` md
+        Here is a note reference,[^1] and another.[^longnote]
+
+        [^1]: Here is the note.
+
+        [^longnote]: Here's one with multiple blocks.
+
+            Subsequent paragraphs are indented to show that they
+        belong to the previous note.
+
+                { some.code }
+
+            The whole paragraph can be indented, or just the
+            first line.  In this way, multi-paragraph notes
+            work like multi-paragraph list items.
+
+        This paragraph won't be part of the note, because it
+        isn't indented.
+        ``````
+
+:    false
+
+     :    Disable the Pandoc note syntax extension.
+
+% \end{markdown}
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[notes]{markdown}
+\begin{document}
+\begin{markdown}
+Here is a note reference,[^1] and another.[^longnote]
+
+[^1]: Here is the note.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous note.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the
+    first line.  In this way, multi-paragraph notes
+    work like multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Here is a note reference,[^1] and another.[^longnote]
+> 
+> [^1]: Here is the note.
+> 
+> [^longnote]: Here's one with multiple blocks.
+> 
+>     Subsequent paragraphs are indented to show that they
+> belong to the previous note.
+> 
+>         { some.code }
+> 
+>     The whole paragraph can be indented, or just the
+>     first line.  In this way, multi-paragraph notes
+>     work like multi-paragraph list items.
+> 
+> This paragraph won't be part of the note, because it
+> isn't indented.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[notes = yes]
+\starttext
+\startmarkdown
+Here is a note reference,[^1] and another.[^longnote]
+
+[^1]: Here is the note.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous note.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the
+    first line.  In this way, multi-paragraph notes
+    work like multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+\stopmarkdown
+\stoptext
+````````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+`````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Here is a note reference,[^1] and another.[^longnote]
+> 
+> [^1]: Here is the note.
+> 
+> [^longnote]: Here's one with multiple blocks.
+> 
+>     Subsequent paragraphs are indented to show that they
+> belong to the previous note.
+> 
+>         { some.code }
+> 
+>     The whole paragraph can be indented, or just the
+>     first line.  In this way, multi-paragraph notes
+>     work like multi-paragraph list items.
+> 
+> This paragraph won't be part of the note, because it
+> isn't indented.
+
+%</manual-options>
+%<*tex>
+% \fi
+% \begin{markdown}
+%
+% The footnotes option has been deprecated and will be removed in
+% Markdown 3.0.0.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { footnotes }
+  { boolean }
+  { false }
+\@@_add_lua_option:nnn
+  { notes }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.footnotes = false
+defaultOptions.notes = false
 %    \end{macrocode}
 % \par
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23153,6 +23153,207 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
+%#### Fancy Lists
+%
+% The \luamdef{extensions.fancy_lists} function implements the Pandoc fancy
+% list extension.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.fancy_lists = function()
+  return {
+    name = "built-in fancy_lists syntax extension",
+    extend_writer = function(self)
+      local options = self.options
+
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->fancylist} as a function that will transform an
+% input ordered list to the output format, where:
+%
+%- `items` is an array of the list items,
+%- `tight` specifies, whether the list is tight or not,
+%- `startnum` is the number of the first list item,
+%- `numstyle` is the style of the list item labels from among the following:
+%    - `Decimal` -- decimal arabic numbers,
+%    - `LowerRoman` -- lower roman numbers,
+%    - `UpperRoman` -- upper roman numbers,
+%    - `LowerAlpha` -- lower ASCII alphabetic characters, and
+%    - `UpperAlpha` -- upper ASCII alphabetic characters, and
+%- `numdelim` is the style of delimiters between list item labels and
+%  texts from among the following:
+%    - `Default` -- default style,
+%    - `OneParen` -- parentheses, and
+%    - `Period` -- periods.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.fancylist(items,tight,startnum,numstyle,numdelim)
+        if not self.is_writing then return "" end
+        local buffer = {}
+        local num = startnum
+        for _,item in ipairs(items) do
+          buffer[#buffer + 1] = self.fancyitem(item,num)
+          if num ~= nil then
+            num = num + 1
+          end
+        end
+        local contents = util.intersperse(buffer,"\n")
+        if tight and options.tightLists then
+          return {"\\markdownRendererFancyOlBeginTight{",
+                  numstyle,"}{",numdelim,"}",contents,
+                  "\n\\markdownRendererFancyOlEndTight "}
+        else
+          return {"\\markdownRendererFancyOlBegin{",
+                  numstyle,"}{",numdelim,"}",contents,
+                  "\n\\markdownRendererFancyOlEnd "}
+        end
+      end
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Define \luamdef{writer->fancyitem} as a function that will transform an
+% input fancy ordered list item to the output format, where `s` is the text of
+% the list item. If the optional parameter `num` is present, it is the number
+% of the list item.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.fancyitem(s,num)
+        if num ~= nil then
+          return {"\\markdownRendererFancyOlItemWithNumber{",num,"}",s,
+                  "\\markdownRendererFancyOlItemEnd "}
+        else
+          return {"\\markdownRendererFancyOlItem ",s,"\\markdownRendererFancyOlItemEnd "}
+        end
+      end
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local options = self.options
+      local writer = self.writer
+
+      local label = parsers.dig + parsers.letter
+      local numdelim = parsers.period + parsers.rparent
+      local enumerator = C(label^3 * numdelim) * #parsers.spacing
+                       + C(label^2 * numdelim) * #parsers.spacing
+                                         * (parsers.tab + parsers.space^1)
+                       + C(label * numdelim) * #parsers.spacing
+                                       * (parsers.tab + parsers.space^-2)
+                       + parsers.space * C(label^2 * numdelim)
+                                       * #parsers.spacing
+                       + parsers.space * C(label * numdelim)
+                                       * #parsers.spacing
+                                       * (parsers.tab + parsers.space^-1)
+                       + parsers.space * parsers.space * C(label^1
+                                       * numdelim) * #parsers.spacing
+      local starter = parsers.bullet + enumerator
+
+      local NestedList = Cs((parsers.optionallyindentedline
+                            - starter)^1)
+                       / function(a) return "\001"..a end
+
+      local ListBlockLine  = parsers.optionallyindentedline
+                           - parsers.blankline - (parsers.indent^-1
+                                                 * starter)
+
+      local ListBlock = parsers.line * ListBlockLine^0
+
+      local ListContinuationBlock = parsers.blanklines * (parsers.indent / "")
+                                  * ListBlock
+
+      local TightListItem = function(starter)
+          return -parsers.ThematicBreak
+                 * (Cs(starter / "" * parsers.tickbox^-1 * ListBlock * NestedList^-1)
+                   / self.parser_functions.parse_blocks_nested)
+                 * -(parsers.blanklines * parsers.indent)
+      end
+
+      local LooseListItem = function(starter)
+          return -parsers.ThematicBreak
+                 * Cs( starter / "" * parsers.tickbox^-1 * ListBlock * Cc("\n")
+                   * (NestedList + ListContinuationBlock^0)
+                   * (parsers.blanklines / "\n\n")
+                   ) / self.parser_functions.parse_blocks_nested
+      end
+
+      local function roman2number(roman)
+        local romans = { ["L"] = 50, ["X"] = 10, ["V"] = 5, ["I"] = 1 }
+        local numeral = 0
+
+        local i = 1
+        local len = string.len(roman)
+        while i < len do
+          local z1, z2 = romans[ string.sub(roman, i, i) ], romans[ string.sub(roman, i+1, i+1) ]
+          if z1 < z2 then
+              numeral = numeral + (z2 - z1)
+              i = i + 2
+          else
+              numeral = numeral + z1
+              i = i + 1
+          end
+        end
+        if i <= len then numeral = numeral + romans[ string.sub(roman,i,i) ] end
+        return numeral
+      end
+
+      local function sniffstyle(itemprefix)
+        local numstr, delimend = itemprefix:match("^([A-Za-z0-9]*)([.)]*)")
+        local numdelim
+        if delimend == ")" then
+          numdelim = "OneParen"
+        elseif delimend == "." then
+          numdelim = "Period"
+        else
+          numdelim = "Default"
+        end
+        numstr = numstr or itemprefix
+
+        local num
+        num = numstr:match("^([IVXL]+)")
+        if num then
+          return roman2number(num), "UpperRoman", numdelim
+        end
+        num = numstr:match("^([ivxl]+)")
+        if num then
+          return roman2number(string.upper(num)), "LowerRoman", numdelim
+        end
+        num = numstr:match("^([A-Z])")
+        if num then
+          return string.byte(num) - string.byte("A") + 1, "UpperAlpha", numdelim
+        end
+        num = numstr:match("^([a-z])")
+        if num then
+          return string.byte(num) - string.byte("a") + 1, "LowerAlpha", numdelim
+        end
+        return math.floor(tonumber(numstr) or 1), "Decimal", numdelim
+      end
+
+      local function fancylist(items,tight,start)
+        local startnum, numstyle, numdelim = sniffstyle(start)
+        return writer.fancylist(items,tight,
+                                options.startNumber and startnum,
+                                numstyle or "Decimal",
+                                numdelim or "Default")
+      end
+
+      local FancyList = Cg(enumerator, "listtype") *
+                      ( Ct(TightListItem(Cb("listtype"))
+                          * TightListItem(enumerator)^0)
+                      * Cc(true) * parsers.skipblanklines * -enumerator
+                      + Ct(LooseListItem(Cb("listtype"))
+                          * LooseListItem(enumerator)^0)
+                      * Cc(false) * parsers.skipblanklines
+                      ) * Cb("listtype") / fancylist
+
+      self.update_rule("OrderedList", FancyList)
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
 %#### Fenced Code
 %
 % The \luamdef{extensions.fenced_code} function implements the commonmark
@@ -23211,6 +23412,71 @@ M.extensions.fenced_code = function(blank_before_code_fence)
       self.update_rule("EndlineExceptions", EndlineExceptions)
 
       self.add_special_character("~")
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### Header Attributes
+%
+% The \luamdef{extensions.header_attributes} function implements a syntax
+% extension that enables the assignment of HTML attributes to headings.
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.header_attributes = function()
+  return {
+    name = "built-in header_attributes syntax extension",
+    extend_writer = function()
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local writer = self.writer
+
+      local AtxHeading = Cg(parsers.heading_start, "level")
+                       * parsers.optionalspace
+                       * (C(((parsers.linechar
+                             - ((parsers.hash^1
+                                * parsers.optionalspace
+                                * parsers.attributes^-1
+                                + parsers.attributes)
+                               * parsers.optionalspace
+                               * parsers.newline))
+                            * (parsers.linechar
+                              - parsers.hash
+                              - parsers.lbrace)^0)^1)
+                           / self.parser_functions.parse_inlines)
+                       * Cg(Ct(parsers.newline
+                              + (parsers.hash^1
+                                * parsers.optionalspace
+                                * parsers.attributes^-1
+                                + parsers.attributes)
+                              * parsers.optionalspace
+                              * parsers.newline), "attributes")
+                       * Cb("level")
+                       * Cb("attributes")
+                       / writer.heading
+
+      local SetextHeading = #(parsers.line * S("=-"))
+                          * (C(((parsers.linechar
+                                - (parsers.attributes
+                                  * parsers.optionalspace
+                                  * parsers.newline))
+                               * (parsers.linechar
+                                 - parsers.lbrace)^0)^1)
+                              / self.parser_functions.parse_inlines)
+                          * Cg(Ct(parsers.newline
+                                 + (parsers.attributes
+                                   * parsers.optionalspace
+                                   * parsers.newline)), "attributes")
+                          * parsers.heading_level
+                          * Cb("attributes")
+                          * parsers.optionalspace
+                          * parsers.newline
+                          / writer.heading
+
+      local Heading = AtxHeading + SetextHeading
+      self.update_rule("Heading", Heading)
     end
   }
 end
@@ -23302,228 +23568,6 @@ M.extensions.notes = function(notes, inline_notes)
       end
 
       self.add_special_character("^")
-    end
-  }
-end
-%    \end{macrocode}
-% \begin{markdown}
-%
-%#### Header Attributes
-%
-% The \luamdef{extensions.header_attributes} function implements a syntax
-% extension that enables the assignment of HTML attributes to headings.
-%
-% \end{markdown}
-%  \begin{macrocode}
-M.extensions.header_attributes = function()
-  return {
-    name = "built-in header_attributes syntax extension",
-    extend_writer = function()
-    end, extend_reader = function(self)
-      local parsers = self.parsers
-      local writer = self.writer
-
-      local AtxHeading = Cg(parsers.heading_start, "level")
-                       * parsers.optionalspace
-                       * (C(((parsers.linechar
-                             - ((parsers.hash^1
-                                * parsers.optionalspace
-                                * parsers.attributes^-1
-                                + parsers.attributes)
-                               * parsers.optionalspace
-                               * parsers.newline))
-                            * (parsers.linechar
-                              - parsers.hash
-                              - parsers.lbrace)^0)^1)
-                           / self.parser_functions.parse_inlines)
-                       * Cg(Ct(parsers.newline
-                              + (parsers.hash^1
-                                * parsers.optionalspace
-                                * parsers.attributes^-1
-                                + parsers.attributes)
-                              * parsers.optionalspace
-                              * parsers.newline), "attributes")
-                       * Cb("level")
-                       * Cb("attributes")
-                       / writer.heading
-
-      local SetextHeading = #(parsers.line * S("=-"))
-                          * (C(((parsers.linechar
-                                - (parsers.attributes
-                                  * parsers.optionalspace
-                                  * parsers.newline))
-                               * (parsers.linechar
-                                 - parsers.lbrace)^0)^1)
-                              / self.parser_functions.parse_inlines)
-                          * Cg(Ct(parsers.newline
-                                 + (parsers.attributes
-                                   * parsers.optionalspace
-                                   * parsers.newline)), "attributes")
-                          * parsers.heading_level
-                          * Cb("attributes")
-                          * parsers.optionalspace
-                          * parsers.newline
-                          / writer.heading
-
-      local Heading = AtxHeading + SetextHeading
-      self.update_rule("Heading", Heading)
-    end
-  }
-end
-%    \end{macrocode}
-% \begin{markdown}
-%
-%#### YAML Metadata
-%
-% The \luamdef{extensions.jekyll_data} function implements the Pandoc
-% `yaml_metadata_block` syntax extension for entering metadata in \acro{yaml}.
-% When the `expect_jekyll_data` parameter is `true`, then a markdown document
-% may begin directly with \acro{yaml} metadata and may contain nothing but
-% \acro{yaml} metadata
-%
-% \end{markdown}
-%  \begin{macrocode}
-M.extensions.jekyll_data = function(expect_jekyll_data)
-  return {
-    name = "built-in jekyll_data syntax extension",
-    extend_writer = function(self)
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% Define \luamdef{writer->jekyllData} as a function that will transform an
-% input \acro{yaml} table `d` to the output format. The table is the value for
-% the key `p` in the parent table; if `p` is nil, then the table has no parent.
-% All scalar keys and values encountered in the table will be cast to a string
-% following \acro{yaml} serialization rules. String values will also be
-% transformed using the function `t`.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      function self.jekyllData(d, t, p)
-        if not self.is_writing then return "" end
-
-        local buf = {}
-
-        local keys = {}
-        for k, _ in pairs(d) do
-          table.insert(keys, k)
-        end
-        table.sort(keys)
-
-        if not p then
-          table.insert(buf, "\\markdownRendererJekyllDataBegin")
-        end
-
-        if #d > 0 then
-            table.insert(buf, "\\markdownRendererJekyllDataSequenceBegin{")
-            table.insert(buf, self.uri(p or "null"))
-            table.insert(buf, "}{")
-            table.insert(buf, #keys)
-            table.insert(buf, "}")
-        else
-            table.insert(buf, "\\markdownRendererJekyllDataMappingBegin{")
-            table.insert(buf, self.uri(p or "null"))
-            table.insert(buf, "}{")
-            table.insert(buf, #keys)
-            table.insert(buf, "}")
-        end
-
-        for _, k in ipairs(keys) do
-          local v = d[k]
-          local typ = type(v)
-          k = tostring(k or "null")
-          if typ == "table" and next(v) ~= nil then
-            table.insert(
-              buf,
-              self.jekyllData(v, t, k)
-            )
-          else
-            k = self.uri(k)
-            v = tostring(v)
-            if typ == "boolean" then
-              table.insert(buf, "\\markdownRendererJekyllDataBoolean{")
-              table.insert(buf, k)
-              table.insert(buf, "}{")
-              table.insert(buf, v)
-              table.insert(buf, "}")
-            elseif typ == "number" then
-              table.insert(buf, "\\markdownRendererJekyllDataNumber{")
-              table.insert(buf, k)
-              table.insert(buf, "}{")
-              table.insert(buf, v)
-              table.insert(buf, "}")
-            elseif typ == "string" then
-              table.insert(buf, "\\markdownRendererJekyllDataString{")
-              table.insert(buf, k)
-              table.insert(buf, "}{")
-              table.insert(buf, t(v))
-              table.insert(buf, "}")
-            elseif typ == "table" then
-              table.insert(buf, "\\markdownRendererJekyllDataEmpty{")
-              table.insert(buf, k)
-              table.insert(buf, "}")
-            else
-              error(format("Unexpected type %s for value of " ..
-                           "YAML key %s", typ, k))
-            end
-          end
-        end
-
-        if #d > 0 then
-          table.insert(buf, "\\markdownRendererJekyllDataSequenceEnd")
-        else
-          table.insert(buf, "\\markdownRendererJekyllDataMappingEnd")
-        end
-
-        if not p then
-          table.insert(buf, "\\markdownRendererJekyllDataEnd")
-        end
-
-        return buf
-      end
-    end, extend_reader = function(self)
-      local parsers = self.parsers
-      local writer = self.writer
-
-      local JekyllData
-                    = Cmt( C((parsers.line - P("---") - P("..."))^0)
-                         , function(s, i, text) -- luacheck: ignore s i
-                             local data
-                             local ran_ok, _ = pcall(function()
-                               local tinyyaml = require("markdown-tinyyaml")
-                               data = tinyyaml.parse(text, {timestamps=false})
-                             end)
-                             if ran_ok and data ~= nil then
-                               return true, writer.jekyllData(data, function(s)
-                                 return self.parser_functions.parse_blocks_nested(s)
-                               end, nil)
-                             else
-                               return false
-                             end
-                           end
-                         )
-
-      local UnexpectedJekyllData
-                    = P("---")
-                    * parsers.blankline / 0
-                    * #(-parsers.blankline)  -- if followed by blank, it's thematic break
-                    * JekyllData
-                    * (P("---") + P("..."))
-
-      local ExpectedJekyllData
-                    = ( P("---")
-                      * parsers.blankline / 0
-                      * #(-parsers.blankline)  -- if followed by blank, it's thematic break
-                      )^-1
-                    * JekyllData
-                    * (P("---") + P("..."))^-1
-
-      self.insert_pattern("Block before Blockquote",
-                          UnexpectedJekyllData, "UnexpectedJekyllData")
-      if expect_jekyll_data then
-        self.update_rule("ExpectedJekyllData", ExpectedJekyllData)
-      end
     end
   }
 end
@@ -23822,47 +23866,6 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-%#### Superscripts
-%
-% The \luamdef{extensions.superscripts} function implements the Pandoc
-% superscript syntax extension.
-%
-% \end{markdown}
-%  \begin{macrocode}
-M.extensions.superscripts = function()
-  return {
-    name = "built-in superscripts syntax extension",
-    extend_writer = function(self)
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% Define \luamdef{writer->superscript} as a function that will transform
-% a superscript span `s` of input text to the output format.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      function self.superscript(s)
-        return {"\\markdownRendererSuperscript{",s,"}"}
-      end
-    end, extend_reader = function(self)
-      local parsers = self.parsers
-      local writer = self.writer
-
-      local Superscript = (
-        parsers.between(parsers.Str, parsers.circumflex, parsers.circumflex)
-      ) / writer.superscript
-
-      self.insert_pattern("Inline after Emph",
-                          Superscript, "Superscript")
-
-      self.add_special_character("^")
-    end
-  }
-end
-%    \end{macrocode}
-% \begin{markdown}
-%
 %#### Subscripts
 %
 % The \luamdef{extensions.subscripts} function implements the Pandoc
@@ -23904,201 +23907,198 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-%#### Fancy Lists
+%#### Superscripts
 %
-% The \luamdef{extensions.fancy_lists} function implements the Pandoc fancy
-% list extension.
+% The \luamdef{extensions.superscripts} function implements the Pandoc
+% superscript syntax extension.
 %
 % \end{markdown}
 %  \begin{macrocode}
-M.extensions.fancy_lists = function()
+M.extensions.superscripts = function()
   return {
-    name = "built-in fancy_lists syntax extension",
+    name = "built-in superscripts syntax extension",
     extend_writer = function(self)
-      local options = self.options
-
 %    \end{macrocode}
 % \par
 % \begin{markdown}
 %
-% Define \luamdef{writer->fancylist} as a function that will transform an
-% input ordered list to the output format, where:
-%
-%- `items` is an array of the list items,
-%- `tight` specifies, whether the list is tight or not,
-%- `startnum` is the number of the first list item,
-%- `numstyle` is the style of the list item labels from among the following:
-%    - `Decimal` -- decimal arabic numbers,
-%    - `LowerRoman` -- lower roman numbers,
-%    - `UpperRoman` -- upper roman numbers,
-%    - `LowerAlpha` -- lower ASCII alphabetic characters, and
-%    - `UpperAlpha` -- upper ASCII alphabetic characters, and
-%- `numdelim` is the style of delimiters between list item labels and
-%  texts from among the following:
-%    - `Default` -- default style,
-%    - `OneParen` -- parentheses, and
-%    - `Period` -- periods.
+% Define \luamdef{writer->superscript} as a function that will transform
+% a superscript span `s` of input text to the output format.
 %
 % \end{markdown}
 %  \begin{macrocode}
-      function self.fancylist(items,tight,startnum,numstyle,numdelim)
-        if not self.is_writing then return "" end
-        local buffer = {}
-        local num = startnum
-        for _,item in ipairs(items) do
-          buffer[#buffer + 1] = self.fancyitem(item,num)
-          if num ~= nil then
-            num = num + 1
-          end
-        end
-        local contents = util.intersperse(buffer,"\n")
-        if tight and options.tightLists then
-          return {"\\markdownRendererFancyOlBeginTight{",
-                  numstyle,"}{",numdelim,"}",contents,
-                  "\n\\markdownRendererFancyOlEndTight "}
-        else
-          return {"\\markdownRendererFancyOlBegin{",
-                  numstyle,"}{",numdelim,"}",contents,
-                  "\n\\markdownRendererFancyOlEnd "}
-        end
-      end
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Define \luamdef{writer->fancyitem} as a function that will transform an
-% input fancy ordered list item to the output format, where `s` is the text of
-% the list item. If the optional parameter `num` is present, it is the number
-% of the list item.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      function self.fancyitem(s,num)
-        if num ~= nil then
-          return {"\\markdownRendererFancyOlItemWithNumber{",num,"}",s,
-                  "\\markdownRendererFancyOlItemEnd "}
-        else
-          return {"\\markdownRendererFancyOlItem ",s,"\\markdownRendererFancyOlItemEnd "}
-        end
+      function self.superscript(s)
+        return {"\\markdownRendererSuperscript{",s,"}"}
       end
     end, extend_reader = function(self)
       local parsers = self.parsers
-      local options = self.options
       local writer = self.writer
 
-      local label = parsers.dig + parsers.letter
-      local numdelim = parsers.period + parsers.rparent
-      local enumerator = C(label^3 * numdelim) * #parsers.spacing
-                       + C(label^2 * numdelim) * #parsers.spacing
-                                         * (parsers.tab + parsers.space^1)
-                       + C(label * numdelim) * #parsers.spacing
-                                       * (parsers.tab + parsers.space^-2)
-                       + parsers.space * C(label^2 * numdelim)
-                                       * #parsers.spacing
-                       + parsers.space * C(label * numdelim)
-                                       * #parsers.spacing
-                                       * (parsers.tab + parsers.space^-1)
-                       + parsers.space * parsers.space * C(label^1
-                                       * numdelim) * #parsers.spacing
-      local starter = parsers.bullet + enumerator
+      local Superscript = (
+        parsers.between(parsers.Str, parsers.circumflex, parsers.circumflex)
+      ) / writer.superscript
 
-      local NestedList = Cs((parsers.optionallyindentedline
-                            - starter)^1)
-                       / function(a) return "\001"..a end
+      self.insert_pattern("Inline after Emph",
+                          Superscript, "Superscript")
 
-      local ListBlockLine  = parsers.optionallyindentedline
-                           - parsers.blankline - (parsers.indent^-1
-                                                 * starter)
+      self.add_special_character("^")
+    end
+  }
+end
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### YAML Metadata
+%
+% The \luamdef{extensions.jekyll_data} function implements the Pandoc
+% `yaml_metadata_block` syntax extension for entering metadata in \acro{yaml}.
+% When the `expect_jekyll_data` parameter is `true`, then a markdown document
+% may begin directly with \acro{yaml} metadata and may contain nothing but
+% \acro{yaml} metadata
+%
+% \end{markdown}
+%  \begin{macrocode}
+M.extensions.jekyll_data = function(expect_jekyll_data)
+  return {
+    name = "built-in jekyll_data syntax extension",
+    extend_writer = function(self)
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->jekyllData} as a function that will transform an
+% input \acro{yaml} table `d` to the output format. The table is the value for
+% the key `p` in the parent table; if `p` is nil, then the table has no parent.
+% All scalar keys and values encountered in the table will be cast to a string
+% following \acro{yaml} serialization rules. String values will also be
+% transformed using the function `t`.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.jekyllData(d, t, p)
+        if not self.is_writing then return "" end
 
-      local ListBlock = parsers.line * ListBlockLine^0
+        local buf = {}
 
-      local ListContinuationBlock = parsers.blanklines * (parsers.indent / "")
-                                  * ListBlock
+        local keys = {}
+        for k, _ in pairs(d) do
+          table.insert(keys, k)
+        end
+        table.sort(keys)
 
-      local TightListItem = function(starter)
-          return -parsers.ThematicBreak
-                 * (Cs(starter / "" * parsers.tickbox^-1 * ListBlock * NestedList^-1)
-                   / self.parser_functions.parse_blocks_nested)
-                 * -(parsers.blanklines * parsers.indent)
-      end
+        if not p then
+          table.insert(buf, "\\markdownRendererJekyllDataBegin")
+        end
 
-      local LooseListItem = function(starter)
-          return -parsers.ThematicBreak
-                 * Cs( starter / "" * parsers.tickbox^-1 * ListBlock * Cc("\n")
-                   * (NestedList + ListContinuationBlock^0)
-                   * (parsers.blanklines / "\n\n")
-                   ) / self.parser_functions.parse_blocks_nested
-      end
+        if #d > 0 then
+            table.insert(buf, "\\markdownRendererJekyllDataSequenceBegin{")
+            table.insert(buf, self.uri(p or "null"))
+            table.insert(buf, "}{")
+            table.insert(buf, #keys)
+            table.insert(buf, "}")
+        else
+            table.insert(buf, "\\markdownRendererJekyllDataMappingBegin{")
+            table.insert(buf, self.uri(p or "null"))
+            table.insert(buf, "}{")
+            table.insert(buf, #keys)
+            table.insert(buf, "}")
+        end
 
-      local function roman2number(roman)
-        local romans = { ["L"] = 50, ["X"] = 10, ["V"] = 5, ["I"] = 1 }
-        local numeral = 0
-
-        local i = 1
-        local len = string.len(roman)
-        while i < len do
-          local z1, z2 = romans[ string.sub(roman, i, i) ], romans[ string.sub(roman, i+1, i+1) ]
-          if z1 < z2 then
-              numeral = numeral + (z2 - z1)
-              i = i + 2
+        for _, k in ipairs(keys) do
+          local v = d[k]
+          local typ = type(v)
+          k = tostring(k or "null")
+          if typ == "table" and next(v) ~= nil then
+            table.insert(
+              buf,
+              self.jekyllData(v, t, k)
+            )
           else
-              numeral = numeral + z1
-              i = i + 1
+            k = self.uri(k)
+            v = tostring(v)
+            if typ == "boolean" then
+              table.insert(buf, "\\markdownRendererJekyllDataBoolean{")
+              table.insert(buf, k)
+              table.insert(buf, "}{")
+              table.insert(buf, v)
+              table.insert(buf, "}")
+            elseif typ == "number" then
+              table.insert(buf, "\\markdownRendererJekyllDataNumber{")
+              table.insert(buf, k)
+              table.insert(buf, "}{")
+              table.insert(buf, v)
+              table.insert(buf, "}")
+            elseif typ == "string" then
+              table.insert(buf, "\\markdownRendererJekyllDataString{")
+              table.insert(buf, k)
+              table.insert(buf, "}{")
+              table.insert(buf, t(v))
+              table.insert(buf, "}")
+            elseif typ == "table" then
+              table.insert(buf, "\\markdownRendererJekyllDataEmpty{")
+              table.insert(buf, k)
+              table.insert(buf, "}")
+            else
+              error(format("Unexpected type %s for value of " ..
+                           "YAML key %s", typ, k))
+            end
           end
         end
-        if i <= len then numeral = numeral + romans[ string.sub(roman,i,i) ] end
-        return numeral
-      end
 
-      local function sniffstyle(itemprefix)
-        local numstr, delimend = itemprefix:match("^([A-Za-z0-9]*)([.)]*)")
-        local numdelim
-        if delimend == ")" then
-          numdelim = "OneParen"
-        elseif delimend == "." then
-          numdelim = "Period"
+        if #d > 0 then
+          table.insert(buf, "\\markdownRendererJekyllDataSequenceEnd")
         else
-          numdelim = "Default"
+          table.insert(buf, "\\markdownRendererJekyllDataMappingEnd")
         end
-        numstr = numstr or itemprefix
 
-        local num
-        num = numstr:match("^([IVXL]+)")
-        if num then
-          return roman2number(num), "UpperRoman", numdelim
+        if not p then
+          table.insert(buf, "\\markdownRendererJekyllDataEnd")
         end
-        num = numstr:match("^([ivxl]+)")
-        if num then
-          return roman2number(string.upper(num)), "LowerRoman", numdelim
-        end
-        num = numstr:match("^([A-Z])")
-        if num then
-          return string.byte(num) - string.byte("A") + 1, "UpperAlpha", numdelim
-        end
-        num = numstr:match("^([a-z])")
-        if num then
-          return string.byte(num) - string.byte("a") + 1, "LowerAlpha", numdelim
-        end
-        return math.floor(tonumber(numstr) or 1), "Decimal", numdelim
+
+        return buf
       end
+    end, extend_reader = function(self)
+      local parsers = self.parsers
+      local writer = self.writer
 
-      local function fancylist(items,tight,start)
-        local startnum, numstyle, numdelim = sniffstyle(start)
-        return writer.fancylist(items,tight,
-                                options.startNumber and startnum,
-                                numstyle or "Decimal",
-                                numdelim or "Default")
+      local JekyllData
+                    = Cmt( C((parsers.line - P("---") - P("..."))^0)
+                         , function(s, i, text) -- luacheck: ignore s i
+                             local data
+                             local ran_ok, _ = pcall(function()
+                               local tinyyaml = require("markdown-tinyyaml")
+                               data = tinyyaml.parse(text, {timestamps=false})
+                             end)
+                             if ran_ok and data ~= nil then
+                               return true, writer.jekyllData(data, function(s)
+                                 return self.parser_functions.parse_blocks_nested(s)
+                               end, nil)
+                             else
+                               return false
+                             end
+                           end
+                         )
+
+      local UnexpectedJekyllData
+                    = P("---")
+                    * parsers.blankline / 0
+                    * #(-parsers.blankline)  -- if followed by blank, it's thematic break
+                    * JekyllData
+                    * (P("---") + P("..."))
+
+      local ExpectedJekyllData
+                    = ( P("---")
+                      * parsers.blankline / 0
+                      * #(-parsers.blankline)  -- if followed by blank, it's thematic break
+                      )^-1
+                    * JekyllData
+                    * (P("---") + P("..."))^-1
+
+      self.insert_pattern("Block before Blockquote",
+                          UnexpectedJekyllData, "UnexpectedJekyllData")
+      if expect_jekyll_data then
+        self.update_rule("ExpectedJekyllData", ExpectedJekyllData)
       end
-
-      local FancyList = Cg(enumerator, "listtype") *
-                      ( Ct(TightListItem(Cb("listtype"))
-                          * TightListItem(enumerator)^0)
-                      * Cc(true) * parsers.skipblanklines * -enumerator
-                      + Ct(LooseListItem(Cb("listtype"))
-                          * LooseListItem(enumerator)^0)
-                      * Cc(false) * parsers.skipblanklines
-                      ) * Cb("listtype") / fancylist
-
-      self.update_rule("OrderedList", FancyList)
     end
   }
 end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -9690,119 +9690,6 @@ In this section, I will describe the individual token renderers.
 \prop_new:N \g_@@_renderer_arities_prop
 \ExplSyntaxOff
 %    \end{macrocode}
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-% \begin{markdown}
-
-#### Tickbox Renderers
-The macros named \mdef{markdownRendererTickedBox},
-\mdef{markdownRendererHalfTickedBox}, and \mdef{markdownRendererUntickedBox}
-represent ticked and unticked boxes, respectively. These macros will either be
-produced, when the \Opt{taskLists} option is enabled, or when the Ballot Box
-with X (☒, U+2612), Hourglass (⌛, U+231B) or Ballot Box (☐, U+2610) Unicode
-characters are encountered in the markdown input, respectively.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[taskLists]{markdown}
-\markdownSetup{
-  renderers = {
-    untickedBox = No,
-    tickedBox = Yes,
-  },
-}
-\begin{document}
-\begin{markdown}
-- [ ] you can't.
-- [x] I can!
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> - No you can't.
-> - Yes I can!
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[taskLists = yes]
-\def\markdownRendererUntickedBox{No}
-\def\markdownRendererTickedBox{Yes}
-\starttext
-\startmarkdown
-- [ ] you can't.
-- [x] I can!
-\stopmarkdown
-\stoptext
-````````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-`````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> - No you can't.
-> - Yes I can!
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererTickedBox{%
-  \markdownRendererTickedBoxPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { tickedBox }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { tickedBox }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererHalfTickedBox{%
-  \markdownRendererHalfTickedBoxPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { halfTickedBox }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { halfTickedBox }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererUntickedBox{%
-  \markdownRendererUntickedBoxPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { untickedBox }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { untickedBox }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
 % \par
 %
 % \iffalse
@@ -9812,15 +9699,25 @@ following text:
 %
 % \begin{markdown}
 
-#### Markdown Document Renderers
-The \mdef{markdownRendererDocumentBegin} and \mdef{markdownRendererDocumentEnd}
-macros represent the beginning and the end of a *markdown* document. The macros
-receive no arguments.
+#### Attribute Renderers
+The following macros are only produced, when the \Opt{headerAttributes} option
+is enabled.
 
-A \TeX{} document may contain any number of markdown documents. Additionally,
-markdown documents may appear not only in a sequence, but several markdown
-documents may also be *nested*. Redefinitions of the macros should take this
-into account.
+\mdef{markdownRendererAttributeIdentifier} represents the \meta{identifier} of
+a markdown element (`id="`\meta{identifier}`"` in HTML and `#`\meta{identifier}
+in Markdown's \Opt{headerAttributes} syntax extension). The macro receives a
+single attribute that corresponds to the \meta{identifier}.
+
+\mdef{markdownRendererAttributeClassName} represents the \meta{class name} of a
+markdown element (`class="`\meta{class name} ...`"` in HTML and
+`.`\meta{class name} in Markdown's \Opt{headerAttributes} syntax extension).
+The macro receives a single attribute that corresponds to the \meta{class
+name}.
+
+\mdef{markdownRendererAttributeKeyValue} represents a HTML attribute in the form
+\meta{key}`=`\meta{value} that is neither an identifier nor a class name.
+The macro receives two attributes that correspond to the \meta{key} and the
+\meta{value}, respectively.
 
 % \end{markdown}
 %
@@ -9828,75 +9725,38 @@ into account.
 
 ##### \LaTeX{} Example {.unnumbered}
 
-Using a text editor, create a text document named `nested.md` with the
-following content:
-``` md
-This is a *nested* markdown document.
-```
-
 Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \documentclass{article}
-\usepackage[contentBlocks]{markdown}
+\usepackage[headerAttributes, underscores=false]{markdown}
 \markdownSetup{
   renderers = {
-    contentBlock = {%
-      \markdownInput{#3}%
-    },
-    documentBegin = {%
+    attributeIdentifier = {%
       \par
-      \emph{(The beginning of a document)}
-      \par
-      \begingroup
-      \markdownSetup{snippet=first-nesting-level}%
-    },
-    documentEnd = {%
-      \endgroup
-      \par
-      \emph{(The end of a document)}
+      \emph{(Identifier: #1)}
       \par
     },
-  },
-}
-\markdownSetupSnippet{first-nesting-level}{
-  renderers = {
-    documentBegin = {
+    attributeClassName = {%
       \par
-      \emph{(The beginning of a nested document)}
+      \emph{(Class name: #1)}
       \par
-      \begingroup
-      \markdownSetup{snippet=second-nesting-level-and-below}
     },
-  },
-}
-\markdownSetupSnippet{second-nesting-level-and-below}{
-  renderers = {
-    documentBegin = {
+    attributeKeyValue = {%
       \par
-      \emph{(The beginning of a nested document)}
-      \par
-      \begingroup
-    },
-    documentEnd = {
-      \endgroup
-      \par
-      \emph{(The end of a nested document)}
+      \emph{(Key: #1, Value: #2)}
       \par
     },
   },
 }
 \begin{document}
 \begin{markdown}
-Hello *world*!
 
-/nested.md
+# First top-level heading {jane=doe}
 
-_Foo_ bar!
-\end{markdown}
-\begin{markdown}
+## A subheading {#identifier}
 
-Bar baz!
+# Second top-level heading {.class_name}
 
 \end{markdown}
 \end{document}
@@ -9908,909 +9768,56 @@ lualatex document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> *(The beginning of a document)*
+> # First top-level heading
 >
-> Hello *world*!
+> *(Key: Jane, Value: Doe)*
 >
-> *(The beginning of a nested document)*
+> ## A subheading
 >
-> This is a *nested* markdown document.
+> *(Identifier: identifier)*
 >
-> *(The end of a nested document)*
+> # Second top-level heading
 >
-> _Foo_ bar!
->
-> *(The end of a document)*
->
-> *(The beginning of a document)*
->
-> Bar baz!
->
-> *(The end of a document)*
+> *(Class name: class\_name)*
 
 %</manual-tokens>
 %<*tex>
 % \fi
 %
 %  \begin{macrocode}
-\def\markdownRendererDocumentBegin{%
-  \markdownRendererDocumentBeginPrototype}%
+\def\markdownRendererAttributeIdentifier{%
+  \markdownRendererAttributeIdentifierPrototype}%
 \ExplSyntaxOn
 \seq_gput_right:Nn
   \g_@@_renderers_seq
-  { documentBegin }
+  { attributeIdentifier }
 \prop_gput:Nnn
   \g_@@_renderer_arities_prop
-  { documentBegin }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererDocumentEnd{%
-  \markdownRendererDocumentEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { documentEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { documentEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Interblock Separator Renderer
-The \mdef{markdownRendererInterblockSeparator} macro represents a separator
-between two markdown block elements. The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownRendererInterblockSeparator{%
-  \par
-  {\it(The end of a block)}%
-  \par
-}
-\markdownBegin
-Hello *world*!
-
-_Foo_ bar!
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(The end of a block)*
-> 
-> _Foo_ bar!
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\markdownSetup{
-  renderers = {
-    interblockSeparator = {%
-      \par
-      \emph{(The end of a block)}%
-      \par
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-Hello *world*!
-
-_Foo_ bar!
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(The end of a block)*
-> 
-> _Foo_ bar!
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererInterblockSeparator{%
-  \par
-  \emph{(The end of a block)}%
-  \par
-}
-\starttext
-\startmarkdown
-Hello *world*!
-
-_Foo_ bar!
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(The end of a block)*
-> 
-> _Foo_ bar!
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInterblockSeparator{%
-  \markdownRendererInterblockSeparatorPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { interblockSeparator }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { interblockSeparator }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Line Break Renderer
-The \mdef{markdownRendererLineBreak} macro represents a forced line break.
-The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownRendererLineBreak{%
-  \par
-  {\it(A forced linebreak)}%
-  \par
-}
-\markdownInput{example.md}
-\bye
-```````
-Using a text editor, create a text document named `example.md` with the
-following content.  Note the two spaces at the end of the first line, which
-specify a hard linebreak.  Due to the limitations of the \TeX{} input
-processor, hard linebreaks would be ignored if we typed them directly into the
-`document.tex` document.
-
-<pre><code>Hello world!  <br/>_Foo_ bar!</code></pre>
-
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(A forced linebreak)*
-> 
-> _Foo_ bar!
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\markdownSetup{
-  renderers = {
-    lineBreak = {%
-      \par
-      \emph{(A forced linebreak)}%
-      \par
-    },
-  },
-}
-\begin{document}
-\markdownInput{example.md}
-\end{document}
-```````
-Using a text editor, create a text document named `example.md` with the
-following content.  Note the two spaces at the end of the first line, which
-specify a hard linebreak.  Due to the limitations of the \TeX{} input
-processor, hard linebreaks would be ignored if we typed them directly into the
-`document.tex` document.
-
-<pre><code>Hello world!  <br/>_Foo_ bar!</code></pre>
-
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(A forced linebreak)*
-> 
-> _Foo_ bar!
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererLineBreak{%
-  \par
-  \emph{(A forced linebreak)}%
-  \par
-}
-\starttext
-\markdownInput{example.md}
-\stoptext
-```````
-Using a text editor, create a text document named `example.md` with the
-following content.  Note the two spaces at the end of the first line, which
-specify a hard linebreak.  Due to the limitations of the \TeX{} input
-processor, hard linebreaks would be ignored if we typed them directly into the
-`document.tex` document.
-
-<pre><code>Hello world!  <br/>_Foo_ bar!</code></pre>
-
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(A forced linebreak)*
-> 
-> _Foo_ bar!
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererLineBreak{%
-  \markdownRendererLineBreakPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { lineBreak }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { lineBreak }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Ellipsis Renderer
-The \mdef{markdownRendererEllipsis} macro replaces any occurance of ASCII
-ellipses in the input text. This macro will only be produced, when the
-\Opt{smartEllipses} option is enabled.  The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionSmartEllipses{true}
-\def\markdownRendererEllipsis{{\it SHAZAM}!}
-\markdownBegin
-The secret word is ...
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> The secret word is *SHAZAM*!
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[smartEllipses]{markdown}
-\markdownSetup{
-  renderers = {
-    ellipsis = \emph{SHAZAM}!,
-  },
-}
-\begin{document}
-\begin{markdown}
-The secret word is ...
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> The secret word is *SHAZAM*!
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[smartEllipses = yes]
-\def\markdownRendererEllipsis{\emph{SHAZAM}!}
-\starttext
-\startmarkdown
-The secret word is ...
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> Hello *world*!
->
-> *(The end of a block)*
-> 
-> _Foo_ bar!
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererEllipsis{%
-  \markdownRendererEllipsisPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { ellipsis }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { ellipsis }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Non-Breaking Space Renderer
-The \mdef{markdownRendererNbsp} macro represents a non-breaking space.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.bib` with the
-following content:
-``` bib
-@book{knuth:tex,
-  author    = "Knuth, Donald Ervin",
-  title     = "The \TeX book, volume A of Computers and typesetting",
-  publisher = "Addison-Wesley",
-  year      = "1984"
-}
-```````
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[
-  citations,
-  citationNbsps,
-]{markdown}
-\markdownSetup{
-  renderers = {
-    nbsp = {$\cdot$},
-  },
-}
-\begin{document}
-
-\begin{markdown}
-The TeXbook [@knuth:tex, p. 123 and 130] is good.
-\end{markdown}
-
-\bibliographystyle{plain}
-\bibliography{document.bib}
-
-\end{document}
-```````
-Next, invoke LuaTeX and BibTeX from the terminal:
-``` sh
-lualatex document.tex
-bibtex document.aux
-lualatex document.tex
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> The TeXbook [1, p.·123·and·130] is good.
->
-> ### References
-> [1] Donald Ervin Knuth. _The TeXbook, volume A of Computers and typesetting._
-> Addison-Wesley, 1984.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererNbsp{%
-  \markdownRendererNbspPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { nbsp }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { nbsp }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Special Character Renderers
-The following macros replace any special plain \TeX{} characters, including
-% \iffalse
-the active pipe character (`|`) of \Hologo{ConTeXt}, in the input text:
-
-- \mdef{markdownRendererAmpersand} replaces the ampersand (`&`).
-- \mdef{markdownRendererBackslash} replaces the backslash (`\`).
-- \mdef{markdownRendererCircumflex} replaces the circumflex (`^`).
-- \mdef{markdownRendererDollarSign} replaces the dollar sign (`$`).
-- \mdef{markdownRendererHash} replaces the hash sign (`#`).
-- \mdef{markdownRendererLeftBrace} replaces the left brace (`{`).
-- \mdef{markdownRendererPercentSign} replaces the percent sign (`%`).
-- \mdef{markdownRendererPipe} replaces the pipe character (`|`).
-- \mdef{markdownRendererRightBrace} replaces the right brace (`}`).
-- \mdef{markdownRendererTilde} replaces the tilde (`~`).
-- \mdef{markdownRendererUnderscore} replaces the underscore (`_`).
-
-% \fi
-% the active pipe character (`|`) of \Hologo{ConTeXt}, in the input text.
-% These macros will only be produced, when the \Opt{hybrid} option is
-% `false`.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content. We will make the tilde behave as if it were written in
-\TeX{}, where it represents a non-breaking space.
-``` tex
-\input markdown
-\def\markdownRendererTilde{~}
-\markdownBegin
-Bartel~Leendert van~der~Waerden
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text, where the middot (`·`) denotes a non-breaking space:
-
-> Bartel·Leendert van·der·Waerden
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content. We will make the tilde behave as if it were written in
-\TeX{}, where it represents a non-breaking space.
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\markdownSetup{
-  renderers = {
-    tilde = ~,
-  },
-}
-\begin{document}
-\begin{markdown}
-Bartel~Leendert van~der~Waerden
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text, where the middot (`·`) denotes a non-breaking space:
-
-> Bartel·Leendert van·der·Waerden
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content. We will make the tilde behave as if it were written in
-\TeX{}, where it represents a non-breaking space.
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererTilde{~}
-\starttext
-\startmarkdown
-Bartel~Leendert van~der~Waerden
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text, where the middot (`·`) denotes a non-breaking space:
-
-> Bartel·Leendert van·der·Waerden
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererLeftBrace{%
-  \markdownRendererLeftBracePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { leftBrace }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { leftBrace }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererRightBrace{%
-  \markdownRendererRightBracePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { rightBrace }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { rightBrace }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererDollarSign{%
-  \markdownRendererDollarSignPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dollarSign }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dollarSign }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererPercentSign{%
-  \markdownRendererPercentSignPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { percentSign }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { percentSign }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererAmpersand{%
-  \markdownRendererAmpersandPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { ampersand }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { ampersand }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererUnderscore{%
-  \markdownRendererUnderscorePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { underscore }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { underscore }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererHash{%
-  \markdownRendererHashPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { hash }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { hash }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererCircumflex{%
-  \markdownRendererCircumflexPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { circumflex }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { circumflex }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererBackslash{%
-  \markdownRendererBackslashPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { backslash }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { backslash }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererTilde{%
-  \markdownRendererTildePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { tilde }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { tilde }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererPipe{%
-  \markdownRendererPipePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { pipe }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { pipe }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Code Span Renderer
-The \mdef{markdownRendererCodeSpan} macro represents inline code span in the
-input text. It receives a single argument that corresponds to the inline
-code span.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\input lmfonts
-
-\def\markdownRendererCodeSpan#1{#1}
-
-\markdownBegin
-`$\sqrt{-1}$ *equals* $i$`
-
-$\sqrt{-1}$ *equals* $i$
-\markdownEnd
-
-\def\markdownOptionHybrid{true}
-\markdownBegin
-$\sqrt{-1}$ *equals* $i$
-\markdownEnd
-
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> \$\\sqrt{-1}\$ \*equals\* \$i\$.
-> 
-> \$\\sqrt{-1}\$ *equals* \$i\$.
-> 
-> √-̅1̅ *equals* $i$.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[smartEllipses]{markdown}
-\markdownSetup{
-  renderers = {
-    codeSpan = {#1},
-  },
-}
-\begin{document}
-
-\begin{markdown}
-`$\sqrt{-1}$ *equals* $i$`
-
-$\sqrt{-1}$ *equals* $i$
-\end{markdown}
-
-\begin{markdown*}{hybrid}
-$\sqrt{-1}$ *equals* $i$
-\end{markdown*}
-
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> \$\\sqrt{-1}\$ \*equals\* \$i\$.
-> 
-> \$\\sqrt{-1}\$ *equals* \$i\$.
-> 
-> √-̅1̅ *equals* $i$.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererCodeSpan#1{#1}
-\starttext
-
-\startmarkdown
-`$\sqrt{-1}$ *equals* $i$`
-
-$\sqrt{-1}$ *equals* $i$
-\stopmarkdown
-
-\setupmarkdown[hybrid = yes]
-\startmarkdown
-$\sqrt{-1}$ *equals* $i$
-\stopmarkdown
-
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> \$\\sqrt{-1}\$ \*equals\* \$i\$.
-> 
-> \$\\sqrt{-1}\$ *equals* \$i\$.
-> 
-> √-̅1̅ *equals* $i$.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererCodeSpan{%
-  \markdownRendererCodeSpanPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { codeSpan }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { codeSpan }
+  { attributeIdentifier }
   { 1 }
 \ExplSyntaxOff
+\def\markdownRendererAttributeClassName{%
+  \markdownRendererAttributeClassNamePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { attributeClassName }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { attributeClassName }
+  { 1 }
+\ExplSyntaxOff
+\def\markdownRendererAttributeKeyValue{%
+  \markdownRendererAttributeKeyValuePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { attributeKeyValue }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { attributeKeyValue }
+  { 2 }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 %
@@ -10821,11 +9828,41 @@ following text:
 %
 % \begin{markdown}
 
-#### Link Renderer
-The \mdef{markdownRendererLink} macro represents a hyperlink. It receives
-four arguments: the label, the fully escaped \acro{uri} that can be directly
-typeset, the raw \acro{uri} that can be used outside typesetting, and the
-title of the link.
+#### Block Quote Renderers
+The \mdef{markdownRendererBlockQuoteBegin} macro represents the beginning of
+a block quote. The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererBlockQuoteBegin{%
+  \markdownRendererBlockQuoteBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { blockQuoteBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { blockQuoteBegin }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererBlockQuoteEnd} macro represents the end of a block
+quote. The macro receives no arguments.
 
 % \end{markdown}
 %
@@ -10837,14 +9874,24 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \input markdown
-\def\markdownRendererLink#1#2#3#4{%
-  #1 {\tt#2} titled {\it#4}%
+\def\markdownRendererBlockQuoteBegin{%
+  \begingroup
+  \vskip\parindent
+  \leftskip=2\parindent
+  \parindent=0pt
+}
+\def\markdownRendererBlockQuoteEnd{%
+  \par
+  \vskip\parindent
+  \endgroup
 }
 \markdownBegin
-Please visit [the link][ctan].
+A quote from William Shakespeare's King Lear:
 
- [ctan]: https://ctan.org/
-         (the Comprehensive TeX Archive Network)
+> This is the excellent foppery of the world that when we are
+> sick in fortune---often the surfeit of our own behavior---we
+> make guilty of our disasters the sun, the moon, and the
+> stars [...]
 \markdownEnd
 \bye
 ```````
@@ -10855,8 +9902,12 @@ luatex document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> Please visit the link <https://ctan.org/> titled *the Comprehensive TeX
-> Archive Network*.
+> A quote from William Shakespeare's King Lear:
+>
+> > This is the excellent foppery of the world that when we are
+> > sick in fortune—often the surfeit of our own behavior—we
+> > make guilty of our disasters the sun, the moon, and the
+> > stars [...]
 
 ##### \LaTeX{} Example {.unnumbered}
 
@@ -10867,17 +9918,18 @@ following content:
 \usepackage{markdown}
 \markdownSetup{
   renderers = {
-    link = {%
-      #1 \texttt{#2} titled \emph{#4}%
-    },
+    blockQuoteBegin = {\begin{quote}},
+    blockQuoteEnd = {\end{quote}},
   },
 }
 \begin{document}
 \begin{markdown}
-Please visit [the link][ctan].
+A quote from William Shakespeare's King Lear:
 
- [ctan]: https://ctan.org/
-         (the Comprehensive TeX Archive Network)
+> This is the excellent foppery of the world that when we are
+> sick in fortune---often the surfeit of our own behavior---we
+> make guilty of our disasters the sun, the moon, and the
+> stars [...]
 \end{markdown}
 \end{document}
 ```````
@@ -10888,8 +9940,12 @@ lualatex document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> Please visit the link <https://ctan.org/> titled *the Comprehensive TeX
-> Archive Network*.
+> A quote from William Shakespeare's King Lear:
+>
+> > This is the excellent foppery of the world that when we are
+> > sick in fortune—often the surfeit of our own behavior—we
+> > make guilty of our disasters the sun, the moon, and the
+> > stars [...]
 
 ##### \Hologo{ConTeXt} Example {.unnumbered}
 
@@ -10897,15 +9953,16 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \usemodule[t][markdown]
-\def\markdownRendererLink#1#2#3#4{%
-  #1 {\tt#2} titled \emph{#4}%
-}
+\def\markdownRendererBlockQuoteBegin{\startquotation}
+\def\markdownRendererBlockQuoteEnd{\stopquotation}
 \starttext
 \startmarkdown
-Please visit [the link][ctan].
+A quote from William Shakespeare's King Lear:
 
- [ctan]: https://ctan.org/
-         (the Comprehensive TeX Archive Network)
+> This is the excellent foppery of the world that when we are
+> sick in fortune---often the surfeit of our own behavior---we
+> make guilty of our disasters the sun, the moon, and the
+> stars [...]
 \stopmarkdown
 \stoptext
 ```````
@@ -10916,379 +9973,28 @@ context document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> Please visit the link <https://ctan.org/> titled *the Comprehensive TeX
-> Archive Network*.
+> A quote from William Shakespeare's King Lear:
+>
+> > This is the excellent foppery of the world that when we are
+> > sick in fortune—often the surfeit of our own behavior—we
+> > make guilty of our disasters the sun, the moon, and the
+> > stars [...]
 
 %</manual-tokens>
 %<*tex>
 % \fi
 %
 %  \begin{macrocode}
-\def\markdownRendererLink{%
-  \markdownRendererLinkPrototype}%
+\def\markdownRendererBlockQuoteEnd{%
+  \markdownRendererBlockQuoteEndPrototype}%
 \ExplSyntaxOn
 \seq_gput_right:Nn
   \g_@@_renderers_seq
-  { link }
+  { blockQuoteEnd }
 \prop_gput:Nnn
   \g_@@_renderer_arities_prop
-  { link }
-  { 4 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Image Renderer
-The \mdef{markdownRendererImage} macro represents an image. It receives
-four arguments: the label, the fully escaped \acro{uri} that can be directly
-typeset, the raw \acro{uri} that can be used outside typesetting, and the
-title of the link.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\begingroup
-\catcode`\@=11
-\catcode`\%=12
-\catcode`\^^A=14
-\global\def\markdownRendererImage#1#2#3#4{^^A
-  \immediate\write18{^^A
-```
-``` sh
-    if printf '%s' "#3" | grep -q ^http; then
-      OUTPUT="$(printf '%s' "#3" | md5sum | cut -d' ' -f1).^^A
-              $(printf '%s' "#3" | sed 's/.*[.]//')";
-      if ! [ -e "$OUTPUT" ]; then
-        wget -O "$OUTPUT" '#3' || rm "$OUTPUT";
-        convert "$OUTPUT" png:"$OUTPUT";
-      fi;
-      printf '%s%%' "$OUTPUT" > \jobname.fetched;
-    else
-      printf '%s%%' "#3"      > \jobname.fetched;
-    fi^^A
-```
-``` tex
-  }^^A
-  {^^A
-    \everyeof={\noexpand}^^A
-    \edef\filename{\@@input"\jobname.fetched" }^^A
-    \includegraphics[width=\textwidth]{\filename}^^A
-  }^^A
-}
-\endgroup
-\begin{document}
-\begin{markdown}
-![TUGboat](https://tug.org/tugboat/noword.jpg)
-\end{markdown}
-\end{document}
-``````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex --shell-escape document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following content. This assumes that you use a Unix-like operating system with
-Bourne or Bourne again shell as the default shell of the current user. It also
-assumes that the `md5sum`, `wget`, and `convert` binaries are installed and
-that the \TeX{} engine has shell access.
-
-> ![TUGboat](https://tug.org/tugboat/noword.jpg "The Communications of the TeX Users Group")
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererImage{%
-  \markdownRendererImagePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { image }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { image }
-  { 4 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Content Block Renderers {#texcontentblockrenderers}
-
-The \mdef{markdownRendererContentBlock} macro represents an iA\,Writer content
-block. It receives four arguments: the local file or online image filename
-extension cast to the lower case, the fully escaped \acro{uri} that can be
-directly typeset, the raw \acro{uri} that can be used outside typesetting,
-and the title of the content block.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererContentBlock{%
-  \markdownRendererContentBlockPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { contentBlock }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { contentBlock }
-  { 4 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererContentBlockOnlineImage} macro represents an
-iA\,Writer online image content block. The macro receives the same arguments
-as \mref{markdownRendererContentBlock}.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererContentBlockOnlineImage{%
-  \markdownRendererContentBlockOnlineImagePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { contentBlockOnlineImage }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { contentBlockOnlineImage }
-  { 4 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererContentBlockCode} macro represents an iA\,Writer
-content block that was recognized as a file in a known programming language
-by its filename extension $s$. If any `markdown-languages.json` file found
-by \pkg{kpathsea}^[Filenames other than `markdown-languages.json` may
-be specified using the `contentBlocksLanguageMap` Lua option.] contains a
-record $(k, v)$, then a non-online-image content block with the filename
-extension $s, s$`:lower()`${}=k$ is considered to be in a known programming
-language $v$.
-The macro receives five arguments: the local file name extension $s$ cast to
-the lower case, the language $v$, the fully escaped \acro{uri} that can be
-directly typeset, the raw \acro{uri} that can be used outside typesetting,
-and the title of the content block.
-
-Note that you will need to place place a `markdown-languages.json` file
-inside your working directory or inside your local \TeX{} directory
-structure.  In this file, you will define a mapping between filename
-extensions and the language names recognized by your favorite syntax
-highlighter; there may exist other creative uses beside syntax highlighting.
-% The `Languages.json` file provided by @sotkov17 is a good starting point.
-% \end{markdown}
-%
-% \iffalse
-[The `Languages.json` file provided by Anton Sotkov][sotkov17] is a good
-starting point.
-
- [sotkov17]: https://github.com/iainc/Markdown-Content-Blocks
-             (File transclusion syntax for Markdown)
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionContentBlocks{true}
-\def\markdownRendererContentBlock#1#2#3#4{%
-  This is {\tt #2}, #4.
-}
-\def\markdownRendererContentBlockOnlineImage#1#2#3#4{%
-  This is the image {\tt #2}, #4.
-}
-\def\markdownRendererContentBlockCode#1#2#3#4#5{%
-  This is the #2 (\uppercase{#1}) document {\tt #3}, #5.
-}
-\markdownBegin
-/document.tex (the document that we are currently typesetting)
-/markdown-languages.json (the mapping between filename extensions
-                          and programming language names)
-https://tug.org/tugboat/noword.jpg (the logotype of TUGboat)
-\markdownEnd
-\bye
-```````
-Create also a text document named `markdown-languages.json` with the following
-content:
-``` js
-{
-  "json": "JavaScript Object Notation",
-}
-``````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is `document.tex`, the document that we are currently typesetting.
->
-> This is the JavaScript Object Notation (JSON) document
-> `markdown-languages.json`, the mapping between filename extensions and
-> programming language names.
->
-> This is the image `https://tug.org/tugboat/noword.jpg`, the logotype of
-> TUGboat.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\begin{filecontents}[overwrite,nosearch,noheader]{markdown-languages.json}
-{
-  "json": "JavaScript Object Notation",
-}
-\end{filecontents}
-\usepackage[contentBlocks]{markdown}
-\markdownSetup{
-  renderers = {
-    contentBlock = {This is \texttt{#2}, #4.},
-    contentBlockOnlineImage = {This is the image \texttt{#2}, #4.},
-    contentBlockCode = {%
-      This is the #2 (\MakeUppercase{#1}) document \texttt{#3}, #5.
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-/document.tex (the document that we are currently typesetting)
-/markdown-languages.json (the mapping between filename extensions
-                          and programming language names)
-https://tug.org/tugboat/noword.jpg (the logotype of TUGboat)
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is `document.tex`, the document that we are currently typesetting.
->
-> This is the JavaScript Object Notation (JSON) document
-> `markdown-languages.json`, the mapping between filename extensions and
-> programming language names.
->
-> This is the image `https://tug.org/tugboat/noword.jpg`, the logotype of
-> TUGboat.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[contentBlocks = yes]
-\def\markdownRendererContentBlock#1#2#3#4{%
-  This is {\tt #2}, #4.
-}
-\def\markdownRendererContentBlockOnlineImage#1#2#3#4{%
-  This is the image {\tt #2}, #4.
-}
-\def\markdownRendererContentBlockCode#1#2#3#4#5{%
-  This is the #2 (\uppercase{#1}) document {\tt #3}, #5.
-}
-\starttext
-\startmarkdown
-/document.tex (the document that we are currently typesetting)
-/markdown-languages.json (the mapping between filename extensions
-                          and programming language names)
-https://tug.org/tugboat/noword.jpg (the logotype of TUGboat)
-\stopmarkdown
-\stoptext
-```````
-Create also a text document named `markdown-languages.json` with the following
-content:
-``` js
-{
-  "json": "JavaScript Object Notation",
-}
-``````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is `document.tex`, the document that we are currently typesetting.
->
-> This is the JavaScript Object Notation (JSON) document
-> `markdown-languages.json`, the mapping between filename extensions and
-> programming language names.
->
-> This is the image `https://tug.org/tugboat/noword.jpg`, the logotype of
-> TUGboat.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererContentBlockCode{%
-  \markdownRendererContentBlockCodePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { contentBlockCode }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { contentBlockCode }
-  { 5 }
+  { blockQuoteEnd }
+  { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par
@@ -11690,6 +10396,2934 @@ following text:
   \g_@@_renderer_arities_prop
   { ulEndTight }
   { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Code Block Renderers
+The \mdef{markdownRendererInputVerbatim} macro represents a code
+block. The macro receives a single argument that corresponds to the
+filename of a file contaning the code block contents.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInputVerbatim{%
+  \markdownRendererInputVerbatimPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inputVerbatim }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inputVerbatim }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererInputFencedCode} macro represents a fenced code
+block. This macro will only be produced, when the \Opt{fencedCode} option is
+enabled. The macro receives two arguments that correspond to the filename of
+a file contaning the code block contents and to the code fence infostring.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{verbatim}
+\usepackage[hyphens]{url}
+\usepackage[fencedCode]{markdown}
+\markdownSetup{
+  renderers = {
+    interblockSeparator = {
+      \def\markdownRendererInterblockSeparator{%
+        \par
+        \def\markdownRendererInterblockSeparator{%
+          \def\markdownRendererInterblockSeparator{%
+            \par
+          }%
+        }%
+      }%
+    },
+    inputVerbatim = {
+      is contained in file \url{#1}:%
+      \verbatiminput{#1}%
+    },
+    inputFencedCode = {
+      in #2 \markdownRendererInputVerbatim{#1}%
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+The following code
+
+    def foo(bar):
+      if len(bar) <= 1:
+        return bar[0]
+      elif len(bar) == 2:
+        return sorted(bar)
+      else:
+        baz = len(bar) // 2
+        return foo(bar[baz:], bar[:baz])
+
+The following code
+
+~~~ Python
+>>> foo([4, 2, 1, 3])
+[1, 2, 3, 4]
+~~~~~~~~~~
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text except for the filename, which may differ:
+
+> The following code is contained in file
+> `./_markdown_document/882453149edcf288976647f6fe147ada.verbatim`:
+> ``` py
+> def foo(bar):
+>   if len(bar) <= 1:
+>     return bar[:1]
+>   elif len(bar) == 2:
+>     return sorted(bar)
+>   else:
+>     baz = bar[len(bar) // 2]
+>     return (
+>       foo([qux for qux in bar if qux < baz]) + [baz] +
+>       foo([qux for qux in bar if qux > baz])
+>     )
+> ``````
+> The following code in Python contained in file
+> `./_markdown_document/cf2a96e2120cef5b1fae5fea36fcc27b.verbatim`:
+> ``` py
+> >>> foo([4, 2, 1, 3])
+> [1, 2, 3, 4]
+> ``````
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInputFencedCode{%
+  \markdownRendererInputFencedCodePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inputFencedCode }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inputFencedCode }
+  { 2 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+% \begin{markdown}
+
+#### Code Span Renderer
+The \mdef{markdownRendererCodeSpan} macro represents inline code span in the
+input text. It receives a single argument that corresponds to the inline
+code span.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\input lmfonts
+
+\def\markdownRendererCodeSpan#1{#1}
+
+\markdownBegin
+`$\sqrt{-1}$ *equals* $i$`
+
+$\sqrt{-1}$ *equals* $i$
+\markdownEnd
+
+\def\markdownOptionHybrid{true}
+\markdownBegin
+$\sqrt{-1}$ *equals* $i$
+\markdownEnd
+
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \$\\sqrt{-1}\$ \*equals\* \$i\$.
+> 
+> \$\\sqrt{-1}\$ *equals* \$i\$.
+> 
+> √-̅1̅ *equals* $i$.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[smartEllipses]{markdown}
+\markdownSetup{
+  renderers = {
+    codeSpan = {#1},
+  },
+}
+\begin{document}
+
+\begin{markdown}
+`$\sqrt{-1}$ *equals* $i$`
+
+$\sqrt{-1}$ *equals* $i$
+\end{markdown}
+
+\begin{markdown*}{hybrid}
+$\sqrt{-1}$ *equals* $i$
+\end{markdown*}
+
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \$\\sqrt{-1}\$ \*equals\* \$i\$.
+> 
+> \$\\sqrt{-1}\$ *equals* \$i\$.
+> 
+> √-̅1̅ *equals* $i$.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererCodeSpan#1{#1}
+\starttext
+
+\startmarkdown
+`$\sqrt{-1}$ *equals* $i$`
+
+$\sqrt{-1}$ *equals* $i$
+\stopmarkdown
+
+\setupmarkdown[hybrid = yes]
+\startmarkdown
+$\sqrt{-1}$ *equals* $i$
+\stopmarkdown
+
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> \$\\sqrt{-1}\$ \*equals\* \$i\$.
+> 
+> \$\\sqrt{-1}\$ *equals* \$i\$.
+> 
+> √-̅1̅ *equals* $i$.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererCodeSpan{%
+  \markdownRendererCodeSpanPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { codeSpan }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { codeSpan }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Content Block Renderers {#texcontentblockrenderers}
+
+The \mdef{markdownRendererContentBlock} macro represents an iA\,Writer content
+block. It receives four arguments: the local file or online image filename
+extension cast to the lower case, the fully escaped \acro{uri} that can be
+directly typeset, the raw \acro{uri} that can be used outside typesetting,
+and the title of the content block.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererContentBlock{%
+  \markdownRendererContentBlockPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { contentBlock }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { contentBlock }
+  { 4 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererContentBlockOnlineImage} macro represents an
+iA\,Writer online image content block. The macro receives the same arguments
+as \mref{markdownRendererContentBlock}.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererContentBlockOnlineImage{%
+  \markdownRendererContentBlockOnlineImagePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { contentBlockOnlineImage }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { contentBlockOnlineImage }
+  { 4 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererContentBlockCode} macro represents an iA\,Writer
+content block that was recognized as a file in a known programming language
+by its filename extension $s$. If any `markdown-languages.json` file found
+by \pkg{kpathsea}^[Filenames other than `markdown-languages.json` may
+be specified using the `contentBlocksLanguageMap` Lua option.] contains a
+record $(k, v)$, then a non-online-image content block with the filename
+extension $s, s$`:lower()`${}=k$ is considered to be in a known programming
+language $v$.
+The macro receives five arguments: the local file name extension $s$ cast to
+the lower case, the language $v$, the fully escaped \acro{uri} that can be
+directly typeset, the raw \acro{uri} that can be used outside typesetting,
+and the title of the content block.
+
+Note that you will need to place place a `markdown-languages.json` file
+inside your working directory or inside your local \TeX{} directory
+structure.  In this file, you will define a mapping between filename
+extensions and the language names recognized by your favorite syntax
+highlighter; there may exist other creative uses beside syntax highlighting.
+% The `Languages.json` file provided by @sotkov17 is a good starting point.
+% \end{markdown}
+%
+% \iffalse
+[The `Languages.json` file provided by Anton Sotkov][sotkov17] is a good
+starting point.
+
+ [sotkov17]: https://github.com/iainc/Markdown-Content-Blocks
+             (File transclusion syntax for Markdown)
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionContentBlocks{true}
+\def\markdownRendererContentBlock#1#2#3#4{%
+  This is {\tt #2}, #4.
+}
+\def\markdownRendererContentBlockOnlineImage#1#2#3#4{%
+  This is the image {\tt #2}, #4.
+}
+\def\markdownRendererContentBlockCode#1#2#3#4#5{%
+  This is the #2 (\uppercase{#1}) document {\tt #3}, #5.
+}
+\markdownBegin
+/document.tex (the document that we are currently typesetting)
+/markdown-languages.json (the mapping between filename extensions
+                          and programming language names)
+https://tug.org/tugboat/noword.jpg (the logotype of TUGboat)
+\markdownEnd
+\bye
+```````
+Create also a text document named `markdown-languages.json` with the following
+content:
+``` js
+{
+  "json": "JavaScript Object Notation",
+}
+``````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is `document.tex`, the document that we are currently typesetting.
+>
+> This is the JavaScript Object Notation (JSON) document
+> `markdown-languages.json`, the mapping between filename extensions and
+> programming language names.
+>
+> This is the image `https://tug.org/tugboat/noword.jpg`, the logotype of
+> TUGboat.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\begin{filecontents}[overwrite,nosearch,noheader]{markdown-languages.json}
+{
+  "json": "JavaScript Object Notation",
+}
+\end{filecontents}
+\usepackage[contentBlocks]{markdown}
+\markdownSetup{
+  renderers = {
+    contentBlock = {This is \texttt{#2}, #4.},
+    contentBlockOnlineImage = {This is the image \texttt{#2}, #4.},
+    contentBlockCode = {%
+      This is the #2 (\MakeUppercase{#1}) document \texttt{#3}, #5.
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+/document.tex (the document that we are currently typesetting)
+/markdown-languages.json (the mapping between filename extensions
+                          and programming language names)
+https://tug.org/tugboat/noword.jpg (the logotype of TUGboat)
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is `document.tex`, the document that we are currently typesetting.
+>
+> This is the JavaScript Object Notation (JSON) document
+> `markdown-languages.json`, the mapping between filename extensions and
+> programming language names.
+>
+> This is the image `https://tug.org/tugboat/noword.jpg`, the logotype of
+> TUGboat.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[contentBlocks = yes]
+\def\markdownRendererContentBlock#1#2#3#4{%
+  This is {\tt #2}, #4.
+}
+\def\markdownRendererContentBlockOnlineImage#1#2#3#4{%
+  This is the image {\tt #2}, #4.
+}
+\def\markdownRendererContentBlockCode#1#2#3#4#5{%
+  This is the #2 (\uppercase{#1}) document {\tt #3}, #5.
+}
+\starttext
+\startmarkdown
+/document.tex (the document that we are currently typesetting)
+/markdown-languages.json (the mapping between filename extensions
+                          and programming language names)
+https://tug.org/tugboat/noword.jpg (the logotype of TUGboat)
+\stopmarkdown
+\stoptext
+```````
+Create also a text document named `markdown-languages.json` with the following
+content:
+``` js
+{
+  "json": "JavaScript Object Notation",
+}
+``````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is `document.tex`, the document that we are currently typesetting.
+>
+> This is the JavaScript Object Notation (JSON) document
+> `markdown-languages.json`, the mapping between filename extensions and
+> programming language names.
+>
+> This is the image `https://tug.org/tugboat/noword.jpg`, the logotype of
+> TUGboat.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererContentBlockCode{%
+  \markdownRendererContentBlockCodePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { contentBlockCode }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { contentBlockCode }
+  { 5 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Definition List Renderers
+The following macros are only produced, when the \Opt{definitionLists} option
+is enabled.
+
+The \mdef{markdownRendererDlBegin} macro represents the beginning of a
+definition list that contains an item with several paragraphs of text (the
+list is not tight). The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlBegin{%
+  \markdownRendererDlBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlBegin }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlBeginTight} macro represents the beginning of a
+definition list that contains an item with several paragraphs of text (the
+list is not tight). This macro will only be produced, when the
+\Opt{tightLists} option is disabled. The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlBeginTight{%
+  \markdownRendererDlBeginTightPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlBeginTight }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlBeginTight }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlItem} macro represents a term in a definition
+list. The macro receives a single argument that corresponds to the term
+being defined.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlItem{%
+  \markdownRendererDlItemPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlItem }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlItem }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlItemEnd} macro represents the end of a list of
+definitions for a single term.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlItemEnd{%
+  \markdownRendererDlItemEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlItemEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlItemEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlDefinitionBegin} macro represents the beginning
+of a definition in a definition list. There can be several definitions for
+a single term.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlDefinitionBegin{%
+  \markdownRendererDlDefinitionBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlDefinitionBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlDefinitionBegin }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlDefinitionEnd} macro represents the end of a
+definition in a definition list. There can be several definitions for a
+single term.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlDefinitionEnd{%
+  \markdownRendererDlDefinitionEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlDefinitionEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlDefinitionEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlEnd} macro represents the end of a definition
+list that contains an item with several paragraphs of text (the list is not
+tight). The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlEnd{%
+  \markdownRendererDlEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererDlEndTight} macro represents the end of a
+definition list that contains no item with several paragraphs of text (the
+list is tight). This macro will only be produced, when the \Opt{tightLists}
+option is disabled. The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionDefinitionLists{true}
+\def\markdownOptionTightLists{true}
+
+\def\markdownRendererInterblockSeparator{%
+  :%
+  \def\markdownRendererInterblockSeparator{\par}%
+}
+\def\markdownRendererDlBeginTight{%
+  \begingroup
+  \parindent=0pt
+}
+\def\markdownRendererDlItem#1{%
+  \par{\bf#1}%
+  \def\markdownRendererDlDefinitionEnd{%
+    ,
+    \def\markdownRendererDlDefinitionEnd{%
+      , and
+      \def\markdownRendererDlDefinitionEnd{.}%
+    }%
+  }%
+}
+\def\markdownRendererDlItemEnd{}
+\def\markdownRendererDlDefinitionBegin{\par--\kern 0.5em}
+\def\markdownRendererDlEndTight{\endgroup}
+
+\markdownBegin
+This is a tight definition list
+
+Coffee
+:   black hot drink
+:   prepared from roasted coffee beans
+:   one of the most traded agricultural commodities in the world
+
+Milk
+:   white cold drink
+:   nutrient-rich
+:   produced on an industrial scale
+\markdownEnd
+
+\def\markdownRendererInterblockSeparator{%
+  \def\markdownRendererInterblockSeparator{\par}%
+}
+\def\markdownRendererDlBegin{}
+\def\markdownRendererDlItem#1{%
+  . #1 is a
+  \def\markdownRendererDlDefinitionBegin{%
+    \def\markdownRendererDlDefinitionBegin{%
+      ,
+      \def\markdownRendererDlDefinitionBegin{, and }%
+    }%
+  }%
+}
+\def\markdownRendererDlItemEnd{}
+\def\markdownRendererDlDefinitionEnd{}
+\def\markdownRendererDlEnd{.}
+
+\markdownBegin
+This is a loose definition list
+
+Coffee
+
+:   black hot drink
+
+:   prepared from roasted coffee beans
+
+:   one of the most traded agricultural commodities in the world
+
+Milk
+
+:   white cold drink
+
+:   nutrient-rich
+
+:   produced on an industrial scale
+\markdownEnd
+
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is a tight definition list:
+>
+> **Coffee**
+>
+> - black hot drink,
+> - prepared from roasted coffee beans, and
+> - one of the most traded agricultural commodities in the world.
+>
+> **Milk**
+>
+> - white cold drink,
+> - nutrient-rich, and
+> - produced on an industrial scale.
+>
+> This is a loose definition list. Coffee is a black hot drink, prepared from
+> roasted coffee beans, and one of the most traded agricultural commodities in
+> the world. Milk is a white cold drink, nutrient-rich, and produced on an
+> industrial scale.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[definitionLists, tightLists]{markdown}
+\begin{document}
+
+\begin{markdown*}{
+  renderers = {
+    interblockSeparator = {%
+      :%
+      \def\markdownRendererInterblockSeparator{\par}%
+    },
+    dlBeginTight = {\begin{description}},
+    dlItem = {%
+      \item[#1]
+      \begin{itemize}
+      \def\markdownRendererDlDefinitionEnd{%
+        ,
+        \def\markdownRendererDlDefinitionEnd{%
+          , and
+          \def\markdownRendererDlDefinitionEnd{.}%
+        }%
+      }%
+    },
+    dlItemEnd = {\end{itemize}},
+    dlDefinitionBegin = \item,
+    dlEndTight = {\end{description}},
+  },
+}
+This is a tight definition list
+
+Coffee
+:   black hot drink
+:   prepared from roasted coffee beans
+:   one of the most traded agricultural commodities in the world
+
+Milk
+:   white cold drink
+:   nutrient-rich
+:   produced on an industrial scale
+\end{markdown*}
+
+\begin{markdown*}{
+  renderers = {
+    interblockSeparator = {%
+      \def\markdownRendererInterblockSeparator{\par}%
+    },
+    dlBegin = {},
+    dlItem = {%
+      . #1 is a
+      \def\markdownRendererDlDefinitionBegin{%
+        \def\markdownRendererDlDefinitionBegin{%
+          ,
+          \def\markdownRendererDlDefinitionBegin{, and }%
+        }%
+      }%
+    },
+    dlItemEnd = {},
+    dlDefinitionEnd = {},
+    dlEnd = {.},
+  },
+}
+This is a loose definition list
+
+Coffee
+
+:   black hot drink
+
+:   prepared from roasted coffee beans
+
+:   one of the most traded agricultural commodities in the world
+
+Milk
+
+:   white cold drink
+
+:   nutrient-rich
+
+:   produced on an industrial scale
+\end{markdown*}
+
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is a tight definition list:
+>
+> **Coffee**
+>
+> - black hot drink,
+> - prepared from roasted coffee beans, and
+> - one of the most traded agricultural commodities in the world.
+>
+> **Milk**
+>
+> - white cold drink,
+> - nutrient-rich, and
+> - produced on an industrial scale.
+>
+> This is a loose definition list. Coffee is a black hot drink, prepared from
+> roasted coffee beans, and one of the most traded agricultural commodities in
+> the world. Milk is a white cold drink, nutrient-rich, and produced on an
+> industrial scale.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown
+  [
+    definitionLists = yes,
+    tightLists = yes,
+  ]
+\starttext
+
+\def\markdownRendererInterblockSeparator{%
+  :%
+  \def\markdownRendererInterblockSeparator{\par}%
+}
+\def\markdownRendererDlBeginTight{}
+\def\markdownRendererDlItem#1{%
+  \par{\bf#1}%
+  \startitemize
+  \def\markdownRendererDlDefinitionEnd{%
+    ,
+    \def\markdownRendererDlDefinitionEnd{%
+      , and
+      \def\markdownRendererDlDefinitionEnd{.}%
+    }%
+  }%
+}
+\def\markdownRendererDlItemEnd{\stopitemize}
+\def\markdownRendererDlDefinitionBegin{\item}
+\def\markdownRendererDlEndTight{}
+
+\startmarkdown
+This is a tight definition list
+
+Coffee
+:   black hot drink
+:   prepared from roasted coffee beans
+:   one of the most traded agricultural commodities in the world
+
+Milk
+:   white cold drink
+:   nutrient-rich
+:   produced on an industrial scale
+\stopmarkdown
+
+\def\markdownRendererInterblockSeparator{%
+  \def\markdownRendererInterblockSeparator{\par}%
+}
+\def\markdownRendererDlBegin{}
+\def\markdownRendererDlItem#1{%
+  . #1 is a
+  \def\markdownRendererDlDefinitionBegin{%
+    \def\markdownRendererDlDefinitionBegin{%
+      ,
+      \def\markdownRendererDlDefinitionBegin{, and }%
+    }%
+  }%
+}
+\def\markdownRendererDlItemEnd{}
+\def\markdownRendererDlDefinitionEnd{}
+\def\markdownRendererDlEnd{.}
+
+\startmarkdown
+This is a loose definition list
+
+Coffee
+
+:   black hot drink
+
+:   prepared from roasted coffee beans
+
+:   one of the most traded agricultural commodities in the world
+
+Milk
+
+:   white cold drink
+
+:   nutrient-rich
+
+:   produced on an industrial scale
+\stopmarkdown
+
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is a tight definition list:
+>
+> **Coffee**
+>
+> - black hot drink,
+> - prepared from roasted coffee beans, and
+> - one of the most traded agricultural commodities in the world.
+>
+> **Milk**
+>
+> - white cold drink,
+> - nutrient-rich, and
+> - produced on an industrial scale.
+>
+> This is a loose definition list. Coffee is a black hot drink, prepared from
+> roasted coffee beans, and one of the most traded agricultural commodities in
+> the world. Milk is a white cold drink, nutrient-rich, and produced on an
+> industrial scale.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDlEndTight{%
+  \markdownRendererDlEndTightPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dlEndTight }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dlEndTight }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Ellipsis Renderer
+The \mdef{markdownRendererEllipsis} macro replaces any occurance of ASCII
+ellipses in the input text. This macro will only be produced, when the
+\Opt{smartEllipses} option is enabled.  The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionSmartEllipses{true}
+\def\markdownRendererEllipsis{{\it SHAZAM}!}
+\markdownBegin
+The secret word is ...
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> The secret word is *SHAZAM*!
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[smartEllipses]{markdown}
+\markdownSetup{
+  renderers = {
+    ellipsis = \emph{SHAZAM}!,
+  },
+}
+\begin{document}
+\begin{markdown}
+The secret word is ...
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> The secret word is *SHAZAM*!
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[smartEllipses = yes]
+\def\markdownRendererEllipsis{\emph{SHAZAM}!}
+\starttext
+\startmarkdown
+The secret word is ...
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(The end of a block)*
+> 
+> _Foo_ bar!
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererEllipsis{%
+  \markdownRendererEllipsisPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { ellipsis }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { ellipsis }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Emphasis Renderers
+The \mdef{markdownRendererEmphasis} macro represents an emphasized span of
+text. The macro receives a single argument that corresponds to the emphasized
+span of text.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownRendererEmphasis#1{{\it#1}}
+\def\markdownRendererStrongEmphasis#1{{\bf#1}}
+\markdownBegin
+This is *emphasis*.
+
+This is **strong emphasis**.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is *emphasis*.
+>
+> This is **strong emphasis**.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    emphasis = {\emph{#1}},
+    strongEmphasis = {\textbf{#1}},
+  },
+}
+\begin{document}
+\begin{markdown}
+This is *emphasis*.
+
+This is **strong emphasis**.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is *emphasis*.
+>
+> This is **strong emphasis**.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererEmphasis#1{\emph{#1}}
+\def\markdownRendererStrongEmphasis#1{\bold{#1}}
+\starttext
+\startmarkdown
+This is *emphasis*.
+
+This is **strong emphasis**.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is *emphasis*.
+>
+> This is **strong emphasis**.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererEmphasis{%
+  \markdownRendererEmphasisPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { emphasis }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { emphasis }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererStrongEmphasis} macro represents a strongly
+emphasized span of text. The macro receives a single argument that
+corresponds to the emphasized span of text.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererStrongEmphasis{%
+  \markdownRendererStrongEmphasisPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { strongEmphasis }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { strongEmphasis }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Header Attribute Context Renderers
+The following macros are only produced, when the \Opt{headerAttributes} option
+is enabled.
+
+The \mdef{markdownRendererHeaderAttributeContextBegin} and
+\mdef{markdownRendererHeaderAttributeContextEnd} macros represent the beginning
+and the end of a section in which the attributes of a heading apply. The macros
+receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[headerAttributes]{markdown}
+\markdownSetup{
+  renderers = {
+    headerAttributeContextBegin = {%
+      \par
+      \emph{(The beginning of a header attribute context)}
+      \par
+    },
+    headerAttributeContextBegin = {%
+      \par
+      \emph{(The end of a header attribute context)}
+      \par
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+
+# First top-level heading
+
+## A subheading {#identifier}
+
+# Second top-level heading {.class_name}
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> # First top-level heading
+>
+> *(The beginning of a header attribute context)*
+>
+> ## A subheading
+>
+> *(The end of a header attribute context)*
+>
+> *(The beginning of a header attribute context)*
+>
+> # Second top-level heading
+>
+> *(The end of a header attribute context)*
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeaderAttributeContextBegin{%
+  \markdownRendererHeaderAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headerAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headerAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererHeaderAttributeContextEnd{%
+  \markdownRendererHeaderAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headerAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headerAttributeContextEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Heading Renderers
+The \mdef{markdownRendererHeadingOne} macro represents a first level heading.
+The macro receives a single argument that corresponds to the heading text.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeadingOne{%
+  \markdownRendererHeadingOnePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headingOne }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headingOne }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererHeadingTwo} macro represents a second level
+heading. The macro receives a single argument that corresponds to the heading
+text.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeadingTwo{%
+  \markdownRendererHeadingTwoPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headingTwo }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headingTwo }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererHeadingThree} macro represents a third level
+heading. The macro receives a single argument that corresponds to the heading
+text.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeadingThree{%
+  \markdownRendererHeadingThreePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headingThree }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headingThree }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererHeadingFour} macro represents a fourth level
+heading. The macro receives a single argument that corresponds to the heading
+text.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeadingFour{%
+  \markdownRendererHeadingFourPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headingFour }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headingFour }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererHeadingFive} macro represents a fifth level
+heading. The macro receives a single argument that corresponds to the heading
+text.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeadingFive{%
+  \markdownRendererHeadingFivePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headingFive }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headingFive }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererHeadingSix} macro represents a sixth level
+heading. The macro receives a single argument that corresponds to the heading
+text.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownRendererInterblockSeparator{}
+\def\markdownRendererHeadingOne{1}
+\def\markdownRendererHeadingTwo{2}
+\def\markdownRendererHeadingThree{3}
+\def\markdownRendererHeadingFour{4}
+\def\markdownRendererHeadingFive{5}
+\def\markdownRendererHeadingSix{6}
+\markdownBegin
+######
+#####
+#####
+###
+######
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> 65536
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    interblockSeparator = {},
+    headingOne = 1,
+    headingTwo = 2,
+    headingThree = 3,
+    headingFour = 4,
+    headingFive = 5,
+    headingSix = 6,
+  },
+}
+\begin{document}
+\begin{markdown}
+######
+#####
+#####
+###
+######
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> 65536
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererInterblockSeparator{}
+\def\markdownRendererHeadingOne{1}
+\def\markdownRendererHeadingTwo{2}
+\def\markdownRendererHeadingThree{3}
+\def\markdownRendererHeadingFour{4}
+\def\markdownRendererHeadingFive{5}
+\def\markdownRendererHeadingSix{6}
+\starttext
+\startmarkdown
+######
+#####
+#####
+###
+######
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> 65536
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererHeadingSix{%
+  \markdownRendererHeadingSixPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { headingSix }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { headingSix }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### HTML Comment Renderers
+
+The \mdef{markdownRendererInlineHtmlComment} macro represents the contents of an
+inline \acro{HTML} comment. This macro will only be produced, when the
+\Opt{html} option is enabled. The macro receives a single argument that
+corresponds to the contents of the \acro{HTML} comment.
+
+The \mdef{markdownRendererBlockHtmlCommentBegin} and
+\mdef{markdownRendererBlockHtmlCommentEnd} macros represent the beginning
+and the end of a block \acro{HTML} comment. The macros receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[html]{markdown}
+\usepackage{marginnote}
+\markdownSetup{
+  renderers = {
+    inlineHtmlComment = {\marginnote{#1}},
+    blockHtmlCommentBegin = {\begin{quote}},
+    blockHtmlCommentEnd = {\end{quote}},
+  },
+}
+\begin{document}
+\begin{markdown}
+A useful use of inline HTML comments are side notes.
+<!-- Side notes are displayed in the horizontal margins next to the relevant
+passages, which makes them *easier for the reader to find* than notes. -->
+
+We can render block HTML comments as blockquotes:
+
+<!--
+Here is a block HTML comment with a code example that a programmer might understand:
+
+    foo = bar + baz - 42
+-->
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following body text:
+
+> A useful use of HTML comments are side notes.
+>
+> We can render block HTML comments as blockquotes:
+> 
+> > Here is a block HTML comment with a code example that a programmer might
+> > understand:
+> >
+> >     foo = bar + baz - 42
+
+The horizontal margins should contain the following text:
+
+> Side notes are displayed in the horizontal margins next to the relevant
+> passages, which makes them *easier for the reader to find* than notes.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInlineHtmlComment{%
+  \markdownRendererInlineHtmlCommentPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inlineHtmlComment }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inlineHtmlComment }
+  { 1 }
+\ExplSyntaxOff
+\def\markdownRendererBlockHtmlCommentBegin{%
+  \markdownRendererBlockHtmlCommentBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { blockHtmlCommentBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { blockHtmlCommentBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererBlockHtmlCommentEnd{%
+  \markdownRendererBlockHtmlCommentEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { blockHtmlCommentEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { blockHtmlCommentEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### HTML Tag and Element Renderers
+
+The \mdef{markdownRendererInlineHtmlTag} macro represents an opening, closing,
+or empty inline \acro{HTML} tag. This macro will only be produced, when the
+\Opt{html} option is enabled. The macro receives a single argument that
+corresponds to the contents of the \acro{HTML} tag.
+
+The \mdef{markdownRendererInputBlockHtmlElement} macro represents a block
+\acro{HTML} element. This macro will only be produced, when the \Opt{html}
+option is enabled. The macro receives a single argument that filename of a file
+containing the contents of the \acro{HTML} element.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[html]{markdown}
+\usepackage{marginnote}
+\usepackage{verbatim}
+\markdownSetup{
+  renderers = {
+    inlineHtmlTag = {\textbf{#1}},
+    inputBlockHtmlElement = {\verbatiminput{#1}},
+  },
+}
+\begin{document}
+\begin{markdown}
+<b>_Hello,_ world!</b><br/>
+
+<div>_Hello,_ world!</div>
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following body text:
+
+> **<b>**_Hello,_ world!**</b><br/>**
+>
+>     <div>_Hello,_ world!</div>
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInlineHtmlTag{%
+  \markdownRendererInlineHtmlTagPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inlineHtmlTag }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inlineHtmlTag }
+  { 1 }
+\ExplSyntaxOff
+\def\markdownRendererInputBlockHtmlElement{%
+  \markdownRendererInputBlockHtmlElementPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inputBlockHtmlElement }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inputBlockHtmlElement }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Image Renderer
+The \mdef{markdownRendererImage} macro represents an image. It receives
+four arguments: the label, the fully escaped \acro{uri} that can be directly
+typeset, the raw \acro{uri} that can be used outside typesetting, and the
+title of the link.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\begingroup
+\catcode`\@=11
+\catcode`\%=12
+\catcode`\^^A=14
+\global\def\markdownRendererImage#1#2#3#4{^^A
+  \immediate\write18{^^A
+```
+``` sh
+    if printf '%s' "#3" | grep -q ^http; then
+      OUTPUT="$(printf '%s' "#3" | md5sum | cut -d' ' -f1).^^A
+              $(printf '%s' "#3" | sed 's/.*[.]//')";
+      if ! [ -e "$OUTPUT" ]; then
+        wget -O "$OUTPUT" '#3' || rm "$OUTPUT";
+        convert "$OUTPUT" png:"$OUTPUT";
+      fi;
+      printf '%s%%' "$OUTPUT" > \jobname.fetched;
+    else
+      printf '%s%%' "#3"      > \jobname.fetched;
+    fi^^A
+```
+``` tex
+  }^^A
+  {^^A
+    \everyeof={\noexpand}^^A
+    \edef\filename{\@@input"\jobname.fetched" }^^A
+    \includegraphics[width=\textwidth]{\filename}^^A
+  }^^A
+}
+\endgroup
+\begin{document}
+\begin{markdown}
+![TUGboat](https://tug.org/tugboat/noword.jpg)
+\end{markdown}
+\end{document}
+``````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following content. This assumes that you use a Unix-like operating system with
+Bourne or Bourne again shell as the default shell of the current user. It also
+assumes that the `md5sum`, `wget`, and `convert` binaries are installed and
+that the \TeX{} engine has shell access.
+
+> ![TUGboat](https://tug.org/tugboat/noword.jpg "The Communications of the TeX Users Group")
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererImage{%
+  \markdownRendererImagePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { image }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { image }
+  { 4 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Interblock Separator Renderer
+The \mdef{markdownRendererInterblockSeparator} macro represents a separator
+between two markdown block elements. The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownRendererInterblockSeparator{%
+  \par
+  {\it(The end of a block)}%
+  \par
+}
+\markdownBegin
+Hello *world*!
+
+_Foo_ bar!
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(The end of a block)*
+> 
+> _Foo_ bar!
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    interblockSeparator = {%
+      \par
+      \emph{(The end of a block)}%
+      \par
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+Hello *world*!
+
+_Foo_ bar!
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(The end of a block)*
+> 
+> _Foo_ bar!
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererInterblockSeparator{%
+  \par
+  \emph{(The end of a block)}%
+  \par
+}
+\starttext
+\startmarkdown
+Hello *world*!
+
+_Foo_ bar!
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(The end of a block)*
+> 
+> _Foo_ bar!
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInterblockSeparator{%
+  \markdownRendererInterblockSeparatorPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { interblockSeparator }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { interblockSeparator }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Line Break Renderer
+The \mdef{markdownRendererLineBreak} macro represents a forced line break.
+The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownRendererLineBreak{%
+  \par
+  {\it(A forced linebreak)}%
+  \par
+}
+\markdownInput{example.md}
+\bye
+```````
+Using a text editor, create a text document named `example.md` with the
+following content.  Note the two spaces at the end of the first line, which
+specify a hard linebreak.  Due to the limitations of the \TeX{} input
+processor, hard linebreaks would be ignored if we typed them directly into the
+`document.tex` document.
+
+<pre><code>Hello world!  <br/>_Foo_ bar!</code></pre>
+
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(A forced linebreak)*
+> 
+> _Foo_ bar!
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    lineBreak = {%
+      \par
+      \emph{(A forced linebreak)}%
+      \par
+    },
+  },
+}
+\begin{document}
+\markdownInput{example.md}
+\end{document}
+```````
+Using a text editor, create a text document named `example.md` with the
+following content.  Note the two spaces at the end of the first line, which
+specify a hard linebreak.  Due to the limitations of the \TeX{} input
+processor, hard linebreaks would be ignored if we typed them directly into the
+`document.tex` document.
+
+<pre><code>Hello world!  <br/>_Foo_ bar!</code></pre>
+
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(A forced linebreak)*
+> 
+> _Foo_ bar!
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererLineBreak{%
+  \par
+  \emph{(A forced linebreak)}%
+  \par
+}
+\starttext
+\markdownInput{example.md}
+\stoptext
+```````
+Using a text editor, create a text document named `example.md` with the
+following content.  Note the two spaces at the end of the first line, which
+specify a hard linebreak.  Due to the limitations of the \TeX{} input
+processor, hard linebreaks would be ignored if we typed them directly into the
+`document.tex` document.
+
+<pre><code>Hello world!  <br/>_Foo_ bar!</code></pre>
+
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Hello *world*!
+>
+> *(A forced linebreak)*
+> 
+> _Foo_ bar!
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererLineBreak{%
+  \markdownRendererLineBreakPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { lineBreak }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { lineBreak }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Link Renderer
+The \mdef{markdownRendererLink} macro represents a hyperlink. It receives
+four arguments: the label, the fully escaped \acro{uri} that can be directly
+typeset, the raw \acro{uri} that can be used outside typesetting, and the
+title of the link.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownRendererLink#1#2#3#4{%
+  #1 {\tt#2} titled {\it#4}%
+}
+\markdownBegin
+Please visit [the link][ctan].
+
+ [ctan]: https://ctan.org/
+         (the Comprehensive TeX Archive Network)
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Please visit the link <https://ctan.org/> titled *the Comprehensive TeX
+> Archive Network*.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    link = {%
+      #1 \texttt{#2} titled \emph{#4}%
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+Please visit [the link][ctan].
+
+ [ctan]: https://ctan.org/
+         (the Comprehensive TeX Archive Network)
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Please visit the link <https://ctan.org/> titled *the Comprehensive TeX
+> Archive Network*.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererLink#1#2#3#4{%
+  #1 {\tt#2} titled \emph{#4}%
+}
+\starttext
+\startmarkdown
+Please visit [the link][ctan].
+
+ [ctan]: https://ctan.org/
+         (the Comprehensive TeX Archive Network)
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Please visit the link <https://ctan.org/> titled *the Comprehensive TeX
+> Archive Network*.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererLink{%
+  \markdownRendererLinkPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { link }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { link }
+  { 4 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Markdown Document Renderers
+The \mdef{markdownRendererDocumentBegin} and \mdef{markdownRendererDocumentEnd}
+macros represent the beginning and the end of a *markdown* document. The macros
+receive no arguments.
+
+A \TeX{} document may contain any number of markdown documents. Additionally,
+markdown documents may appear not only in a sequence, but several markdown
+documents may also be *nested*. Redefinitions of the macros should take this
+into account.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `nested.md` with the
+following content:
+``` md
+This is a *nested* markdown document.
+```
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[contentBlocks]{markdown}
+\markdownSetup{
+  renderers = {
+    contentBlock = {%
+      \markdownInput{#3}%
+    },
+    documentBegin = {%
+      \par
+      \emph{(The beginning of a document)}
+      \par
+      \begingroup
+      \markdownSetup{snippet=first-nesting-level}%
+    },
+    documentEnd = {%
+      \endgroup
+      \par
+      \emph{(The end of a document)}
+      \par
+    },
+  },
+}
+\markdownSetupSnippet{first-nesting-level}{
+  renderers = {
+    documentBegin = {
+      \par
+      \emph{(The beginning of a nested document)}
+      \par
+      \begingroup
+      \markdownSetup{snippet=second-nesting-level-and-below}
+    },
+  },
+}
+\markdownSetupSnippet{second-nesting-level-and-below}{
+  renderers = {
+    documentBegin = {
+      \par
+      \emph{(The beginning of a nested document)}
+      \par
+      \begingroup
+    },
+    documentEnd = {
+      \endgroup
+      \par
+      \emph{(The end of a nested document)}
+      \par
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+Hello *world*!
+
+/nested.md
+
+_Foo_ bar!
+\end{markdown}
+\begin{markdown}
+
+Bar baz!
+
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> *(The beginning of a document)*
+>
+> Hello *world*!
+>
+> *(The beginning of a nested document)*
+>
+> This is a *nested* markdown document.
+>
+> *(The end of a nested document)*
+>
+> _Foo_ bar!
+>
+> *(The end of a document)*
+>
+> *(The beginning of a document)*
+>
+> Bar baz!
+>
+> *(The end of a document)*
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererDocumentBegin{%
+  \markdownRendererDocumentBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { documentBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { documentBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererDocumentEnd{%
+  \markdownRendererDocumentEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { documentEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { documentEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Non-Breaking Space Renderer
+The \mdef{markdownRendererNbsp} macro represents a non-breaking space.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.bib` with the
+following content:
+``` bib
+@book{knuth:tex,
+  author    = "Knuth, Donald Ervin",
+  title     = "The \TeX book, volume A of Computers and typesetting",
+  publisher = "Addison-Wesley",
+  year      = "1984"
+}
+```````
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[
+  citations,
+  citationNbsps,
+]{markdown}
+\markdownSetup{
+  renderers = {
+    nbsp = {$\cdot$},
+  },
+}
+\begin{document}
+
+\begin{markdown}
+The TeXbook [@knuth:tex, p. 123 and 130] is good.
+\end{markdown}
+
+\bibliographystyle{plain}
+\bibliography{document.bib}
+
+\end{document}
+```````
+Next, invoke LuaTeX and BibTeX from the terminal:
+``` sh
+lualatex document.tex
+bibtex document.aux
+lualatex document.tex
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> The TeXbook [1, p.·123·and·130] is good.
+>
+> ### References
+> [1] Donald Ervin Knuth. _The TeXbook, volume A of Computers and typesetting._
+> Addison-Wesley, 1984.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererNbsp{%
+  \markdownRendererNbspPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { nbsp }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { nbsp }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Note Renderer
+The \mdef{markdownRendererNote} macro represents a note. This macro
+will only be produced, when the \Opt{notes} option is enabled. The
+macro receives a single argument that corresponds to the note text.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionNotes{true}
+\def\markdownRendererNote#1{ (and \lowercase{#1})}
+\markdownBegin
+This is some text[^1] and this is some other text[^2].
+
+ [^1]: this is a note
+
+ [^2]: this is some other note
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is some text (and this is a note) and this is some other
+> text (and this is some other note).
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[notes]{markdown}
+\markdownSetup{
+  renderers = {
+    note = { (and \MakeLowercase{#1})},
+  },
+}
+\begin{document}
+\begin{markdown}
+This is some text[^1] and this is some other text[^2].
+
+ [^1]: this is a note
+
+ [^2]: this is some other note
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is some text (and this is a note) and this is some other
+> text (and this is some other note).
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[notes = yes]
+\def\markdownRendererNote#1{ (and \lowercase{#1})}
+\starttext
+\startmarkdown
+This is some text[^1] and this is some other text[^2].
+
+ [^1]: this is a note
+
+ [^2]: this is some other note
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is some text (and this is a note) and this is some other
+> text (and this is some other note).
+
+%</manual-tokens>
+%<*tex>
+% \fi
+% \begin{markdown}
+%
+% The \mdef{markdownRendererFootnote} and
+% \mdef{markdownRendererFootnotePrototype} macros have been deprecated
+% and will be removed in Markdown 3.0.0.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Npn
+  \markdownRendererNote
+  {
+    \cs_if_exist:NTF
+      \markdownRendererFootnote
+      {
+        \markdownWarning
+          {
+            Footnote~renderer~has~been~deprecated,~
+            to~be~removed~in~Markdown~3.0.0
+          }
+        \markdownRendererFootnote
+      }
+      {
+        \cs_if_exist:NTF
+          \markdownRendererFootnotePrototype
+          {
+            \markdownWarning
+              {
+                Footnote~renderer~prototype~has~been~deprecated,~
+                to~be~removed~in~Markdown~3.0.0
+              }
+            \markdownRendererFootnotePrototype
+          }
+          {
+            \markdownRendererNotePrototype
+          }
+      }
+  }
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { footnote }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { footnote }
+  { 1 }
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { note }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { note }
+  { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par
@@ -12441,359 +14075,19 @@ following text:
 %
 % \begin{markdown}
 
-#### Definition List Renderers
-The following macros are only produced, when the \Opt{definitionLists} option
-is enabled.
-
-The \mdef{markdownRendererDlBegin} macro represents the beginning of a
-definition list that contains an item with several paragraphs of text (the
-list is not tight). The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlBegin{%
-  \markdownRendererDlBeginPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlBegin }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlBegin }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlBeginTight} macro represents the beginning of a
-definition list that contains an item with several paragraphs of text (the
-list is not tight). This macro will only be produced, when the
-\Opt{tightLists} option is disabled. The macro receives no arguments.
+#### Parenthesized Citations Renderer
+The \mdef{markdownRendererCite} macro represents a string of one or more
+parenthetical citations. This macro will only be produced, when the
+\Opt{citations} option is enabled. The macro receives the parameter
+`{`\meta{number of citations}`}` followed by \meta{suppress author}
+`{`\meta{prenote}`}{`\meta{postnote}`}{`\meta{name}`}` repeated
+\meta{number of citations} times. The \meta{suppress author} parameter is
+either the token `-`, when the author's name is to be suppressed, or `+`
+otherwise.
 
 % \end{markdown}
 %
 % \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlBeginTight{%
-  \markdownRendererDlBeginTightPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlBeginTight }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlBeginTight }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlItem} macro represents a term in a definition
-list. The macro receives a single argument that corresponds to the term
-being defined.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlItem{%
-  \markdownRendererDlItemPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlItem }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlItem }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlItemEnd} macro represents the end of a list of
-definitions for a single term.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlItemEnd{%
-  \markdownRendererDlItemEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlItemEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlItemEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlDefinitionBegin} macro represents the beginning
-of a definition in a definition list. There can be several definitions for
-a single term.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlDefinitionBegin{%
-  \markdownRendererDlDefinitionBeginPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlDefinitionBegin }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlDefinitionBegin }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlDefinitionEnd} macro represents the end of a
-definition in a definition list. There can be several definitions for a
-single term.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlDefinitionEnd{%
-  \markdownRendererDlDefinitionEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlDefinitionEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlDefinitionEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlEnd} macro represents the end of a definition
-list that contains an item with several paragraphs of text (the list is not
-tight). The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlEnd{%
-  \markdownRendererDlEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererDlEndTight} macro represents the end of a
-definition list that contains no item with several paragraphs of text (the
-list is tight). This macro will only be produced, when the \Opt{tightLists}
-option is disabled. The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionDefinitionLists{true}
-\def\markdownOptionTightLists{true}
-
-\def\markdownRendererInterblockSeparator{%
-  :%
-  \def\markdownRendererInterblockSeparator{\par}%
-}
-\def\markdownRendererDlBeginTight{%
-  \begingroup
-  \parindent=0pt
-}
-\def\markdownRendererDlItem#1{%
-  \par{\bf#1}%
-  \def\markdownRendererDlDefinitionEnd{%
-    ,
-    \def\markdownRendererDlDefinitionEnd{%
-      , and
-      \def\markdownRendererDlDefinitionEnd{.}%
-    }%
-  }%
-}
-\def\markdownRendererDlItemEnd{}
-\def\markdownRendererDlDefinitionBegin{\par--\kern 0.5em}
-\def\markdownRendererDlEndTight{\endgroup}
-
-\markdownBegin
-This is a tight definition list
-
-Coffee
-:   black hot drink
-:   prepared from roasted coffee beans
-:   one of the most traded agricultural commodities in the world
-
-Milk
-:   white cold drink
-:   nutrient-rich
-:   produced on an industrial scale
-\markdownEnd
-
-\def\markdownRendererInterblockSeparator{%
-  \def\markdownRendererInterblockSeparator{\par}%
-}
-\def\markdownRendererDlBegin{}
-\def\markdownRendererDlItem#1{%
-  . #1 is a
-  \def\markdownRendererDlDefinitionBegin{%
-    \def\markdownRendererDlDefinitionBegin{%
-      ,
-      \def\markdownRendererDlDefinitionBegin{, and }%
-    }%
-  }%
-}
-\def\markdownRendererDlItemEnd{}
-\def\markdownRendererDlDefinitionEnd{}
-\def\markdownRendererDlEnd{.}
-
-\markdownBegin
-This is a loose definition list
-
-Coffee
-
-:   black hot drink
-
-:   prepared from roasted coffee beans
-
-:   one of the most traded agricultural commodities in the world
-
-Milk
-
-:   white cold drink
-
-:   nutrient-rich
-
-:   produced on an industrial scale
-\markdownEnd
-
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is a tight definition list:
->
-> **Coffee**
->
-> - black hot drink,
-> - prepared from roasted coffee beans, and
-> - one of the most traded agricultural commodities in the world.
->
-> **Milk**
->
-> - white cold drink,
-> - nutrient-rich, and
-> - produced on an industrial scale.
->
-> This is a loose definition list. Coffee is a black hot drink, prepared from
-> roasted coffee beans, and one of the most traded agricultural commodities in
-> the world. Milk is a white cold drink, nutrient-rich, and produced on an
-> industrial scale.
 
 ##### \LaTeX{} Example {.unnumbered}
 
@@ -12801,303 +14095,43 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \documentclass{article}
-\usepackage[definitionLists, tightLists]{markdown}
-\begin{document}
-
-\begin{markdown*}{
-  renderers = {
-    interblockSeparator = {%
-      :%
-      \def\markdownRendererInterblockSeparator{\par}%
-    },
-    dlBeginTight = {\begin{description}},
-    dlItem = {%
-      \item[#1]
-      \begin{itemize}
-      \def\markdownRendererDlDefinitionEnd{%
-        ,
-        \def\markdownRendererDlDefinitionEnd{%
-          , and
-          \def\markdownRendererDlDefinitionEnd{.}%
-        }%
-      }%
-    },
-    dlItemEnd = {\end{itemize}},
-    dlDefinitionBegin = \item,
-    dlEndTight = {\end{description}},
-  },
-}
-This is a tight definition list
-
-Coffee
-:   black hot drink
-:   prepared from roasted coffee beans
-:   one of the most traded agricultural commodities in the world
-
-Milk
-:   white cold drink
-:   nutrient-rich
-:   produced on an industrial scale
-\end{markdown*}
-
-\begin{markdown*}{
-  renderers = {
-    interblockSeparator = {%
-      \def\markdownRendererInterblockSeparator{\par}%
-    },
-    dlBegin = {},
-    dlItem = {%
-      . #1 is a
-      \def\markdownRendererDlDefinitionBegin{%
-        \def\markdownRendererDlDefinitionBegin{%
-          ,
-          \def\markdownRendererDlDefinitionBegin{, and }%
-        }%
-      }%
-    },
-    dlItemEnd = {},
-    dlDefinitionEnd = {},
-    dlEnd = {.},
-  },
-}
-This is a loose definition list
-
-Coffee
-
-:   black hot drink
-
-:   prepared from roasted coffee beans
-
-:   one of the most traded agricultural commodities in the world
-
-Milk
-
-:   white cold drink
-
-:   nutrient-rich
-
-:   produced on an industrial scale
-\end{markdown*}
-
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is a tight definition list:
->
-> **Coffee**
->
-> - black hot drink,
-> - prepared from roasted coffee beans, and
-> - one of the most traded agricultural commodities in the world.
->
-> **Milk**
->
-> - white cold drink,
-> - nutrient-rich, and
-> - produced on an industrial scale.
->
-> This is a loose definition list. Coffee is a black hot drink, prepared from
-> roasted coffee beans, and one of the most traded agricultural commodities in
-> the world. Milk is a white cold drink, nutrient-rich, and produced on an
-> industrial scale.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown
-  [
-    definitionLists = yes,
-    tightLists = yes,
-  ]
-\starttext
-
-\def\markdownRendererInterblockSeparator{%
-  :%
-  \def\markdownRendererInterblockSeparator{\par}%
-}
-\def\markdownRendererDlBeginTight{}
-\def\markdownRendererDlItem#1{%
-  \par{\bf#1}%
-  \startitemize
-  \def\markdownRendererDlDefinitionEnd{%
-    ,
-    \def\markdownRendererDlDefinitionEnd{%
-      , and
-      \def\markdownRendererDlDefinitionEnd{.}%
-    }%
-  }%
-}
-\def\markdownRendererDlItemEnd{\stopitemize}
-\def\markdownRendererDlDefinitionBegin{\item}
-\def\markdownRendererDlEndTight{}
-
-\startmarkdown
-This is a tight definition list
-
-Coffee
-:   black hot drink
-:   prepared from roasted coffee beans
-:   one of the most traded agricultural commodities in the world
-
-Milk
-:   white cold drink
-:   nutrient-rich
-:   produced on an industrial scale
-\stopmarkdown
-
-\def\markdownRendererInterblockSeparator{%
-  \def\markdownRendererInterblockSeparator{\par}%
-}
-\def\markdownRendererDlBegin{}
-\def\markdownRendererDlItem#1{%
-  . #1 is a
-  \def\markdownRendererDlDefinitionBegin{%
-    \def\markdownRendererDlDefinitionBegin{%
-      ,
-      \def\markdownRendererDlDefinitionBegin{, and }%
-    }%
-  }%
-}
-\def\markdownRendererDlItemEnd{}
-\def\markdownRendererDlDefinitionEnd{}
-\def\markdownRendererDlEnd{.}
-
-\startmarkdown
-This is a loose definition list
-
-Coffee
-
-:   black hot drink
-
-:   prepared from roasted coffee beans
-
-:   one of the most traded agricultural commodities in the world
-
-Milk
-
-:   white cold drink
-
-:   nutrient-rich
-
-:   produced on an industrial scale
-\stopmarkdown
-
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is a tight definition list:
->
-> **Coffee**
->
-> - black hot drink,
-> - prepared from roasted coffee beans, and
-> - one of the most traded agricultural commodities in the world.
->
-> **Milk**
->
-> - white cold drink,
-> - nutrient-rich, and
-> - produced on an industrial scale.
->
-> This is a loose definition list. Coffee is a black hot drink, prepared from
-> roasted coffee beans, and one of the most traded agricultural commodities in
-> the world. Milk is a white cold drink, nutrient-rich, and produced on an
-> industrial scale.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererDlEndTight{%
-  \markdownRendererDlEndTightPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { dlEndTight }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { dlEndTight }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Emphasis Renderers
-The \mdef{markdownRendererEmphasis} macro represents an emphasized span of
-text. The macro receives a single argument that corresponds to the emphasized
-span of text.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownRendererEmphasis#1{{\it#1}}
-\def\markdownRendererStrongEmphasis#1{{\bf#1}}
-\markdownBegin
-This is *emphasis*.
-
-This is **strong emphasis**.
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is *emphasis*.
->
-> This is **strong emphasis**.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
+\usepackage[citations]{markdown}
+\newcount\citationsCounter
+\newcount\citationsTotal
+\makeatletter
+\def\citations#1#2#3#4{%
+  a parenthesized citation \emph{#4}
+  \advance\citationsCounter by 1\relax
+  \ifx\relax#2\relax
+    \ifx\relax#3\relax\else
+      with a postfix \emph{#3}%
+    \fi
+  \else
+    with a prefix \emph{#2}%
+    \ifx\relax#3\relax\else
+      \ and a postfix \emph{#3}%
+    \fi
+  \fi
+  \ifnum\citationsCounter>\citationsTotal\relax
+    .%
+    \expandafter\@gobble
+  \else
+    , and
+  \fi\citations}
+\makeatother
 \markdownSetup{
   renderers = {
-    emphasis = {\emph{#1}},
-    strongEmphasis = {\textbf{#1}},
+    cite = {%
+      \citationsCounter=1%
+      \citationsTotal=#1%
+      This is
+      \expandafter\citations
+    },
   },
 }
 \begin{document}
 \begin{markdown}
-This is *emphasis*.
-
-This is **strong emphasis**.
+[see @abrahams90, pp. 12; @eijkhout91, pp. 34]
 \end{markdown}
 \end{document}
 ```````
@@ -13108,51 +14142,24 @@ lualatex document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following text:
 
-> This is *emphasis*.
->
-> This is **strong emphasis**.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererEmphasis#1{\emph{#1}}
-\def\markdownRendererStrongEmphasis#1{\bold{#1}}
-\starttext
-\startmarkdown
-This is *emphasis*.
-
-This is **strong emphasis**.
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is *emphasis*.
->
-> This is **strong emphasis**.
+> This is a parenthesized citation *abrahams90* with a prefix see
+> and a postfix *pp. 12*, and a citation *eijkhout91* with a
+> postfix *pp. 34*.
 
 %</manual-tokens>
 %<*tex>
 % \fi
 %
 %  \begin{macrocode}
-\def\markdownRendererEmphasis{%
-  \markdownRendererEmphasisPrototype}%
+\def\markdownRendererCite{%
+  \markdownRendererCitePrototype}%
 \ExplSyntaxOn
 \seq_gput_right:Nn
   \g_@@_renderers_seq
-  { emphasis }
+  { cite }
 \prop_gput:Nnn
   \g_@@_renderer_arities_prop
-  { emphasis }
+  { cite }
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
@@ -13165,9 +14172,12 @@ following text:
 %
 % \begin{markdown}
 
-The \mdef{markdownRendererStrongEmphasis} macro represents a strongly
-emphasized span of text. The macro receives a single argument that
-corresponds to the emphasized span of text.
+#### Raw Content Renderers
+The \mdef{markdownRendererInputRawInline} macro represents an inline raw span.
+The macro receives two arguments: the filename of a file contaning the inline
+raw span contents and the raw attribute that designates the format of the
+inline raw span. This macro will only be produced, when the \Opt{rawAttribute}
+option is enabled.
 
 % \end{markdown}
 %
@@ -13177,343 +14187,15 @@ corresponds to the emphasized span of text.
 % \fi
 %
 %  \begin{macrocode}
-\def\markdownRendererStrongEmphasis{%
-  \markdownRendererStrongEmphasisPrototype}%
+\def\markdownRendererInputRawInline{%
+  \markdownRendererInputRawInlinePrototype}%
 \ExplSyntaxOn
 \seq_gput_right:Nn
   \g_@@_renderers_seq
-  { strongEmphasis }
+  { inputRawInline }
 \prop_gput:Nnn
   \g_@@_renderer_arities_prop
-  { strongEmphasis }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Block Quote Renderers
-The \mdef{markdownRendererBlockQuoteBegin} macro represents the beginning of
-a block quote. The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererBlockQuoteBegin{%
-  \markdownRendererBlockQuoteBeginPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { blockQuoteBegin }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { blockQuoteBegin }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererBlockQuoteEnd} macro represents the end of a block
-quote. The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownRendererBlockQuoteBegin{%
-  \begingroup
-  \vskip\parindent
-  \leftskip=2\parindent
-  \parindent=0pt
-}
-\def\markdownRendererBlockQuoteEnd{%
-  \par
-  \vskip\parindent
-  \endgroup
-}
-\markdownBegin
-A quote from William Shakespeare's King Lear:
-
-> This is the excellent foppery of the world that when we are
-> sick in fortune---often the surfeit of our own behavior---we
-> make guilty of our disasters the sun, the moon, and the
-> stars [...]
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> A quote from William Shakespeare's King Lear:
->
-> > This is the excellent foppery of the world that when we are
-> > sick in fortune—often the surfeit of our own behavior—we
-> > make guilty of our disasters the sun, the moon, and the
-> > stars [...]
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\markdownSetup{
-  renderers = {
-    blockQuoteBegin = {\begin{quote}},
-    blockQuoteEnd = {\end{quote}},
-  },
-}
-\begin{document}
-\begin{markdown}
-A quote from William Shakespeare's King Lear:
-
-> This is the excellent foppery of the world that when we are
-> sick in fortune---often the surfeit of our own behavior---we
-> make guilty of our disasters the sun, the moon, and the
-> stars [...]
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> A quote from William Shakespeare's King Lear:
->
-> > This is the excellent foppery of the world that when we are
-> > sick in fortune—often the surfeit of our own behavior—we
-> > make guilty of our disasters the sun, the moon, and the
-> > stars [...]
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererBlockQuoteBegin{\startquotation}
-\def\markdownRendererBlockQuoteEnd{\stopquotation}
-\starttext
-\startmarkdown
-A quote from William Shakespeare's King Lear:
-
-> This is the excellent foppery of the world that when we are
-> sick in fortune---often the surfeit of our own behavior---we
-> make guilty of our disasters the sun, the moon, and the
-> stars [...]
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> A quote from William Shakespeare's King Lear:
->
-> > This is the excellent foppery of the world that when we are
-> > sick in fortune—often the surfeit of our own behavior—we
-> > make guilty of our disasters the sun, the moon, and the
-> > stars [...]
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererBlockQuoteEnd{%
-  \markdownRendererBlockQuoteEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { blockQuoteEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { blockQuoteEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Code Block Renderers
-The \mdef{markdownRendererInputVerbatim} macro represents a code
-block. The macro receives a single argument that corresponds to the
-filename of a file contaning the code block contents.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInputVerbatim{%
-  \markdownRendererInputVerbatimPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inputVerbatim }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inputVerbatim }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererInputFencedCode} macro represents a fenced code
-block. This macro will only be produced, when the \Opt{fencedCode} option is
-enabled. The macro receives two arguments that correspond to the filename of
-a file contaning the code block contents and to the code fence infostring.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{verbatim}
-\usepackage[hyphens]{url}
-\usepackage[fencedCode]{markdown}
-\markdownSetup{
-  renderers = {
-    interblockSeparator = {
-      \def\markdownRendererInterblockSeparator{%
-        \par
-        \def\markdownRendererInterblockSeparator{%
-          \def\markdownRendererInterblockSeparator{%
-            \par
-          }%
-        }%
-      }%
-    },
-    inputVerbatim = {
-      is contained in file \url{#1}:%
-      \verbatiminput{#1}%
-    },
-    inputFencedCode = {
-      in #2 \markdownRendererInputVerbatim{#1}%
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-The following code
-
-    def foo(bar):
-      if len(bar) <= 1:
-        return bar[0]
-      elif len(bar) == 2:
-        return sorted(bar)
-      else:
-        baz = len(bar) // 2
-        return foo(bar[baz:], bar[:baz])
-
-The following code
-
-~~~ Python
->>> foo([4, 2, 1, 3])
-[1, 2, 3, 4]
-~~~~~~~~~~
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text except for the filename, which may differ:
-
-> The following code is contained in file
-> `./_markdown_document/882453149edcf288976647f6fe147ada.verbatim`:
-> ``` py
-> def foo(bar):
->   if len(bar) <= 1:
->     return bar[:1]
->   elif len(bar) == 2:
->     return sorted(bar)
->   else:
->     baz = bar[len(bar) // 2]
->     return (
->       foo([qux for qux in bar if qux < baz]) + [baz] +
->       foo([qux for qux in bar if qux > baz])
->     )
-> ``````
-> The following code in Python contained in file
-> `./_markdown_document/cf2a96e2120cef5b1fae5fea36fcc27b.verbatim`:
-> ``` py
-> >>> foo([4, 2, 1, 3])
-> [1, 2, 3, 4]
-> ``````
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInputFencedCode{%
-  \markdownRendererInputFencedCodePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inputFencedCode }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inputFencedCode }
+  { inputRawInline }
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
@@ -13523,6 +14205,1152 @@ following text except for the filename, which may differ:
 %</tex>
 %<*manual-tokens>
 % \fi
+%
+% \begin{markdown}
+
+The \mdef{markdownRendererInputRawBlock} macro represents a raw block. The
+macro receives two arguments: the filename of a file contaning the raw block
+and the raw attribute that designates the format of the raw block. This macro
+will only be produced, when the \Opt{rawAttribute} and \Opt{fencedCode} options
+are enabled.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[rawAttribute, fencedCode]{markdown}
+\usepackage{expl3}
+\ExplSyntaxOn
+\cs_new:Nn
+  \display_raw_content:nn
+  {
+    % If the raw attribute is TeX, execute the content as a TeX document.
+    \str_if_eq:nnTF
+      { #2 }
+      { tex }
+      { \markdownEscape { #1 } }
+      % Otherwise, ignore the content.
+      { }
+  }
+\markdownSetup{
+  renderers = {
+    rawInline = { \display_raw_content:nn { #1 } { #2 } },
+    rawBlock  = { \display_raw_content:nn { #1 } { #2 } }
+  },
+}
+\ExplSyntaxOff
+\begin{document}
+\begin{markdown}
+`$H_2 O$`{=tex} is a liquid.
+
+``` {=html}
+<p>Here is some HTML content that will be ignored.</p>
+```
+\end{markdown}
+\end{document}
+````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> H~2~O is a liquid.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererInputRawBlock{%
+  \markdownRendererInputRawBlockPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { inputRawBlock }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { inputRawBlock }
+  { 2 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Special Character Renderers
+The following macros replace any special plain \TeX{} characters, including
+% \iffalse
+the active pipe character (`|`) of \Hologo{ConTeXt}, in the input text:
+
+- \mdef{markdownRendererAmpersand} replaces the ampersand (`&`).
+- \mdef{markdownRendererBackslash} replaces the backslash (`\`).
+- \mdef{markdownRendererCircumflex} replaces the circumflex (`^`).
+- \mdef{markdownRendererDollarSign} replaces the dollar sign (`$`).
+- \mdef{markdownRendererHash} replaces the hash sign (`#`).
+- \mdef{markdownRendererLeftBrace} replaces the left brace (`{`).
+- \mdef{markdownRendererPercentSign} replaces the percent sign (`%`).
+- \mdef{markdownRendererPipe} replaces the pipe character (`|`).
+- \mdef{markdownRendererRightBrace} replaces the right brace (`}`).
+- \mdef{markdownRendererTilde} replaces the tilde (`~`).
+- \mdef{markdownRendererUnderscore} replaces the underscore (`_`).
+
+% \fi
+% the active pipe character (`|`) of \Hologo{ConTeXt}, in the input text.
+% These macros will only be produced, when the \Opt{hybrid} option is
+% `false`.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content. We will make the tilde behave as if it were written in
+\TeX{}, where it represents a non-breaking space.
+``` tex
+\input markdown
+\def\markdownRendererTilde{~}
+\markdownBegin
+Bartel~Leendert van~der~Waerden
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text, where the middot (`·`) denotes a non-breaking space:
+
+> Bartel·Leendert van·der·Waerden
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content. We will make the tilde behave as if it were written in
+\TeX{}, where it represents a non-breaking space.
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    tilde = ~,
+  },
+}
+\begin{document}
+\begin{markdown}
+Bartel~Leendert van~der~Waerden
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text, where the middot (`·`) denotes a non-breaking space:
+
+> Bartel·Leendert van·der·Waerden
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content. We will make the tilde behave as if it were written in
+\TeX{}, where it represents a non-breaking space.
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererTilde{~}
+\starttext
+\startmarkdown
+Bartel~Leendert van~der~Waerden
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text, where the middot (`·`) denotes a non-breaking space:
+
+> Bartel·Leendert van·der·Waerden
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererLeftBrace{%
+  \markdownRendererLeftBracePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { leftBrace }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { leftBrace }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererRightBrace{%
+  \markdownRendererRightBracePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { rightBrace }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { rightBrace }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererDollarSign{%
+  \markdownRendererDollarSignPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { dollarSign }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { dollarSign }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererPercentSign{%
+  \markdownRendererPercentSignPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { percentSign }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { percentSign }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererAmpersand{%
+  \markdownRendererAmpersandPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { ampersand }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { ampersand }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererUnderscore{%
+  \markdownRendererUnderscorePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { underscore }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { underscore }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererHash{%
+  \markdownRendererHashPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { hash }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { hash }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererCircumflex{%
+  \markdownRendererCircumflexPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { circumflex }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { circumflex }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererBackslash{%
+  \markdownRendererBackslashPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { backslash }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { backslash }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererTilde{%
+  \markdownRendererTildePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { tilde }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { tilde }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererPipe{%
+  \markdownRendererPipePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { pipe }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { pipe }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Strike-Through Renderer
+The \mdef{markdownRendererStrikeThrough} macro represents a strike-through span of
+text. The macro receives a single argument that corresponds to the striked-out
+span of text. This macro will only be produced, when the \Opt{strikeThrough}
+option is enabled.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionStrikeThrough{true}
+\input soulutf8.sty
+\def\markdownRendererStrikeThrough#1{\st{#1}}
+\markdownBegin
+This is ~~a lunar roving vehicle~~ strike-through text.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[strikeThrough]{markdown}
+\usepackage{soulutf8}
+\markdownSetup{
+  renderers = {
+    strikeThrough = {\st{#1}},
+  },
+}
+\begin{document}
+\begin{markdown}
+This is ~~a lunar roving vehicle~~ strike-through text.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[strikeThrough = yes]
+\def\markdownRendererStrikeThrough#1{\overstrikes{#1}}
+\starttext
+\startmarkdown
+This is ~~a lunar roving vehicle~~ strike-through text.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is ~~a lunar roving vehicle~~ strike-through text.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererStrikeThrough{%
+  \markdownRendererStrikeThroughPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { strikeThrough }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { strikeThrough }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Subscript Renderer
+The \mdef{markdownRendererSubscript} macro represents a subscript span of
+text. The macro receives a single argument that corresponds to the subscript
+span of text. This macro will only be produced, when the \Opt{subscripts}
+option is enabled.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionSubscripts{true}
+\def\markdownRendererSubscript#1{ (#1 moles) and }
+\markdownBegin
+H~2~O is a liquid.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> H (2 moles) and O is a liquid.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[subscripts]{markdown}
+\markdownSetup{
+  renderers = {
+    subscript = { (#1 moles) and },
+  },
+}
+\begin{document}
+\begin{markdown}
+H~2~O is a liquid.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> H (2 moles) and O is a liquid.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[subscripts = yes]
+\def\markdownRendererSubscript#1{ (#1 moles) and }
+\starttext
+\startmarkdown
+H~2~O is a liquid.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> H (2 moles) and O is a liquid.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererSubscript{%
+  \markdownRendererSubscriptPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { subscript }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { subscript }
+  { 1 }
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Superscript Renderer
+The \mdef{markdownRendererSuperscript} macro represents a superscript span of
+text. The macro receives a single argument that corresponds to the superscript
+span of text. This macro will only be produced, when the \Opt{superscripts}
+option is enabled.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownOptionSuperscripts{true}
+\def\markdownRendererSuperscript#1{ taken to the power of #1}
+\markdownBegin
+2^10^ is 1024.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> 2 taken to the power of 10 is 1024.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[superscripts]{markdown}
+\markdownSetup{
+  renderers = {
+    superscript = { taken to the power of #1},
+  },
+}
+\begin{document}
+\begin{markdown}
+2^10^ is 1024.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> 2 taken to the power of 10 is 1024.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[superscripts = yes]
+\def\markdownRendererSuperscript#1{ taken to the power of #1}
+\starttext
+\startmarkdown
+2^10^ is 1024.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> 2 taken to the power of 10 is 1024.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererSuperscript{%
+  \markdownRendererSuperscriptPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { superscript }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { superscript }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Table Renderer
+The \mdef{markdownRendererTable} macro represents a table. This macro will only
+be produced, when the \Opt{pipeTables} option is enabled. The macro receives the
+parameters `{`\meta{caption}`}{`\meta{number of rows}`}{`\meta{number of columns}`}`
+followed by `{`\meta{alignments}`}` and then by `{`\meta{row}`}` repeated
+\meta{number of rows} times, where \meta{row} is `{`\meta{column}`}` repeated
+\meta{number of columns} times, \meta{alignments} is \meta{alignment} repeated
+\meta{number of columns} times, and \meta{alignment} is one of the following:
+
+- `d` -- The corresponding column has an unspecified (default) alignment.
+- `l` -- The corresponding column is left-aligned.
+- `c` -- The corresponding column is centered.
+- `r` -- The corresponding column is right-aligned.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[pipeTables, tableCaptions]{markdown}
+\newcount\rowCounter
+\newcount\columnCounter
+\makeatletter
+\def\processRow#1{%
+  \columnCounter=1%
+  \ifnum\rowCounter=0\relax
+    As for the alignment,
+  \else
+    In row \the\rowCounter,
+  \fi
+  \processColumn#1
+  \advance\rowCounter by 1\relax
+  \ifnum\rowCounter>\rowTotal\relax
+    \expandafter\@gobble
+  \fi\processRow}%
+\def\processColumn#1{%
+  column number \the\columnCounter{}
+  \ifnum\rowCounter=0\relax
+    \if#1d{}has default alignment\fi
+    \if#1l{}is left-aligned\fi
+    \if#1c{}is centered\fi
+    \if#1r{}is right-aligned\fi
+  \else
+    says \emph{#1}%
+  \fi
+  \advance\columnCounter by 1\relax
+  \ifnum\columnCounter<\columnTotal\relax, \fi
+  \ifnum\columnCounter=\columnTotal\relax, and \fi
+  \ifnum\columnCounter>\columnTotal\relax
+    .\expandafter\@gobble
+  \fi\processColumn}%
+\makeatother
+\markdownSetup{
+  renderers = {
+    table = {%
+      This is a table with caption \emph{#1} that is #3 colums wide
+      and #2 rows long.
+      \rowCounter=0%
+      \def\rowTotal{#2}%
+      \def\columnTotal{#3}%
+      \processRow
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+| Right | Left | Default | Center |
+|------:|:-----|---------|:------:|
+|   12  |  12  |    12   |    12  |
+|  123  |  123 |   123   |   123  |
+|    1  |    1 |     1   |     1  |
+
+  : Demonstration of pipe table syntax
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is a table with caption *Demonstration of pipe table syntax* that is 4
+> colums wide and 4 rows long. As for the alignment, column number 1 is
+> right-aligned, column number 2 is left-aligned, column number 3 has default
+> alignment, and column number 4 is centered. In row 1, column number 1 says
+> *Right*, column number 2 says *Left*, column number 3 says *Default*, and
+> column number 4 says *Center*. In row 2, column number 1 says *12*, column
+> number 2 says *12*, column number 3 says *12*, and column number 4 says *12*.
+> In row 3, column number 1 says *123*, column number 2 says *123*, column
+> number 3 says *123*, and column number 4 says *123*. In row 4, column number
+> 1 says *1*, column number 2 says *1*, column number 3 says *1*, and column
+> number 4 says *1*.
+
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererTable{%
+  \markdownRendererTablePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { table }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { table }
+  { 3 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Text Citations Renderer
+The \mdef{markdownRendererTextCite} macro represents a string of one or more
+text citations. This macro will only be produced, when the
+\Opt{citations} option is enabled. The macro receives parameters in the same 
+format as the \mref{markdownRendererCite} macro.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[citations]{markdown}
+\newcount\citationsCounter
+\newcount\citationsTotal
+\makeatletter
+\def\citations#1#2#3#4{%
+  a text citation \emph{#4}
+  \advance\citationsCounter by 1\relax
+  \ifx\relax#2\relax
+    \ifx\relax#3\relax\else
+      with a postfix \emph{#3}%
+    \fi
+  \else
+    with a prefix \emph{#2}%
+    \ifx\relax#3\relax\else
+      \ and a postfix \emph{#3}%
+    \fi
+  \fi
+  \ifnum\citationsCounter>\citationsTotal\relax
+    .%
+    \expandafter\@gobble
+  \else
+    , and
+  \fi\citations}
+\makeatother
+\markdownSetup{
+  renderers = {
+    textCite = {%
+      \citationsCounter=1%
+      \citationsTotal=#1%
+      This is
+      \expandafter\citations
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+@abrahams90 [pp. 12; also @eijkhout91]
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is a text citation *abrahams90* with a postfix *pp. 12*,
+> and a citation *eijkhout91* with a prefix *also*.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererTextCite{%
+  \markdownRendererTextCitePrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { textCite }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { textCite }
+  { 1 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Thematic Break Renderer
+The \mdef{markdownRendererThematicBreak} macro represents a thematic break.
+The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\def\markdownRendererThematicBreak{\vfil\break}
+\markdownBegin
+This is the first page.
+
+***
+
+This is the second page.
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is the first page.
+>
+> ***
+>
+> This is the second page.
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\markdownSetup{
+  renderers = {
+    thematicBreak = \newpage,
+  },
+}
+\begin{document}
+\begin{markdown}
+This is the first page.
+
+***
+
+This is the second page.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is the first page.
+>
+> ***
+>
+> This is the second page.
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\def\markdownRendererThematicBreak{\page[yes]}
+\starttext
+\startmarkdown
+This is the first page.
+
+***
+
+This is the second page.
+\stopmarkdown
+\stoptext
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> This is the first page.
+>
+> ***
+>
+> This is the second page.
+
+%</manual-tokens>
+%<*tex>
+% \fi
+% \begin{markdown}
+%
+% The \mdef{markdownRendererHorizontalRule} and
+% \mdef{markdownRendererHorizontalRulePrototype} macros have been deprecated
+% and will be removed in Markdown 3.0.0.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Npn
+  \markdownRendererThematicBreak
+  {
+    \cs_if_exist:NTF
+      \markdownRendererHorizontalRule
+      {
+        \markdownWarning
+          {
+            Horizontal~rule~renderer~has~been~deprecated,~
+            to~be~removed~in~Markdown~3.0.0
+          }
+        \markdownRendererHorizontalRule
+      }
+      {
+        \cs_if_exist:NTF
+          \markdownRendererHorizontalRulePrototype
+          {
+            \markdownWarning
+              {
+                Horizontal~rule~renderer~prototype~has~been~deprecated,~
+                to~be~removed~in~Markdown~3.0.0
+              }
+            \markdownRendererHorizontalRulePrototype
+          }
+          {
+            \markdownRendererThematicBreakPrototype
+          }
+      }
+  }
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { horizontalRule }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { horizontalRule }
+  { 0 }
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { thematicBreak }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { thematicBreak }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
+#### Tickbox Renderers
+The macros named \mdef{markdownRendererTickedBox},
+\mdef{markdownRendererHalfTickedBox}, and \mdef{markdownRendererUntickedBox}
+represent ticked and unticked boxes, respectively. These macros will either be
+produced, when the \Opt{taskLists} option is enabled, or when the Ballot Box
+with X (☒, U+2612), Hourglass (⌛, U+231B) or Ballot Box (☐, U+2610) Unicode
+characters are encountered in the markdown input, respectively.
+
+% \end{markdown}
+%
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[taskLists]{markdown}
+\markdownSetup{
+  renderers = {
+    untickedBox = No,
+    tickedBox = Yes,
+  },
+}
+\begin{document}
+\begin{markdown}
+- [ ] you can't.
+- [x] I can!
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> - No you can't.
+> - Yes I can!
+
+##### \Hologo{ConTeXt} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[taskLists = yes]
+\def\markdownRendererUntickedBox{No}
+\def\markdownRendererTickedBox{Yes}
+\starttext
+\startmarkdown
+- [ ] you can't.
+- [x] I can!
+\stopmarkdown
+\stoptext
+````````
+Next, invoke LuaTeX from the terminal:
+``` sh
+context document.tex
+`````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> - No you can't.
+> - Yes I can!
+
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererTickedBox{%
+  \markdownRendererTickedBoxPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { tickedBox }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { tickedBox }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererHalfTickedBox{%
+  \markdownRendererHalfTickedBoxPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { halfTickedBox }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { halfTickedBox }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererUntickedBox{%
+  \markdownRendererUntickedBoxPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { untickedBox }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { untickedBox }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
 % \begin{markdown}
 
 #### YAML Metadata Renderers {#yamlmetadatarenderers}
@@ -13963,1831 +15791,6 @@ following text:
 
 > Jane Doe is 99 years old.
 
-% \fi
-%
-% \begin{markdown}
-
-#### Heading Renderers
-The \mdef{markdownRendererHeadingOne} macro represents a first level heading.
-The macro receives a single argument that corresponds to the heading text.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeadingOne{%
-  \markdownRendererHeadingOnePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headingOne }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headingOne }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererHeadingTwo} macro represents a second level
-heading. The macro receives a single argument that corresponds to the heading
-text.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeadingTwo{%
-  \markdownRendererHeadingTwoPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headingTwo }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headingTwo }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererHeadingThree} macro represents a third level
-heading. The macro receives a single argument that corresponds to the heading
-text.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeadingThree{%
-  \markdownRendererHeadingThreePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headingThree }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headingThree }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererHeadingFour} macro represents a fourth level
-heading. The macro receives a single argument that corresponds to the heading
-text.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeadingFour{%
-  \markdownRendererHeadingFourPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headingFour }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headingFour }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererHeadingFive} macro represents a fifth level
-heading. The macro receives a single argument that corresponds to the heading
-text.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeadingFive{%
-  \markdownRendererHeadingFivePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headingFive }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headingFive }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererHeadingSix} macro represents a sixth level
-heading. The macro receives a single argument that corresponds to the heading
-text.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownRendererInterblockSeparator{}
-\def\markdownRendererHeadingOne{1}
-\def\markdownRendererHeadingTwo{2}
-\def\markdownRendererHeadingThree{3}
-\def\markdownRendererHeadingFour{4}
-\def\markdownRendererHeadingFive{5}
-\def\markdownRendererHeadingSix{6}
-\markdownBegin
-######
-#####
-#####
-###
-######
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> 65536
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\markdownSetup{
-  renderers = {
-    interblockSeparator = {},
-    headingOne = 1,
-    headingTwo = 2,
-    headingThree = 3,
-    headingFour = 4,
-    headingFive = 5,
-    headingSix = 6,
-  },
-}
-\begin{document}
-\begin{markdown}
-######
-#####
-#####
-###
-######
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> 65536
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererInterblockSeparator{}
-\def\markdownRendererHeadingOne{1}
-\def\markdownRendererHeadingTwo{2}
-\def\markdownRendererHeadingThree{3}
-\def\markdownRendererHeadingFour{4}
-\def\markdownRendererHeadingFive{5}
-\def\markdownRendererHeadingSix{6}
-\starttext
-\startmarkdown
-######
-#####
-#####
-###
-######
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> 65536
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeadingSix{%
-  \markdownRendererHeadingSixPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headingSix }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headingSix }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Thematic Break Renderer
-The \mdef{markdownRendererThematicBreak} macro represents a thematic break.
-The macro receives no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownRendererThematicBreak{\vfil\break}
-\markdownBegin
-This is the first page.
-
-***
-
-This is the second page.
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is the first page.
->
-> ***
->
-> This is the second page.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage{markdown}
-\markdownSetup{
-  renderers = {
-    thematicBreak = \newpage,
-  },
-}
-\begin{document}
-\begin{markdown}
-This is the first page.
-
-***
-
-This is the second page.
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is the first page.
->
-> ***
->
-> This is the second page.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\def\markdownRendererThematicBreak{\page[yes]}
-\starttext
-\startmarkdown
-This is the first page.
-
-***
-
-This is the second page.
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is the first page.
->
-> ***
->
-> This is the second page.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-% \begin{markdown}
-%
-% The \mdef{markdownRendererHorizontalRule} and
-% \mdef{markdownRendererHorizontalRulePrototype} macros have been deprecated
-% and will be removed in Markdown 3.0.0.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\cs_new:Npn
-  \markdownRendererThematicBreak
-  {
-    \cs_if_exist:NTF
-      \markdownRendererHorizontalRule
-      {
-        \markdownWarning
-          {
-            Horizontal~rule~renderer~has~been~deprecated,~
-            to~be~removed~in~Markdown~3.0.0
-          }
-        \markdownRendererHorizontalRule
-      }
-      {
-        \cs_if_exist:NTF
-          \markdownRendererHorizontalRulePrototype
-          {
-            \markdownWarning
-              {
-                Horizontal~rule~renderer~prototype~has~been~deprecated,~
-                to~be~removed~in~Markdown~3.0.0
-              }
-            \markdownRendererHorizontalRulePrototype
-          }
-          {
-            \markdownRendererThematicBreakPrototype
-          }
-      }
-  }
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { horizontalRule }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { horizontalRule }
-  { 0 }
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { thematicBreak }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { thematicBreak }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Note Renderer
-The \mdef{markdownRendererNote} macro represents a note. This macro
-will only be produced, when the \Opt{notes} option is enabled. The
-macro receives a single argument that corresponds to the note text.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionNotes{true}
-\def\markdownRendererNote#1{ (and \lowercase{#1})}
-\markdownBegin
-This is some text[^1] and this is some other text[^2].
-
- [^1]: this is a note
-
- [^2]: this is some other note
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is some text (and this is a note) and this is some other
-> text (and this is some other note).
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[notes]{markdown}
-\markdownSetup{
-  renderers = {
-    note = { (and \MakeLowercase{#1})},
-  },
-}
-\begin{document}
-\begin{markdown}
-This is some text[^1] and this is some other text[^2].
-
- [^1]: this is a note
-
- [^2]: this is some other note
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is some text (and this is a note) and this is some other
-> text (and this is some other note).
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[notes = yes]
-\def\markdownRendererNote#1{ (and \lowercase{#1})}
-\starttext
-\startmarkdown
-This is some text[^1] and this is some other text[^2].
-
- [^1]: this is a note
-
- [^2]: this is some other note
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is some text (and this is a note) and this is some other
-> text (and this is some other note).
-
-%</manual-tokens>
-%<*tex>
-% \fi
-% \begin{markdown}
-%
-% The \mdef{markdownRendererFootnote} and
-% \mdef{markdownRendererFootnotePrototype} macros have been deprecated
-% and will be removed in Markdown 3.0.0.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\cs_new:Npn
-  \markdownRendererNote
-  {
-    \cs_if_exist:NTF
-      \markdownRendererFootnote
-      {
-        \markdownWarning
-          {
-            Footnote~renderer~has~been~deprecated,~
-            to~be~removed~in~Markdown~3.0.0
-          }
-        \markdownRendererFootnote
-      }
-      {
-        \cs_if_exist:NTF
-          \markdownRendererFootnotePrototype
-          {
-            \markdownWarning
-              {
-                Footnote~renderer~prototype~has~been~deprecated,~
-                to~be~removed~in~Markdown~3.0.0
-              }
-            \markdownRendererFootnotePrototype
-          }
-          {
-            \markdownRendererNotePrototype
-          }
-      }
-  }
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { footnote }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { footnote }
-  { 1 }
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { note }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { note }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Parenthesized Citations Renderer
-The \mdef{markdownRendererCite} macro represents a string of one or more
-parenthetical citations. This macro will only be produced, when the
-\Opt{citations} option is enabled. The macro receives the parameter
-`{`\meta{number of citations}`}` followed by \meta{suppress author}
-`{`\meta{prenote}`}{`\meta{postnote}`}{`\meta{name}`}` repeated
-\meta{number of citations} times. The \meta{suppress author} parameter is
-either the token `-`, when the author's name is to be suppressed, or `+`
-otherwise.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[citations]{markdown}
-\newcount\citationsCounter
-\newcount\citationsTotal
-\makeatletter
-\def\citations#1#2#3#4{%
-  a parenthesized citation \emph{#4}
-  \advance\citationsCounter by 1\relax
-  \ifx\relax#2\relax
-    \ifx\relax#3\relax\else
-      with a postfix \emph{#3}%
-    \fi
-  \else
-    with a prefix \emph{#2}%
-    \ifx\relax#3\relax\else
-      \ and a postfix \emph{#3}%
-    \fi
-  \fi
-  \ifnum\citationsCounter>\citationsTotal\relax
-    .%
-    \expandafter\@gobble
-  \else
-    , and
-  \fi\citations}
-\makeatother
-\markdownSetup{
-  renderers = {
-    cite = {%
-      \citationsCounter=1%
-      \citationsTotal=#1%
-      This is
-      \expandafter\citations
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-[see @abrahams90, pp. 12; @eijkhout91, pp. 34]
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is a parenthesized citation *abrahams90* with a prefix see
-> and a postfix *pp. 12*, and a citation *eijkhout91* with a
-> postfix *pp. 34*.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererCite{%
-  \markdownRendererCitePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { cite }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { cite }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Text Citations Renderer
-The \mdef{markdownRendererTextCite} macro represents a string of one or more
-text citations. This macro will only be produced, when the
-\Opt{citations} option is enabled. The macro receives parameters in the same 
-format as the \mref{markdownRendererCite} macro.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[citations]{markdown}
-\newcount\citationsCounter
-\newcount\citationsTotal
-\makeatletter
-\def\citations#1#2#3#4{%
-  a text citation \emph{#4}
-  \advance\citationsCounter by 1\relax
-  \ifx\relax#2\relax
-    \ifx\relax#3\relax\else
-      with a postfix \emph{#3}%
-    \fi
-  \else
-    with a prefix \emph{#2}%
-    \ifx\relax#3\relax\else
-      \ and a postfix \emph{#3}%
-    \fi
-  \fi
-  \ifnum\citationsCounter>\citationsTotal\relax
-    .%
-    \expandafter\@gobble
-  \else
-    , and
-  \fi\citations}
-\makeatother
-\markdownSetup{
-  renderers = {
-    textCite = {%
-      \citationsCounter=1%
-      \citationsTotal=#1%
-      This is
-      \expandafter\citations
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-@abrahams90 [pp. 12; also @eijkhout91]
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is a text citation *abrahams90* with a postfix *pp. 12*,
-> and a citation *eijkhout91* with a prefix *also*.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererTextCite{%
-  \markdownRendererTextCitePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { textCite }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { textCite }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Table Renderer
-The \mdef{markdownRendererTable} macro represents a table. This macro will only
-be produced, when the \Opt{pipeTables} option is enabled. The macro receives the
-parameters `{`\meta{caption}`}{`\meta{number of rows}`}{`\meta{number of columns}`}`
-followed by `{`\meta{alignments}`}` and then by `{`\meta{row}`}` repeated
-\meta{number of rows} times, where \meta{row} is `{`\meta{column}`}` repeated
-\meta{number of columns} times, \meta{alignments} is \meta{alignment} repeated
-\meta{number of columns} times, and \meta{alignment} is one of the following:
-
-- `d` -- The corresponding column has an unspecified (default) alignment.
-- `l` -- The corresponding column is left-aligned.
-- `c` -- The corresponding column is centered.
-- `r` -- The corresponding column is right-aligned.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[pipeTables, tableCaptions]{markdown}
-\newcount\rowCounter
-\newcount\columnCounter
-\makeatletter
-\def\processRow#1{%
-  \columnCounter=1%
-  \ifnum\rowCounter=0\relax
-    As for the alignment,
-  \else
-    In row \the\rowCounter,
-  \fi
-  \processColumn#1
-  \advance\rowCounter by 1\relax
-  \ifnum\rowCounter>\rowTotal\relax
-    \expandafter\@gobble
-  \fi\processRow}%
-\def\processColumn#1{%
-  column number \the\columnCounter{}
-  \ifnum\rowCounter=0\relax
-    \if#1d{}has default alignment\fi
-    \if#1l{}is left-aligned\fi
-    \if#1c{}is centered\fi
-    \if#1r{}is right-aligned\fi
-  \else
-    says \emph{#1}%
-  \fi
-  \advance\columnCounter by 1\relax
-  \ifnum\columnCounter<\columnTotal\relax, \fi
-  \ifnum\columnCounter=\columnTotal\relax, and \fi
-  \ifnum\columnCounter>\columnTotal\relax
-    .\expandafter\@gobble
-  \fi\processColumn}%
-\makeatother
-\markdownSetup{
-  renderers = {
-    table = {%
-      This is a table with caption \emph{#1} that is #3 colums wide
-      and #2 rows long.
-      \rowCounter=0%
-      \def\rowTotal{#2}%
-      \def\columnTotal{#3}%
-      \processRow
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-| Right | Left | Default | Center |
-|------:|:-----|---------|:------:|
-|   12  |  12  |    12   |    12  |
-|  123  |  123 |   123   |   123  |
-|    1  |    1 |     1   |     1  |
-
-  : Demonstration of pipe table syntax
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is a table with caption *Demonstration of pipe table syntax* that is 4
-> colums wide and 4 rows long. As for the alignment, column number 1 is
-> right-aligned, column number 2 is left-aligned, column number 3 has default
-> alignment, and column number 4 is centered. In row 1, column number 1 says
-> *Right*, column number 2 says *Left*, column number 3 says *Default*, and
-> column number 4 says *Center*. In row 2, column number 1 says *12*, column
-> number 2 says *12*, column number 3 says *12*, and column number 4 says *12*.
-> In row 3, column number 1 says *123*, column number 2 says *123*, column
-> number 3 says *123*, and column number 4 says *123*. In row 4, column number
-> 1 says *1*, column number 2 says *1*, column number 3 says *1*, and column
-> number 4 says *1*.
-
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererTable{%
-  \markdownRendererTablePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { table }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { table }
-  { 3 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### HTML Comment Renderers
-
-The \mdef{markdownRendererInlineHtmlComment} macro represents the contents of an
-inline \acro{HTML} comment. This macro will only be produced, when the
-\Opt{html} option is enabled. The macro receives a single argument that
-corresponds to the contents of the \acro{HTML} comment.
-
-The \mdef{markdownRendererBlockHtmlCommentBegin} and
-\mdef{markdownRendererBlockHtmlCommentEnd} macros represent the beginning
-and the end of a block \acro{HTML} comment. The macros receive no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[html]{markdown}
-\usepackage{marginnote}
-\markdownSetup{
-  renderers = {
-    inlineHtmlComment = {\marginnote{#1}},
-    blockHtmlCommentBegin = {\begin{quote}},
-    blockHtmlCommentEnd = {\end{quote}},
-  },
-}
-\begin{document}
-\begin{markdown}
-A useful use of inline HTML comments are side notes.
-<!-- Side notes are displayed in the horizontal margins next to the relevant
-passages, which makes them *easier for the reader to find* than notes. -->
-
-We can render block HTML comments as blockquotes:
-
-<!--
-Here is a block HTML comment with a code example that a programmer might understand:
-
-    foo = bar + baz - 42
--->
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following body text:
-
-> A useful use of HTML comments are side notes.
->
-> We can render block HTML comments as blockquotes:
-> 
-> > Here is a block HTML comment with a code example that a programmer might
-> > understand:
-> >
-> >     foo = bar + baz - 42
-
-The horizontal margins should contain the following text:
-
-> Side notes are displayed in the horizontal margins next to the relevant
-> passages, which makes them *easier for the reader to find* than notes.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInlineHtmlComment{%
-  \markdownRendererInlineHtmlCommentPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inlineHtmlComment }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inlineHtmlComment }
-  { 1 }
-\ExplSyntaxOff
-\def\markdownRendererBlockHtmlCommentBegin{%
-  \markdownRendererBlockHtmlCommentBeginPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { blockHtmlCommentBegin }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { blockHtmlCommentBegin }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererBlockHtmlCommentEnd{%
-  \markdownRendererBlockHtmlCommentEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { blockHtmlCommentEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { blockHtmlCommentEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### HTML Tag and Element Renderers
-
-The \mdef{markdownRendererInlineHtmlTag} macro represents an opening, closing,
-or empty inline \acro{HTML} tag. This macro will only be produced, when the
-\Opt{html} option is enabled. The macro receives a single argument that
-corresponds to the contents of the \acro{HTML} tag.
-
-The \mdef{markdownRendererInputBlockHtmlElement} macro represents a block
-\acro{HTML} element. This macro will only be produced, when the \Opt{html}
-option is enabled. The macro receives a single argument that filename of a file
-containing the contents of the \acro{HTML} element.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[html]{markdown}
-\usepackage{marginnote}
-\usepackage{verbatim}
-\markdownSetup{
-  renderers = {
-    inlineHtmlTag = {\textbf{#1}},
-    inputBlockHtmlElement = {\verbatiminput{#1}},
-  },
-}
-\begin{document}
-\begin{markdown}
-<b>_Hello,_ world!</b><br/>
-
-<div>_Hello,_ world!</div>
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following body text:
-
-> **<b>**_Hello,_ world!**</b><br/>**
->
->     <div>_Hello,_ world!</div>
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInlineHtmlTag{%
-  \markdownRendererInlineHtmlTagPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inlineHtmlTag }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inlineHtmlTag }
-  { 1 }
-\ExplSyntaxOff
-\def\markdownRendererInputBlockHtmlElement{%
-  \markdownRendererInputBlockHtmlElementPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inputBlockHtmlElement }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inputBlockHtmlElement }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Attribute Renderers
-The following macros are only produced, when the \Opt{headerAttributes} option
-is enabled.
-
-\mdef{markdownRendererAttributeIdentifier} represents the \meta{identifier} of
-a markdown element (`id="`\meta{identifier}`"` in HTML and `#`\meta{identifier}
-in Markdown's \Opt{headerAttributes} syntax extension). The macro receives a
-single attribute that corresponds to the \meta{identifier}.
-
-\mdef{markdownRendererAttributeClassName} represents the \meta{class name} of a
-markdown element (`class="`\meta{class name} ...`"` in HTML and
-`.`\meta{class name} in Markdown's \Opt{headerAttributes} syntax extension).
-The macro receives a single attribute that corresponds to the \meta{class
-name}.
-
-\mdef{markdownRendererAttributeKeyValue} represents a HTML attribute in the form
-\meta{key}`=`\meta{value} that is neither an identifier nor a class name.
-The macro receives two attributes that correspond to the \meta{key} and the
-\meta{value}, respectively.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[headerAttributes, underscores=false]{markdown}
-\markdownSetup{
-  renderers = {
-    attributeIdentifier = {%
-      \par
-      \emph{(Identifier: #1)}
-      \par
-    },
-    attributeClassName = {%
-      \par
-      \emph{(Class name: #1)}
-      \par
-    },
-    attributeKeyValue = {%
-      \par
-      \emph{(Key: #1, Value: #2)}
-      \par
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-
-# First top-level heading {jane=doe}
-
-## A subheading {#identifier}
-
-# Second top-level heading {.class_name}
-
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> # First top-level heading
->
-> *(Key: Jane, Value: Doe)*
->
-> ## A subheading
->
-> *(Identifier: identifier)*
->
-> # Second top-level heading
->
-> *(Class name: class\_name)*
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererAttributeIdentifier{%
-  \markdownRendererAttributeIdentifierPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { attributeIdentifier }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { attributeIdentifier }
-  { 1 }
-\ExplSyntaxOff
-\def\markdownRendererAttributeClassName{%
-  \markdownRendererAttributeClassNamePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { attributeClassName }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { attributeClassName }
-  { 1 }
-\ExplSyntaxOff
-\def\markdownRendererAttributeKeyValue{%
-  \markdownRendererAttributeKeyValuePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { attributeKeyValue }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { attributeKeyValue }
-  { 2 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Header Attribute Context Renderers
-The following macros are only produced, when the \Opt{headerAttributes} option
-is enabled.
-
-The \mdef{markdownRendererHeaderAttributeContextBegin} and
-\mdef{markdownRendererHeaderAttributeContextEnd} macros represent the beginning
-and the end of a section in which the attributes of a heading apply. The macros
-receive no arguments.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[headerAttributes]{markdown}
-\markdownSetup{
-  renderers = {
-    headerAttributeContextBegin = {%
-      \par
-      \emph{(The beginning of a header attribute context)}
-      \par
-    },
-    headerAttributeContextBegin = {%
-      \par
-      \emph{(The end of a header attribute context)}
-      \par
-    },
-  },
-}
-\begin{document}
-\begin{markdown}
-
-# First top-level heading
-
-## A subheading {#identifier}
-
-# Second top-level heading {.class_name}
-
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> # First top-level heading
->
-> *(The beginning of a header attribute context)*
->
-> ## A subheading
->
-> *(The end of a header attribute context)*
->
-> *(The beginning of a header attribute context)*
->
-> # Second top-level heading
->
-> *(The end of a header attribute context)*
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererHeaderAttributeContextBegin{%
-  \markdownRendererHeaderAttributeContextBeginPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headerAttributeContextBegin }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headerAttributeContextBegin }
-  { 0 }
-\ExplSyntaxOff
-\def\markdownRendererHeaderAttributeContextEnd{%
-  \markdownRendererHeaderAttributeContextEndPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { headerAttributeContextEnd }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { headerAttributeContextEnd }
-  { 0 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Strike-Through Renderer
-The \mdef{markdownRendererStrikeThrough} macro represents a strike-through span of
-text. The macro receives a single argument that corresponds to the striked-out
-span of text. This macro will only be produced, when the \Opt{strikeThrough}
-option is enabled.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionStrikeThrough{true}
-\input soulutf8.sty
-\def\markdownRendererStrikeThrough#1{\st{#1}}
-\markdownBegin
-This is ~~a lunar roving vehicle~~ strike-through text.
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is ~~a lunar roving vehicle~~ strike-through text.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[strikeThrough]{markdown}
-\usepackage{soulutf8}
-\markdownSetup{
-  renderers = {
-    strikeThrough = {\st{#1}},
-  },
-}
-\begin{document}
-\begin{markdown}
-This is ~~a lunar roving vehicle~~ strike-through text.
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is ~~a lunar roving vehicle~~ strike-through text.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[strikeThrough = yes]
-\def\markdownRendererStrikeThrough#1{\overstrikes{#1}}
-\starttext
-\startmarkdown
-This is ~~a lunar roving vehicle~~ strike-through text.
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> This is ~~a lunar roving vehicle~~ strike-through text.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererStrikeThrough{%
-  \markdownRendererStrikeThroughPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { strikeThrough }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { strikeThrough }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Superscript Renderer
-The \mdef{markdownRendererSuperscript} macro represents a superscript span of
-text. The macro receives a single argument that corresponds to the superscript
-span of text. This macro will only be produced, when the \Opt{superscripts}
-option is enabled.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionSuperscripts{true}
-\def\markdownRendererSuperscript#1{ taken to the power of #1}
-\markdownBegin
-2^10^ is 1024.
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> 2 taken to the power of 10 is 1024.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[superscripts]{markdown}
-\markdownSetup{
-  renderers = {
-    superscript = { taken to the power of #1},
-  },
-}
-\begin{document}
-\begin{markdown}
-2^10^ is 1024.
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> 2 taken to the power of 10 is 1024.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[superscripts = yes]
-\def\markdownRendererSuperscript#1{ taken to the power of #1}
-\starttext
-\startmarkdown
-2^10^ is 1024.
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> 2 taken to the power of 10 is 1024.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererSuperscript{%
-  \markdownRendererSuperscriptPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { superscript }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { superscript }
-  { 1 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Subscript Renderer
-The \mdef{markdownRendererSubscript} macro represents a subscript span of
-text. The macro receives a single argument that corresponds to the subscript
-span of text. This macro will only be produced, when the \Opt{subscripts}
-option is enabled.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### Plain \TeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\input markdown
-\def\markdownOptionSubscripts{true}
-\def\markdownRendererSubscript#1{ (#1 moles) and }
-\markdownBegin
-H~2~O is a liquid.
-\markdownEnd
-\bye
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-luatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> H (2 moles) and O is a liquid.
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[subscripts]{markdown}
-\markdownSetup{
-  renderers = {
-    subscript = { (#1 moles) and },
-  },
-}
-\begin{document}
-\begin{markdown}
-H~2~O is a liquid.
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> H (2 moles) and O is a liquid.
-
-##### \Hologo{ConTeXt} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\usemodule[t][markdown]
-\setupmarkdown[subscripts = yes]
-\def\markdownRendererSubscript#1{ (#1 moles) and }
-\starttext
-\startmarkdown
-H~2~O is a liquid.
-\stopmarkdown
-\stoptext
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-context document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> H (2 moles) and O is a liquid.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererSubscript{%
-  \markdownRendererSubscriptPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { subscript }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { subscript }
-  { 1 }
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-#### Raw Content Renderers
-The \mdef{markdownRendererInputRawInline} macro represents an inline raw span.
-The macro receives two arguments: the filename of a file contaning the inline
-raw span contents and the raw attribute that designates the format of the
-inline raw span. This macro will only be produced, when the \Opt{rawAttribute}
-option is enabled.
-
-% \end{markdown}
-%
-% \iffalse
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInputRawInline{%
-  \markdownRendererInputRawInlinePrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inputRawInline }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inputRawInline }
-  { 2 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
-% \fi
-%
-% \begin{markdown}
-
-The \mdef{markdownRendererInputRawBlock} macro represents a raw block. The
-macro receives two arguments: the filename of a file contaning the raw block
-and the raw attribute that designates the format of the raw block. This macro
-will only be produced, when the \Opt{rawAttribute} and \Opt{fencedCode} options
-are enabled.
-
-% \end{markdown}
-%
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-```` tex
-\documentclass{article}
-\usepackage[rawAttribute, fencedCode]{markdown}
-\usepackage{expl3}
-\ExplSyntaxOn
-\cs_new:Nn
-  \display_raw_content:nn
-  {
-    % If the raw attribute is TeX, execute the content as a TeX document.
-    \str_if_eq:nnTF
-      { #2 }
-      { tex }
-      { \markdownEscape { #1 } }
-      % Otherwise, ignore the content.
-      { }
-  }
-\markdownSetup{
-  renderers = {
-    rawInline = { \display_raw_content:nn { #1 } { #2 } },
-    rawBlock  = { \display_raw_content:nn { #1 } { #2 } }
-  },
-}
-\ExplSyntaxOff
-\begin{document}
-\begin{markdown}
-`$H_2 O$`{=tex} is a liquid.
-
-``` {=html}
-<p>Here is some HTML content that will be ignored.</p>
-```
-\end{markdown}
-\end{document}
-````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text:
-
-> H~2~O is a liquid.
-
-%</manual-tokens>
-%<*tex>
-% \fi
-%
-%  \begin{macrocode}
-\def\markdownRendererInputRawBlock{%
-  \markdownRendererInputRawBlockPrototype}%
-\ExplSyntaxOn
-\seq_gput_right:Nn
-  \g_@@_renderers_seq
-  { inputRawBlock }
-\prop_gput:Nnn
-  \g_@@_renderer_arities_prop
-  { inputRawBlock }
-  { 2 }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-%
-% \iffalse
-%</tex>
-%<*manual-tokens>
 % \fi
 %
 % \begin{markdown}


### PR DESCRIPTION
New token renderers and built-in syntax extensions are appended to the source code, which makes it difficult to work on several features at the same time without merge conflicts. Lua options are alphabetically ordered, but there are a number of sorting errors. This pull request sorts Lua options, token renderers, and built-in syntax extensions as they appear in the source code. This makes it less likely for merge conflicts to occur for features that are developed in parallel.