### PR TITLE
Add support for attributes on fenced code blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 Development:
 
-- Add support for line blocks (contributed by @lostenderman, #209, #248)
+- Add support for line blocks. (contributed by @lostenderman, #209, #248)
+- Add support for attributes on fenced code blocks. (#123, #211)
 
 Documentation:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12324,6 +12324,55 @@ corresponds to the emphasized span of text.
 %
 % \begin{markdown}
 
+#### Fenced Code Attribute Context Renderers
+The following macros are only produced, when the \Opt{fencedCode} option is
+enabled.
+
+The \mdef{markdownRendererFencedCodeAttributeContextBegin} and
+\mdef{markdownRendererFencedCodeAttributeContextEnd} macros represent the
+beginning and the end of a context in which the attributes of a fenced code
+apply. The macros receive no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererFencedCodeAttributeContextBegin{%
+  \markdownRendererFencedCodeAttributeContextBeginPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { fencedCodeAttributeContextBegin }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { fencedCodeAttributeContextBegin }
+  { 0 }
+\ExplSyntaxOff
+\def\markdownRendererFencedCodeAttributeContextEnd{%
+  \markdownRendererFencedCodeAttributeContextEndPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { fencedCodeAttributeContextEnd }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { fencedCodeAttributeContextEnd }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 #### Fenced Div Attribute Context Renderers
 The following macros are only produced, when the \Opt{fencedDiv} option is
 enabled.
@@ -25650,6 +25699,12 @@ end
   \markdownRendererHeaderAttributeContextBeginPrototype
 \cs_gset_eq:NN
   \markdownRendererFencedDivAttributeContextEndPrototype
+  \markdownRendererHeaderAttributeContextEndPrototype
+\cs_gset_eq:NN
+  \markdownRendererFencedCodeAttributeContextBeginPrototype
+  \markdownRendererHeaderAttributeContextBeginPrototype
+\cs_gset_eq:NN
+  \markdownRendererFencedCodeAttributeContextEndPrototype
   \markdownRendererHeaderAttributeContextEndPrototype
 \cs_gset:Npn
   \markdownRendererReplacementCharacterPrototype

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -5425,6 +5425,54 @@ defaultOptions.fencedCode = false
 %</lua,lua-cli>
 %<*manual-options>
 
+#### Option `fencedCodeAttributes`
+
+`fencedCodeAttributes` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{fencedCodeAttributes}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Enable the Pandoc fenced code attribute extension:
+
+        ```````` md
+        ~~~~ {#mycode .haskell .numberLines startFrom="100"}
+        qsort []     = []
+        qsort (x:xs) = qsort (filter (< x) xs) ++ [x] ++
+                       qsort (filter (>= x) xs)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ```````````
+
+:    false
+
+     :  Disable the Pandoc fenced code attribute extension.
+
+% \end{markdown}
+% \iffalse
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { fencedCodeAttributes }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli>
+% \fi
+%  \begin{macrocode}
+defaultOptions.fencedCodeAttributes = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli>
+%<*manual-options>
+
 #### Option `fencedDivs`
 
 `fencedDivs` (default value: `false`)
@@ -25206,7 +25254,7 @@ function M.new(options)
   if options.fencedCode then
     local fenced_code_extension = M.extensions.fenced_code(
       options.blankBeforeCodeFence,
-      false,
+      options.fencedCodeAttributes,
       options.rawAttribute)
     table.insert(extensions, fenced_code_extension)
   end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -275,6 +275,15 @@ pre {
   white-space: pre;
   white-space: pre-wrap;
   word-wrap: break-word;
+  counter-reset: line;
+}
+
+.sourceCode.linenos > span {
+  counter-increment: line;
+}
+
+.sourceCode.linenos > span:before{
+  content: counter(line) "  ";
 }
 
 b, strong {
@@ -5452,6 +5461,56 @@ defaultOptions.fencedCode = false
 
 % \end{markdown}
 % \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[fencedCode,
+            fencedCodeAttributes]{markdown}
+\usepackage{minted}
+\markdownSetup{
+  renderers = {
+    fencedCodeAttributeContextBegin = {%
+      \begingroup
+      \markdownSetup{
+        renderers = {
+          attributeKeyValue = {%
+            \setminted{{#1} = {#2}}%
+          },
+        },
+      }%
+    },
+    fencedCodeAttributeContextEnd = {%
+      \endgroup
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+``` js {linenos=true}
+if (a > 3) {
+    moveShip(5 * gravity, DOWN);
+}
+``````
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> ``` js {.linenos}
+> 1. if (a > 3) {
+> 2.     moveShip(5 * gravity, DOWN);
+> 3. }
+> ``````
+
 %</manual-options>
 %<*tex>
 % \fi
@@ -12336,6 +12395,56 @@ apply. The macros receive no arguments.
 % \end{markdown}
 %
 % \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[fencedCode,
+            fencedCodeAttributes]{markdown}
+\usepackage{minted}
+\markdownSetup{
+  renderers = {
+    fencedCodeAttributeContextBegin = {%
+      \begingroup
+      \markdownSetup{
+        renderers = {
+          attributeKeyValue = {%
+            \setminted{{#1} = {#2}}%
+          },
+        },
+      }%
+    },
+    fencedCodeAttributeContextEnd = {%
+      \endgroup
+    },
+  },
+}
+\begin{document}
+\begin{markdown}
+``` js {linenos=true}
+if (a > 3) {
+    moveShip(5 * gravity, DOWN);
+}
+``````
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> ``` js {.linenos}
+> 1. if (a > 3) {
+> 2.     moveShip(5 * gravity, DOWN);
+> 3. }
+> ``````
+
 %</manual-tokens>
 %<*tex>
 % \fi

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21917,6 +21917,14 @@ parsers.attributes = parsers.lbrace
                    * parsers.optionalspace
                    * parsers.rbrace
 
+
+parsers.raw_attribute = parsers.lbrace
+                      * parsers.optionalspace
+                      * parsers.equal
+                      * C(parsers.attribute_key)
+                      * parsers.optionalspace
+                      * parsers.rbrace
+
 -- block followed by 0 or more optionally
 -- indented blocks with first line indented.
 parsers.indented_blocks = function(bl)
@@ -21979,73 +21987,6 @@ parsers.intickschar = (parsers.any - S(" \n\r`"))
 
 parsers.inticks     = parsers.openticks * parsers.space^-1
                     * C(parsers.intickschar^0) * parsers.closeticks
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-%#### Parsers Used for Fenced Code Blocks
-%
-% \end{markdown}
-%  \begin{macrocode}
-local function captures_geq_length(_,i,a,b)
-  return #a >= #b and i
-end
-
-parsers.tilde_infostring
-                     = C((parsers.linechar
-                        - (parsers.spacechar^1 * parsers.newline))^0)
-                     * parsers.optionalspace
-                     * (parsers.newline + parsers.eof)
-
-parsers.backtick_infostring
-                     = C((parsers.linechar
-                        - (parsers.backtick
-                          + parsers.spacechar^1 * parsers.newline))^0)
-                     * parsers.optionalspace
-                     * (parsers.newline + parsers.eof)
-
-local fenceindent
-parsers.fencehead    = function(char, infostring)
-  return               C(parsers.nonindentspace) / function(s) fenceindent = #s end
-                     * Cg(char^3, "fencelength")
-                     * parsers.optionalspace * infostring
-end
-
-parsers.fencehead_with_attributes
-                     = function(char)
-  return               C(parsers.nonindentspace) / function(s) fenceindent = #s end
-                     * Cg(char^3, "fencelength")
-                     * parsers.optionalspace * Ct(parsers.attributes)
-                     * parsers.optionalspace * (parsers.newline + parsers.eof)
-end
-
-parsers.fencetail    = function(char)
-  return               parsers.nonindentspace
-                     * Cmt(C(char^3) * Cb("fencelength"), captures_geq_length)
-                     * parsers.optionalspace * (parsers.newline + parsers.eof)
-                     + parsers.eof
-end
-
-parsers.fencedline   = function(char)
-  return               C(parsers.line - parsers.fencetail(char))
-                     / function(s)
-                         local i = 1
-                         local remaining = fenceindent
-                         while true do
-                           local c = s:sub(i, i)
-                           if c == " " and remaining > 0 then
-                             remaining = remaining - 1
-                             i = i + 1
-                           elseif c == "\t" and remaining > 3 then
-                             remaining = remaining - 4
-                             i = i + 1
-                           else
-                             break
-                           end
-                         end
-                         return s:sub(i)
-                       end
-end
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -22278,18 +22219,6 @@ parsers.urlchar      = parsers.anyescaped - parsers.newline - parsers.more
 %
 % \end{markdown}
 %  \begin{macrocode}
-parsers.TildeFencedCode
-       = parsers.fencehead(parsers.tilde,
-                           parsers.tilde_infostring)
-       * Cs(parsers.fencedline(parsers.tilde)^0)
-       * parsers.fencetail(parsers.tilde)
-
-parsers.BacktickFencedCode
-       = parsers.fencehead(parsers.backtick,
-                           parsers.backtick_infostring)
-       * Cs(parsers.fencedline(parsers.backtick)^0)
-       * parsers.fencetail(parsers.backtick)
-
 parsers.lineof = function(c)
     return (parsers.leader * (P(c) * parsers.optionalspace)^3
            * (parsers.newline * parsers.blankline^1
@@ -24213,9 +24142,16 @@ end
 % parameter is `true`, the syntax extension requires a blank line between a
 % paragraph and the following fenced code block.
 %
+% When the `allow_attributes` option is `true`, the syntax extension permits
+% attributes following the infostring. When the `allow_raw_blocks` option is
+% `true`, the syntax extension permits the specification of raw blocks using
+% Pandoc's raw attribute syntax extension.
+%
 % \end{markdown}
 %  \begin{macrocode}
-M.extensions.fenced_code = function(blank_before_code_fence)
+M.extensions.fenced_code = function(blank_before_code_fence,
+                                    allow_attributes,
+                                    allow_raw_blocks)
   return {
     name = "built-in fenced_code syntax extension",
     extend_writer = function(self)
@@ -24226,29 +24162,140 @@ M.extensions.fenced_code = function(blank_before_code_fence)
 % \begin{markdown}
 %
 % Define \luamdef{writer->fencedCode} as a function that will transform an
-% input fenced code block `s` with the infostring `i` to the output
-% format.
+% input fenced code block `s` with the infostring `i` and optional attributes
+% `attr` to the output format.
 %
 % \end{markdown}
 %  \begin{macrocode}
-      function self.fencedCode(s, i)
+      function self.fencedCode(s, i, attr)
         if not self.is_writing then return "" end
         s = s:gsub("\n$", "")
+        local buf = {}
+        if attr ~= nil then
+          table.insert(buf, {"\\markdownRendererFencedCodeAttributeContextBegin",
+                             self.attributes(attr)})
+        end
         local name = util.cache_verbatim(options.cacheDir, s)
-        return {"\\markdownRendererInputFencedCode{",
-                name,"}{",self.string(i),"}"}
+        table.insert(buf, {"\\markdownRendererInputFencedCode{",
+                           name,"}{",self.string(i),"}"})
+        if attr ~= nil then
+          table.insert(buf, "\\markdownRendererFencedCodeAttributeContextEnd")
+        end
+        return buf
+      end
+
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->rawBlock} as a function that will transform an
+% input raw block `s` with the raw attribute `attr` to the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      if allow_raw_blocks then
+        function self.rawBlock(s, attr)
+          if not self.is_writing then return "" end
+          s = s:gsub("\n$", "")
+          local name = util.cache_verbatim(options.cacheDir, s)
+          return {"\\markdownRendererInputRawBlock{",
+                  name,"}{", self.string(attr),"}"}
+        end
       end
     end, extend_reader = function(self)
       local parsers = self.parsers
       local writer = self.writer
 
-      local FencedCode = (parsers.TildeFencedCode
-                         + parsers.BacktickFencedCode)
-                       / function(infostring, code)
-                           local expanded_code = self.expandtabs(code)
-                           return writer.fencedCode(expanded_code,
-                                                    infostring)
-                         end
+      local function captures_geq_length(_,i,a,b)
+        return #a >= #b and i
+      end
+
+      local tilde_infostring
+                           = C((parsers.linechar
+                              - (parsers.spacechar^1 * parsers.newline))^0)
+
+      local backtick_infostring
+                           = C((parsers.linechar
+                              - (parsers.backtick
+                                + parsers.spacechar^1 * parsers.newline))^0)
+
+      local fenceindent
+      local fencehead      = function(char, infostring)
+        return               C(parsers.nonindentspace) / function(s) fenceindent = #s end
+                           * Cg(char^3, "fencelength")
+                           * parsers.optionalspace
+                           * infostring
+                           * (parsers.newline + parsers.eof)
+      end
+
+      local fencetail      = function(char)
+        return               parsers.nonindentspace
+                           * Cmt(C(char^3) * Cb("fencelength"), captures_geq_length)
+                           * parsers.optionalspace * (parsers.newline + parsers.eof)
+                           + parsers.eof
+      end
+
+      local fencedline     = function(char)
+        return               C(parsers.line - fencetail(char))
+                           / function(s)
+                               local i = 1
+                               local remaining = fenceindent
+                               while true do
+                                 local c = s:sub(i, i)
+                                 if c == " " and remaining > 0 then
+                                   remaining = remaining - 1
+                                   i = i + 1
+                                 elseif c == "\t" and remaining > 3 then
+                                   remaining = remaining - 4
+                                   i = i + 1
+                                 else
+                                   break
+                                 end
+                               end
+                               return s:sub(i)
+                             end
+      end
+
+      local TildeFencedCode
+             = fencehead(parsers.tilde, tilde_infostring)
+             * Cs(fencedline(parsers.tilde)^0)
+             * fencetail(parsers.tilde)
+
+      local BacktickFencedCode
+             = fencehead(parsers.backtick, backtick_infostring)
+             * Cs(fencedline(parsers.backtick)^0)
+             * fencetail(parsers.backtick)
+
+            local infostring_with_attributes
+                             = Ct(C((parsers.linechar
+                                    - ( parsers.optionalspace
+                                      * parsers.attributes))^0)
+                                 * parsers.optionalspace
+                                 * Ct(parsers.attributes))
+
+      local FencedCode
+               = (TildeFencedCode + BacktickFencedCode)
+               / function(infostring, code)
+                   local expanded_code = self.expandtabs(code)
+
+                   if allow_raw_blocks then
+                     local raw_attr = lpeg.match(parsers.raw_attribute,
+                                                 infostring)
+                     if raw_attr then
+                       return writer.rawBlock(expanded_code, raw_attr)
+                     end
+                   end
+
+                   local attr = nil
+                   if allow_attributes then
+                     local match = lpeg.match(infostring_with_attributes,
+                                              infostring)
+                     if match then
+                       infostring, attr = table.unpack(match)
+                     end
+                   end
+                   return writer.fencedCode(expanded_code, infostring, attr)
+                 end
 
       self.insert_pattern("Block after Verbatim",
                           FencedCode, "FencedCode")
@@ -24257,10 +24304,8 @@ M.extensions.fenced_code = function(blank_before_code_fence)
       if blank_before_code_fence then
         fencestart = parsers.fail
       else
-        fencestart = parsers.fencehead(parsers.backtick,
-                                       parsers.backtick_infostring)
-                   + parsers.fencehead(parsers.tilde,
-                                       parsers.tilde_infostring)
+        fencestart = fencehead(parsers.backtick, backtick_infostring)
+                   + fencehead(parsers.tilde, tilde_infostring)
       end
 
       self.update_rule("EndlineExceptions", function(previous_pattern)
@@ -24790,14 +24835,14 @@ end
 %
 %#### Raw Attributes
 %
-% The \luamdef{extensions.raw_attribute} function implements the Pandoc
-% raw attribute syntax extension.
+% The \luamdef{extensions.raw_inline} function implements the Pandoc
+% raw attribute syntax extension for inline code spans.
 %
 % \end{markdown}
 %  \begin{macrocode}
-M.extensions.raw_attribute = function()
+M.extensions.raw_inline = function()
   return {
-    name = "built-in raw_attribute syntax extension",
+    name = "built-in raw_inline syntax extension",
     extend_writer = function(self)
       local options = self.options
 
@@ -24816,60 +24861,15 @@ M.extensions.raw_attribute = function()
         return {"\\markdownRendererInputRawInline{",
                 name,"}{", self.string(attr),"}"}
       end
-
-      if options.fencedCode then
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% Define \luamdef{writer->rawBlock} as a function that will transform an
-% input raw block `s` with the raw attribute `attr` to the output format.
-%
-% \end{markdown}
-%  \begin{macrocode}
-        function self.rawBlock(s, attr)
-          if not self.is_writing then return "" end
-          s = s:gsub("\n$", "")
-          local name = util.cache_verbatim(options.cacheDir, s)
-          return {"\\markdownRendererInputRawBlock{",
-                  name,"}{", self.string(attr),"}"}
-        end
-      end
     end, extend_reader = function(self)
-      local options = self.options
       local writer = self.writer
 
-      local raw_attribute = parsers.lbrace
-                          * parsers.optionalspace
-                          * parsers.equal
-                          * C(parsers.attribute_key)
-                          * parsers.optionalspace
-                          * parsers.rbrace
-
       local RawInline = parsers.inticks
-                      * raw_attribute
+                      * parsers.raw_attribute
                       / writer.rawInline
 
       self.insert_pattern("Inline before Code",
                           RawInline, "RawInline")
-
-      if options.fencedCode then
-        local RawBlock = (parsers.TildeFencedCode
-                         + parsers.BacktickFencedCode)
-                       / function(infostring, code)
-                           local expanded_code = self.expandtabs(code)
-                           local attr = lpeg.match(raw_attribute, infostring)
-                           if attr then
-                             return writer.rawBlock(expanded_code, attr)
-                           else
-                             return writer.fencedCode(expanded_code,
-                                                      infostring)
-                           end
-                         end
-
-        self.insert_pattern("Block after Verbatim",
-                            RawBlock, "RawBlock")
-      end
     end
   }
 end
@@ -25205,7 +25205,9 @@ function M.new(options)
 
   if options.fencedCode then
     local fenced_code_extension = M.extensions.fenced_code(
-      options.blankBeforeCodeFence)
+      options.blankBeforeCodeFence,
+      false,
+      options.rawAttribute)
     table.insert(extensions, fenced_code_extension)
   end
 
@@ -25233,8 +25235,8 @@ function M.new(options)
   end
 
   if options.rawAttribute then
-    local raw_attribute_extension = M.extensions.raw_attribute()
-    table.insert(extensions, raw_attribute_extension)
+    local raw_inline_extension = M.extensions.raw_inline()
+    table.insert(extensions, raw_inline_extension)
   end
 
   if options.strikeThrough then

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -10,13 +10,13 @@
       \TYPE{- value:               #2}%
       \TYPE{END attributeKeyValue}},
     fencedDivAttributeContextBegin = {%
-      \TYPE{fencedDivAttributeContextBegin}},
+      \TYPE{BEGIN fencedDivAttributeContext}},
     fencedDivAttributeContextEnd = {%
-      \TYPE{fencedDivAttributeContextEnd}},
+      \TYPE{END fencedDivAttributeContext}},
     bracketedSpanAttributeContextBegin = {%
-      \TYPE{bracketedSpanAttributeContextBegin}},
+      \TYPE{BEGIN bracketedSpanAttributeContext}},
     bracketedSpanAttributeContextEnd = {%
-      \TYPE{bracketedSpanAttributeContextEnd}},
+      \TYPE{END bracketedSpanAttributeContext}},
     documentBegin = {%
       \begingroup
       \catcode"09=12%  Prevent spaces (U+0009) from folding into a single space token
@@ -35,9 +35,9 @@
       \TYPE{ellipsis}%
       \GOBBLE},
     headerAttributeContextBegin = {%
-      \TYPE{headerAttributeContextBegin}},
+      \TYPE{BEGIN headerAttributeContext}},
     headerAttributeContextEnd = {%
-      \TYPE{headerAttributeContextEnd}},
+      \TYPE{END headerAttributeContext}},
     nbsp = {%
       \TYPE{nbsp}%
       \GOBBLE},

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -9,6 +9,10 @@
       \TYPE{- key:                 #1}%
       \TYPE{- value:               #2}%
       \TYPE{END attributeKeyValue}},
+    fencedCodeAttributeContextBegin = {%
+      \TYPE{BEGIN fencedCodeAttributeContext}},
+    fencedCodeAttributeContextEnd = {%
+      \TYPE{END fencedCodeAttributeContext}},
     fencedDivAttributeContextBegin = {%
       \TYPE{BEGIN fencedDivAttributeContext}},
     fencedDivAttributeContextEnd = {%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -7,6 +7,10 @@
   \TYPE{- key:                 #1}%
   \TYPE{- value:               #2}%
   \TYPE{END attributeKeyValue}}%
+\def\markdownRendererFencedCodeAttributeContextBegin{%
+  \TYPE{BEGIN fencedCodeAttributeContext}}%
+\def\markdownRendererFencedCodeAttributeContextEnd{%
+  \TYPE{END fencedCodeAttributeContext}}%
 \def\markdownRendererFencedDivAttributeContextBegin{%
   \TYPE{BEGIN fencedDivAttributeContext}}%
 \def\markdownRendererFencedDivAttributeContextEnd{%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -8,13 +8,13 @@
   \TYPE{- value:               #2}%
   \TYPE{END attributeKeyValue}}%
 \def\markdownRendererFencedDivAttributeContextBegin{%
-  \TYPE{fencedDivAttributeContextBegin}}%
+  \TYPE{BEGIN fencedDivAttributeContext}}%
 \def\markdownRendererFencedDivAttributeContextEnd{%
-  \TYPE{fencedDivAttributeContextEnd}}%
+  \TYPE{END fencedDivAttributeContext}}%
 \def\markdownRendererBracketedSpanAttributeContextBegin{%
-  \TYPE{bracketedSpanAttributeContextBegin}}%
+  \TYPE{BEGIN bracketedSpanAttributeContext}}%
 \def\markdownRendererBracketedSpanAttributeContextEnd{%
-  \TYPE{bracketedSpanAttributeContextEnd}}%
+  \TYPE{END bracketedSpanAttributeContext}}%
 \def\markdownRendererDocumentBegin{%
   \begingroup
   \catcode"09=12%  Prevent spaces (U+0009) from folding into a single space token
@@ -30,9 +30,9 @@
 \def\markdownRendererEllipsis#1{%
   \TYPE{ellipsis}}%
 \def\markdownRendererHeaderAttributeContextBegin{%
-  \TYPE{headerAttributeContextBegin}}%
+  \TYPE{BEGIN headerAttributeContext}}%
 \def\markdownRendererHeaderAttributeContextEnd{%
-  \TYPE{headerAttributeContextEnd}}%
+  \TYPE{END headerAttributeContext}}%
 \def\markdownRendererNbsp#1{%
   \TYPE{nbsp}}%
 \def\markdownRendererLeftBrace#1{%

