### PR TITLE
Use just the first word from `#2` to determine language in `\markdownRendererInputFencedCodePrototype`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Default Renderer Prototypes:
 - Use `paralist` LaTeX package to define default renderer prototypes for
   fancy lists when `fancyList` Lua option is enabled. (#241)
 - Insert `\unskip` after default raw inline renderer prototype. (ca2047e)
+- In LaTeX and ConTeXt, use just first word of infostring to determine fence
+  code block language. (#244)
 
 Unit Tests:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1264,12 +1264,18 @@ local md5 = require("md5")
 %:    A package that is used to polyfill the general hook management system in
 %     the default renderer prototypes for \acro{yaml} metadata, see Section
 %     <#sec:latexyamlmetadata>, and also in the default renderer prototype
-%     for attribute identifiers.
+%     for identifier attributes.
 %
 % \pkg{soulutf8}
 %
 %:    A package that is used in the default renderer prototype for
 %     strike-throughs.
+%
+% \pkg{ltxcmds}
+%
+%:    A package that is used to detect whether the \pkg{minted} and
+%     \pkg{listings} packages are loaded in the default renderer prototype
+%     for fenced code blocks.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -26996,6 +27002,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
+\RequirePackage{ltxcmds}
 \ExplSyntaxOn
 \cs_gset:Npn
   \markdownRendererInputFencedCodePrototype#1#2
@@ -27012,7 +27019,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-        \@ifpackageloaded
+        \ltx@ifpackageloaded
           { minted }
           {
             \catcode`\#=6\relax
@@ -27028,7 +27035,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-            \@ifpackageloaded
+            \ltx@ifpackageloaded
               { listings }
               { \lstinputlisting[language=#2]{#1} }
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25169,7 +25169,7 @@ end
 \def\markdownRendererInputVerbatimPrototype#1{%
   \par{\tt\input#1\relax{}}\par}%
 \def\markdownRendererInputFencedCodePrototype#1#2{%
-  \markdownRendererInputVerbatimPrototype{#1}}%
+  \markdownRendererInputVerbatim{#1}}%
 \def\markdownRendererHeadingOnePrototype#1{#1}%
 \def\markdownRendererHeadingTwoPrototype#1{#1}%
 \def\markdownRendererHeadingThreePrototype#1{#1}%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27000,7 +27000,7 @@ end
 \cs_gset:Npn
   \markdownRendererInputFencedCodePrototype#1#2
   {
-    \str_if_empty:nTF
+    \tl_if_empty:nTF
       { #2 }
       { \markdownRendererInputVerbatim{#1} }
       {
@@ -27921,7 +27921,7 @@ end
 \cs_gset:Npn
   \markdownRendererInputFencedCodePrototype#1#2
   {
-    \str_if_empty:nTF
+    \tl_if_empty:nTF
       { #2 }
       { \markdownRendererInputVerbatim{#1} }
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26984,13 +26984,42 @@ end
   blockQuoteBegin = {\begin{quotation}},
   blockQuoteEnd = {\end{quotation}},
   inputVerbatim = {\VerbatimInput{#1}},
-  inputFencedCode = {%
-    \ifx\relax#2\relax
-      \VerbatimInput{#1}%
-    \else
-      \@ifundefined{minted@code}{%
-        \@ifundefined{lst@version}{%
-          \markdownRendererInputFencedCode{#1}{}%
+  thematicBreak = {\noindent\rule[0.5ex]{\linewidth}{1pt}},
+  note = {\footnote{#1}}}}
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+%#### Fenced Code
+% When no infostring has been specified, default to the indented code block
+% renderer.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset:Npn
+  \markdownRendererInputFencedCodePrototype#1#2
+  {
+    \str_if_empty:nTF
+      { #2 }
+      { \markdownRendererInputVerbatim{#1} }
+      {
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% When the \pkg{minted} package is loaded, use it for syntax highlighting.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \@ifpackageloaded
+          { minted }
+          {
+            \catcode`\#=6\relax
+            \inputminted{#2}{#1}
+            \catcode`\#=12\relax
+          }
+          {
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -26999,26 +27028,23 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-        }{%
-          \lstinputlisting[language=#2]{#1}%
-        }%
+            \@ifpackageloaded
+              { listings }
+              { \lstinputlisting[language=#2]{#1} }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
 %
-% When the \pkg{minted} package is loaded, use it for syntax highlighting.
-% The \pkg{minted} package is preferred over \pkg{listings}.
+% When neither the \pkg{listings} package nor the \pkg{minted} package is
+% loaded, act as though no infostring were given.
 %
 % \end{markdown}
 %  \begin{macrocode}
-      }{%
-        \catcode`\#=6\relax
-        \inputminted{#2}{#1}%
-        \catcode`\#=12\relax
-      }%
-    \fi},
-  thematicBreak = {\noindent\rule[0.5ex]{\linewidth}{1pt}},
-  note = {\footnote{#1}}}}
+              { \markdownRendererInputFencedCode{#1}{} }
+          }
+      }
+  }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27907,17 +27907,30 @@ end
 \def\markdownRendererBlockQuoteBeginPrototype{\startquotation}%
 \def\markdownRendererBlockQuoteEndPrototype{\stopquotation}%
 \def\markdownRendererInputVerbatimPrototype#1{\typefile{#1}}%
-\def\markdownRendererInputFencedCodePrototype#1#2{%
-  \ifx\relax#2\relax
-    \typefile{#1}%
-  \else
 %    \end{macrocode}
 % \par
 % \begin{markdown}
 %
-% The code fence infostring is used as a name from the \Hologo{ConTeXt}
-% `\definetyping` macro. This allows the user to set up code highlighting
-% mapping as follows:
+%#### Fenced Code
+% When no infostring has been specified, default to the indented code block
+% renderer.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset:Npn
+  \markdownRendererInputFencedCodePrototype#1#2
+  {
+    \str_if_empty:nTF
+      { #2 }
+      { \markdownRendererInputVerbatim{#1} }
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Otherwise, the code fence infostring is used as a name from the
+% \Hologo{ConTeXt} `\definetyping` macro. This allows the user to set up
+% code highlighting mapping as follows:
 % ````` tex
 % % Map the `TEX` syntax highlighter to the `latex` infostring.
 % \definetyping [latex]
@@ -27934,6 +27947,16 @@ end
 %   \stopmarkdown
 % \stoptext
 % `````````
+%
+% \end{markdown}
+%  \begin{macrocode}
+      { \typefile[#2][]{#1} }
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26361,7 +26361,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\renewcommand\markdownRendererInputFencedCode[2]{%
+\renewcommand\markdownRendererInputFencedCodePrototype[2]{%
   \def\next##1 ##2\relax{%
     \ifthenelse{\equal{##1}{dot}}{%
       \markdownIfOption{frozenCache}{}{%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27010,7 +27010,22 @@ end
     \tl_if_empty:nTF
       { #2 }
       { \markdownRendererInputVerbatim{#1} }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Otherwise, extract the first word of the infostring and treat it as the name
+% of the programming language in which the code block is written.
+%
+% \end{markdown}
+%  \begin{macrocode}
       {
+        \regex_extract_once:nnN
+          { \w* }
+          { #2 }
+          \l_tmpa_seq
+        \seq_pop_left:NN
+          \l_tmpa_seq
+          \l_tmpa_tl
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -27023,7 +27038,10 @@ end
           { minted }
           {
             \catcode`\#=6\relax
-            \inputminted{#2}{#1}
+            \exp_args:NV
+              \inputminted
+              \l_tmpa_tl
+              { #1 }
             \catcode`\#=12\relax
           }
           {
@@ -27037,7 +27055,7 @@ end
 %  \begin{macrocode}
             \ltx@ifpackageloaded
               { listings }
-              { \lstinputlisting[language=#2]{#1} }
+              { \lstinputlisting[language=\l_tmpa_tl]{#1} }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -27935,9 +27953,10 @@ end
 % \par
 % \begin{markdown}
 %
-% Otherwise, the code fence infostring is used as a name from the
-% \Hologo{ConTeXt} `\definetyping` macro. This allows the user to set up
-% code highlighting mapping as follows:
+% Otherwise, extract the first word of the infostring and treat it as the name
+% of the programming language in which the code block is written.
+% This name is then used in the \Hologo{ConTeXt} `\definetyping` macro, which
+% allows the user to set up code highlighting mapping as follows:
 % ````` tex
 % % Map the `TEX` syntax highlighter to the `latex` infostring.
 % \definetyping [latex]
@@ -27957,18 +27976,18 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-      { \typefile[#2][]{#1} }
+      {
+        \regex_extract_once:nnN
+          { \w* }
+          { #2 }
+          \l_tmpa_seq
+        \seq_pop_left:NN
+          \l_tmpa_seq
+          \l_tmpa_tl
+        \typefile[\l_tmpa_tl][]{#1}
+      }
   }
 \ExplSyntaxOff
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-%
-% \end{markdown}
-%  \begin{macrocode}
-    \typefile[#2][]{#1}%
-  \fi}%
 \def\markdownRendererHeadingOnePrototype#1{\chapter{#1}}%
 \def\markdownRendererHeadingTwoPrototype#1{\section{#1}}%
 \def\markdownRendererHeadingThreePrototype#1{\subsection{#1}}%


### PR DESCRIPTION
Closes #225.