### PR TITLE
Map non-breaking space to `writer->nbsp` and U+0000 to U+FFFD in strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Documentation:
 
 Fixes:
 
+- Map U+0000 to U+FFFD in strings. (lostenderman#34, #247)
 - Map non-breaking space to `writer->nbsp` in strings. (lostenderman#99, #247)
 
 Default Renderer Prototypes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ Documentation:
 - Update examples for options `bracketedSpans` and `fencedDivs`.
   (499c65a, 532cdb8)
 
+Fixes:
+
+- Map non-breaking space to `writer->nbsp` in strings. (lostenderman#99, #247)
+
 Default Renderer Prototypes:
 
 - Use `paralist` LaTeX package to define default renderer prototypes for
@@ -20,7 +24,8 @@ Default Renderer Prototypes:
 
 Unit Tests:
 
-- Do not fold tabs and spaces into a single space token. (#242)
+- Do not fold tabs and spaces into a single space token.
+  (lostenderman#107, #242)
 
 Speed Improvements:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20861,6 +20861,7 @@ function M.writer.new(options)
      ["^"] = "\\markdownRendererCircumflex{}",
      ["~"] = "\\markdownRendererTilde{}",
      ["|"] = "\\markdownRendererPipe{}",
+     [entities.hex_entity('0000')] = entities.hex_entity('FFFD'),
      [entities.hex_entity('00A0')] = self.nbsp,
    }
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20861,6 +20861,7 @@ function M.writer.new(options)
      ["^"] = "\\markdownRendererCircumflex{}",
      ["~"] = "\\markdownRendererTilde{}",
      ["|"] = "\\markdownRendererPipe{}",
+     [entities.hex_entity('00A0')] = self.nbsp,
    }
 %    \end{macrocode}
 % \par


### PR DESCRIPTION
Closes https://github.com/lostenderman/markdown/issues/34 and https://github.com/lostenderman/markdown/issues/99.