### PR TITLE
Make `\*group_begin:` and `\*group_end:` the default renderer prototypes for attribute contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Default Renderer Prototypes:
 - Use `paralist` LaTeX package to define default renderer prototypes for
   fancy lists when `fancyList` Lua option is enabled. (#241)
 - Insert `\unskip` after default raw inline renderer prototype. (ca2047e)
+- Make `\*group_begin:` and `\*group_end:` the default renderer prototypes
+  for attribute contexts. (#243)
 
 Unit Tests:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25186,6 +25186,32 @@ end
 \def\markdownRendererStrikeThroughPrototype#1{#1}%
 \def\markdownRendererSuperscriptPrototype#1{#1}%
 \def\markdownRendererSubscriptPrototype#1{#1}%
+\ExplSyntaxOn
+\cs_gset:Npn
+  \markdownRendererHeaderAttributeContextBeginPrototype
+  {
+    \group_begin:
+    \color_group_begin:
+  }
+\cs_gset:Npn
+  \markdownRendererHeaderAttributeContextEndPrototype
+  {
+    \color_group_end:
+    \group_end:
+  }
+\cs_gset_eq:NN
+  \markdownRendererBracketedSpanAttributeContextBeginPrototype
+  \markdownRendererHeaderAttributeContextBeginPrototype
+\cs_gset_eq:NN
+  \markdownRendererBracketedSpanAttributeContextEndPrototype
+  \markdownRendererHeaderAttributeContextEndPrototype
+\cs_gset_eq:NN
+  \markdownRendererFencedDivAttributeContextBeginPrototype
+  \markdownRendererHeaderAttributeContextBeginPrototype
+\cs_gset_eq:NN
+  \markdownRendererFencedDivAttributeContextEndPrototype
+  \markdownRendererHeaderAttributeContextEndPrototype
+\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -26957,7 +26983,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-  headerAttributeContextBegin = {
+  headerAttributeContextBegin = {%
     \markdownSetup{
       rendererPrototypes = {
         attributeIdentifier = {%
@@ -26979,6 +27005,7 @@ end
       },
     }%
   },
+  headerAttributeContextEnd = {},
   superscript = {\textsuperscript{#1}},
   subscript = {\textsubscript{#1}},
   blockQuoteBegin = {\begin{quotation}},


### PR DESCRIPTION
Closes #233.