### PR TITLE
Only make backticks special when `codeSpans` or `fencedCode` are enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Documentation:
 - Update examples for options `bracketedSpans` and `fencedDivs`.
   (499c65a, 532cdb8)
 
+Speed Improvements:
+
+- Only make backticks special when `codeSpans` or `fencedCode` are enabled.
+  (#239)
+
 ## 2.19.0 (2022-12-23)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22843,7 +22843,6 @@ function M.reader.new(writer, options)
     end
 
     self.add_special_character("*")
-    self.add_special_character("`")
     self.add_special_character("[")
     self.add_special_character("]")
     self.add_special_character("<")
@@ -23000,6 +22999,8 @@ function M.reader.new(writer, options)
 
     if not options.codeSpans then
       syntax.Code = parsers.fail
+    else
+      self.add_special_character("`")
     end
 
     if not options.html then
@@ -23937,6 +23938,7 @@ M.extensions.fenced_code = function(blank_before_code_fence)
         return previous_pattern + fencestart
       end)
 
+      self.add_special_character("`")
       self.add_special_character("~")
     end
   }


### PR DESCRIPTION
Currently, backticks are always treated as special characters. When neither the `codeSpans` nor the `fencedCode` Lua option is enabled, any backtick character will be unsuccessfully matched against all `Inline` rules before it is matched by the `Symbol` rule, which slows down parsing. This pull request causes backticks to be treated as normal characters when `codeSpans` and `fencedCode` Lua options are disabled. This allows backticks to be matched early by the `Str` rule, improving the parsing speed.