--- a/tests/testfiles/lunamark-markdown/blank-before-div-fence.test
+++ b/tests/testfiles/lunamark-markdown/blank-before-div-fence.test
@@ -25,7 +25,7 @@ interblockSeparator
 interblockSeparator
 interblockSeparator
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: foo
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 documentEnd

--- a/tests/testfiles/lunamark-markdown/bracketed-spans.test
+++ b/tests/testfiles/lunamark-markdown/bracketed-spans.test
@@ -8,12 +8,12 @@ propagates through the plain TeX interface.
 documentBegin
 codeSpan: bracketedSpans
 interblockSeparator
-bracketedSpanAttributeContextBegin
+BEGIN bracketedSpanAttributeContext
 attributeClassName: class
 BEGIN attributeKeyValue
 - key: key
 - value: val
 END attributeKeyValue
 emphasis: some text
-bracketedSpanAttributeContextEnd
+END bracketedSpanAttributeContext
 documentEnd

--- a/tests/testfiles/lunamark-markdown/fenced-code-attributes.test
+++ b/tests/testfiles/lunamark-markdown/fenced-code-attributes.test
@@ -1,0 +1,31 @@
+\def\markdownOptionFencedCode{true}
+\def\markdownOptionFencedCodeAttributes{true}
+<<<
+This test ensures that the Lua `fencedCode` and `fencedCodeAttributes` options
+correctly propagate through the plain TeX interface.
+
+The following fenced code block attributes should be recognized as such.
+
+~~~~ foo {#mycode .haskell .numberLines startFrom="100"}
+bar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+>>>
+documentBegin
+codeSpan: fencedCode
+codeSpan: fencedCodeAttributes
+interblockSeparator
+interblockSeparator
+BEGIN fencedCodeAttributeContext
+attributeIdentifier: mycode
+attributeClassName: haskell
+attributeClassName: numberLines
+BEGIN attributeKeyValue
+- key: startFrom
+- value: 100
+END attributeKeyValue
+BEGIN fencedCode
+- src: ./_markdown_test/37b51d194a7513e45b56f6524f2d51f2.verbatim
+- infostring: foo
+END fencedCode
+END fencedCodeAttributeContext
+documentEnd

--- a/tests/testfiles/lunamark-markdown/fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/fenced-divs.test
@@ -111,74 +111,74 @@ codeSpan: fencedDivs
 codeSpan: fencedCode
 interblockSeparator
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: myclass
 BEGIN attributeKeyValue
 - key: lang
 - value: fr
 END attributeKeyValue
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level1
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level2-more-colons
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level2-fewer-colons
 interblockSeparator
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level2-same-number-of-colons
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level3
-fencedDivAttributeContextEnd
-fencedDivAttributeContextEnd
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
+END fencedDivAttributeContext
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: Warning
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: Danger
-fencedDivAttributeContextEnd
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: some-classname
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeIdentifier: some-id
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 BEGIN attributeKeyValue
 - key: lang
 - value: some
 END attributeKeyValue
-fencedDivAttributeContextEnd
-fencedDivAttributeContextEnd
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
+END fencedDivAttributeContext
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level1
 interblockSeparator
 blockQuoteBegin
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: level2-inside-blockquote
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 blockQuoteEnd
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeIdentifier: some-identifier
 interblockSeparator
 blockQuoteBegin
 blockQuoteEnd
 interblockSeparator
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
 interblockSeparator
 interblockSeparator
@@ -186,32 +186,32 @@ leftBrace
 rightBrace
 codeSpan:  ::: 
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: some-classname
 interblockSeparator
 BEGIN fencedCode
 - src: ./_markdown_test/e441fcf4a7686817fe868bf38a5c2c07.verbatim
 - infostring: 
 END fencedCode
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: cit
 BEGIN attributeKeyValue
 - key: custom-style
 - value: raggedleft
 END attributeKeyValue
 emphasis: fenced
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: cit
 BEGIN attributeKeyValue
 - key: custom-style
 - value: raggedleft
 END attributeKeyValue
 emphasis: fenced
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
 leftBrace
 rightBrace

--- a/tests/testfiles/lunamark-markdown/header-attributes.test
+++ b/tests/testfiles/lunamark-markdown/header-attributes.test
@@ -23,13 +23,13 @@ A level two heading {#fourth4-id .2not-a-class}
 documentBegin
 codeSpan: headerAttributes
 interblockSeparator
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: first-id
 attributeClassName: unnumbered
 headingOne: A level one heading
 interblockSeparator
-headerAttributeContextEnd
-headerAttributeContextBegin
+END headerAttributeContext
+BEGIN headerAttributeContext
 attributeIdentifier: second_id2
 attributeClassName: unnumbered
 BEGIN attributeKeyValue
@@ -38,12 +38,12 @@ BEGIN attributeKeyValue
 END attributeKeyValue
 headingOne: A level one heading
 interblockSeparator
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: third-3id
 attributeClassName: a-class
 headingTwo: A level two heading
 interblockSeparator
-headerAttributeContextEnd
+END headerAttributeContext
 headingTwo: A level two heading (leftBrace)(hash)fourth4-id .2not-a-class(rightBrace)
 interblockSeparator
 headingThree: A level three heading (hash)(hash) (leftBrace)(hash)5not-the-fifth-id(rightBrace)
@@ -52,7 +52,7 @@ headingFour: A level four heading (leftBrace)(hash)-6not-the-sixth-id(rightBrace
 interblockSeparator
 headingFive: A level five heading (hash)(hash) (leftBrace)(hash)--not-7the-seventh-id(rightBrace)
 interblockSeparator
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: the-eighth-id
 BEGIN attributeKeyValue
 - key: attribute
@@ -60,9 +60,9 @@ BEGIN attributeKeyValue
 END attributeKeyValue
 headingSix: A level six heading
 interblockSeparator
-headerAttributeContextEnd
-headerAttributeContextEnd
-headerAttributeContextBegin
+END headerAttributeContext
+END headerAttributeContext
+BEGIN headerAttributeContext
 attributeIdentifier: appear
 attributeIdentifier: should
 attributeIdentifier: the
@@ -82,5 +82,5 @@ BEGIN attributeKeyValue
 - value: ing
 END attributeKeyValue
 headingOne: Attributes
-headerAttributeContextEnd
+END headerAttributeContext
 documentEnd

--- a/tests/testfiles/lunamark-markdown/no-blank-before-div-fence.test
+++ b/tests/testfiles/lunamark-markdown/no-blank-before-div-fence.test
@@ -21,11 +21,11 @@ codeSpan: fencedDivs
 codeSpan: blankBeforeDivFence
 interblockSeparator
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: foo
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 interblockSeparator
-fencedDivAttributeContextBegin
+BEGIN fencedDivAttributeContext
 attributeClassName: foo
-fencedDivAttributeContextEnd
+END fencedDivAttributeContext
 documentEnd

--- a/tests/testfiles/lunamark-markdown/no-fenced-code-attributes.test
+++ b/tests/testfiles/lunamark-markdown/no-fenced-code-attributes.test
@@ -1,0 +1,23 @@
+\def\markdownOptionFencedCode{true}
+<<<
+This test ensures that the Lua `fencedCode` option correctly propagates through
+the plain TeX interface and that the `fencedCodeAttributes` option is disabled
+by default.
+
+The following fenced code block attributes should be recognized as a part of
+the infostring.
+
+~~~~ foo {#mycode .haskell .numberLines startFrom="100"}
+bar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+>>>
+documentBegin
+codeSpan: fencedCode
+codeSpan: fencedCodeAttributes
+interblockSeparator
+interblockSeparator
+BEGIN fencedCode
+- src: ./_markdown_test/37b51d194a7513e45b56f6524f2d51f2.verbatim
+- infostring: foo (leftBrace)(hash)mycode .haskell .numberLines startFrom="100"(rightBrace)
+END fencedCode
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-slice.test
+++ b/tests/testfiles/lunamark-markdown/no-slice.test
@@ -136,7 +136,7 @@ codeSpan: slice
 interblockSeparator
 headingOne: This is an H1
 interblockSeparator
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: first-h2
 headingTwo: This is an H2
 interblockSeparator
@@ -170,8 +170,8 @@ interblockSeparator
 interblockSeparator
 codeSpan: latex (backslash)documentclass(leftBrace)article(rightBrace) (backslash)begin(leftBrace)document(rightBrace)   Hello world! (backslash)end(leftBrace)document(rightBrace) 
 interblockSeparator
-headerAttributeContextEnd
-headerAttributeContextBegin
+END headerAttributeContext
+BEGIN headerAttributeContext
 attributeIdentifier: second-h2
 headingTwo: This is an H2
 interblockSeparator
@@ -242,7 +242,7 @@ interblockSeparator
 interblockSeparator
 emphasis: Term 2
 interblockSeparator
-headerAttributeContextEnd
+END headerAttributeContext
 headingTwo: This is an H2
 interblockSeparator
 interblockSeparator

--- a/tests/testfiles/lunamark-markdown/slice-existing-section.test
+++ b/tests/testfiles/lunamark-markdown/slice-existing-section.test
@@ -140,7 +140,7 @@ belong to the previous note.
     multi-paragraph list items.
 >>>
 documentBegin
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: first-h2
 headingTwo: This is an H2
 interblockSeparator
@@ -183,5 +183,5 @@ BEGIN fencedCode
 - infostring: latex
 END fencedCode
 interblockSeparator
-headerAttributeContextEnd
+END headerAttributeContext
 documentEnd

--- a/tests/testfiles/lunamark-markdown/slice-two-sections.test
+++ b/tests/testfiles/lunamark-markdown/slice-two-sections.test
@@ -140,7 +140,7 @@ belong to the previous note.
     multi-paragraph list items.
 >>>
 documentBegin
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: first-h2
 headingTwo: This is an H2
 interblockSeparator
@@ -183,8 +183,8 @@ BEGIN fencedCode
 - infostring: latex
 END fencedCode
 interblockSeparator
-headerAttributeContextEnd
-headerAttributeContextBegin
+END headerAttributeContext
+BEGIN headerAttributeContext
 attributeIdentifier: second-h2
 headingTwo: This is an H2
 interblockSeparator
@@ -282,5 +282,5 @@ dlDefinitionEnd
 dlItemEnd
 dlEndTight
 interblockSeparator
-headerAttributeContextEnd
+END headerAttributeContext
 documentEnd

--- a/tests/testfiles/lunamark-markdown/slice-with-deferred-content.test
+++ b/tests/testfiles/lunamark-markdown/slice-with-deferred-content.test
@@ -16,7 +16,7 @@ Here are the definitions:
  [image]: http://image (This is the title of the image.)
 >>>
 documentBegin
-headerAttributeContextBegin
+BEGIN headerAttributeContext
 attributeIdentifier: section-with-deferred-content
 headingOne: This is another section
 interblockSeparator
@@ -32,5 +32,5 @@ BEGIN image
 - title: This is the title of the image.
 END image
 interblockSeparator
-headerAttributeContextEnd
+END headerAttributeContext
 documentEnd


### PR DESCRIPTION
Continues #123.

### Tasks

- [x] Add *fenced code attributes* syntax extension (see also [Pandoc][1]) as a parameter of `extensions.fenced_code()`.
- [x] Add *fenced code* attribute context renderers.
- [x] Add `fencedCodeAttributes` Lua option and load the corresponding syntax extension in `M.new()`.
- [x] Unit-test the [*fenced code attributes*][6].
- [x] Add example for *fenced code attribute* context renderers and the `fencedCodeAttributes` Lua option.
- [x] Update `CHANGES.md`

 [1]: https://pandoc.org/MANUAL.html#extension-fenced_code_attributes
 [2]: https://github.com/jgm/lunamark/pull/36
 [3]: https://pandoc.org/MANUAL.html#extension-link_attributes
 [4]: https://pandoc.org/MANUAL.html#extension-inline_code_attributes
 [5]: https://github.com/Omikhleia/lunamark/blob/60ba0bd/tests/lunamark/ext_link_attributes.test
 [6]: https://github.com/Omikhleia/lunamark/blob/60ba0bd/tests/lunamark/ext_fenced_code_attributes.test
 [7]: https://github.com/Witiko/markdown/pull/207
 [8]: https://github.com/jgm/lunamark/issues/43