### PR TITLE
Map U+0000 and U+FFFD to `\markdownRendererReplacementCharacter`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Documentation:
 
 Fixes:
 
-- Map U+0000 to U+FFFD in strings. (lostenderman#34, #247)
+- Map U+0000 to U+FFFD in strings. (lostenderman#34, #247, #250)
 - Map non-breaking space to `writer->nbsp` in strings.
   (lostenderman#99, #247, #249)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -14715,6 +14715,39 @@ following text:
 %
 % \begin{markdown}
 
+#### Replacement Character Renderers
+The \mdef{markdownRendererReplacementCharacter} macro represents the U+0000
+and U+FFFD Unicode characters. The macro receives no arguments.
+
+% \end{markdown}
+%
+% \iffalse
+%</manual-tokens>
+%<*tex>
+% \fi
+%
+%  \begin{macrocode}
+\def\markdownRendererReplacementCharacter{%
+  \markdownRendererReplacementCharacterPrototype}%
+\ExplSyntaxOn
+\seq_gput_right:Nn
+  \g_@@_renderers_seq
+  { replacementCharacter }
+\prop_gput:Nnn
+  \g_@@_renderer_arities_prop
+  { replacementCharacter }
+  { 0 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+%
+% \iffalse
+%</tex>
+%<*manual-tokens>
+% \fi
+%
+% \begin{markdown}
+
 #### Special Character Renderers
 The following macros replace any special plain \TeX{} characters, including
 % \iffalse
@@ -20838,6 +20871,7 @@ function M.writer.new(options)
     ["☒"] = "\\markdownRendererTickedBox{}",
     ["⌛"] = "\\markdownRendererHalfTickedBox{}",
     ["☐"] = "\\markdownRendererUntickedBox{}",
+    [entities.hex_entity('FFFD')] = "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
 % \par
@@ -20861,19 +20895,19 @@ function M.writer.new(options)
 % \end{markdown}
 %  \begin{macrocode}
   self.escaped_chars = {
-     ["{"] = "\\markdownRendererLeftBrace{}",
-     ["}"] = "\\markdownRendererRightBrace{}",
-     ["%"] = "\\markdownRendererPercentSign{}",
-     ["\\"] = "\\markdownRendererBackslash{}",
-     ["#"] = "\\markdownRendererHash{}",
-     ["$"] = "\\markdownRendererDollarSign{}",
-     ["&"] = "\\markdownRendererAmpersand{}",
-     ["_"] = "\\markdownRendererUnderscore{}",
-     ["^"] = "\\markdownRendererCircumflex{}",
-     ["~"] = "\\markdownRendererTilde{}",
-     ["|"] = "\\markdownRendererPipe{}",
-     [entities.hex_entity('0000')] = entities.hex_entity('FFFD'),
-   }
+    ["{"] = "\\markdownRendererLeftBrace{}",
+    ["}"] = "\\markdownRendererRightBrace{}",
+    ["%"] = "\\markdownRendererPercentSign{}",
+    ["\\"] = "\\markdownRendererBackslash{}",
+    ["#"] = "\\markdownRendererHash{}",
+    ["$"] = "\\markdownRendererDollarSign{}",
+    ["&"] = "\\markdownRendererAmpersand{}",
+    ["_"] = "\\markdownRendererUnderscore{}",
+    ["^"] = "\\markdownRendererCircumflex{}",
+    ["~"] = "\\markdownRendererTilde{}",
+    ["|"] = "\\markdownRendererPipe{}",
+    [entities.hex_entity('0000')] = "\\markdownRendererReplacementCharacter{}",
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -25229,6 +25263,14 @@ end
 \cs_gset_eq:NN
   \markdownRendererFencedDivAttributeContextEndPrototype
   \markdownRendererHeaderAttributeContextEndPrototype
+\cs_gset:Npn
+  \markdownRendererReplacementCharacterPrototype
+  {
+    % TODO: Replace with `\codepoint_generate:nn` in TeX Live 2023
+    \sys_if_engine_pdftex:TF
+      { ^^ef^^bf^^bd }
+      { ^^^^fffd }
+  }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -276,5 +276,8 @@
       \TYPE{- src:                 #1}%
       \TYPE{- raw attribute:       #2}%
       \TYPE{END rawBlock}},
+    replacementCharacter = {%
+      \TYPE{replacementCharacter}%
+      \GOBBLE},
   }%
 }%

--- a/tests/support/plain-setup.tex
+++ b/tests/support/plain-setup.tex
@@ -256,3 +256,5 @@
   \TYPE{- src:                 #1}%
   \TYPE{- raw attribute:       #2}%
   \TYPE{END rawBlock}}%
+\def\markdownRendererReplacementCharacter#1{%
+  \TYPE{replacementCharacter}}%


### PR DESCRIPTION
Closes https://github.com/lostenderman/markdown/issues/34 after discussion [at LuaTeX mailing list][1].

 [1]: https://tug.org/pipermail/luatex/2023-January/007798.html