### PR TITLE
Fix ownership of repository before running Docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,8 @@ jobs:
           submodules: true
       - name: Build Docker image
         run: make docker-image TEXLIVE_TAG=${{ matrix.texlive }}
+      - name: Fix ownership of repository
+        run: docker run --rm -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} chown -R root:root /git-repo
       - name: Test Lua command-line interface
         run: |
           RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' |
@@ -85,9 +87,9 @@ jobs:
                     tee /dev/stderr)"
           test "$RESULT" = '\markdownRendererDocumentBegin'$'\n''Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
       - name: Run unit tests
-        run: docker run -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} make test
+        run: docker run --rm -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} make test
       - name: Build distribution archives
-        run: docker run -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} make dist gh-pages
+        run: docker run --rm -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} make dist gh-pages
       - name: Upload artifact markdown.tds.zip
         if: matrix.texlive == 'latest'
         uses: actions/upload-artifact@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ Speed Improvements:
 - Only make backticks special when `codeSpans` or `fencedCode` are enabled.
   (#239)
 
+Continuous Integration:
+
+- Fix ownership of repository before running Docker image. (#240)
+
 ## 2.19.0 (2022-12-23)
 
 Development:


### PR DESCRIPTION
In CI, we [run Docker container][1] as superuser rather than as the current unix user and group. This has long gone unnoticed, but makes calls to `git` fail after [recent security patches][2]. This PR runs Docker container with the current unix user and group.

 [1]: https://github.com/Witiko/markdown/blob/cf47462789492e02b35c83a3eba795bfaf355d35/.github/workflows/main.yml#L90
 [2]: https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765