### PR TITLE
Add support for slicing fenced divs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Development:
 
 - Add renderers that represent the sections implied by headings.
   (#258, #264)
+- Add support for slicing fenced divs. (#229, #266)
 
 Fixes:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21834,13 +21834,9 @@ function M.writer.new(options)
 %  \begin{macrocode}
   function self.document(d)
     local buf = {"\\markdownRendererDocumentBegin\n", d}
-    local attribute_change_buf
 
     -- pop all attributes
-    while #self.active_attributes > 0 do
-      attribute_change_buf = self.pop_attributes()
-      table.insert(buf, attribute_change_buf)
-    end
+    table.insert(buf, self.pop_attributes())
 
     table.insert(buf, "\\markdownRendererDocumentEnd")
 
@@ -21901,7 +21897,7 @@ function M.writer.new(options)
   local function apply_attributes()
     local buf = {}
     for i = 1, #self.active_attributes do
-      local start_output = self.active_attributes[i][2]
+      local start_output = self.active_attributes[i][3]
       if start_output ~= nil then
         table.insert(buf, start_output)
       end
@@ -21912,7 +21908,7 @@ function M.writer.new(options)
   local function tear_down_attributes()
     local buf = {}
     for i = #self.active_attributes, 1, -1 do
-      local end_output = self.active_attributes[i][3]
+      local end_output = self.active_attributes[i][4]
       if end_output ~= nil then
         table.insert(buf, end_output)
       end
@@ -21923,18 +21919,21 @@ function M.writer.new(options)
 % \begin{markdown}
 %
 % The \luamref{writer->push\_attributes} method adds `attributes`
-% to \luamref{writer->active\_attributes}. The `start_output` string
-% is used to construct a rope that will be returned by this function,
-% together with output produced as a result of slicing (see \Opt{slice}).
-% The `end_output` string is stored together with `attributes` and is
-% used to construct the return value of the \luamref{writer->pop\_attributes}
+% of type `attribute_type` to \luamref{writer->active\_attributes}. The
+% `start_output` string is used to construct a rope that will be returned by
+% this function, together with output produced as a result of slicing (see
+% \Opt{slice}).  The `end_output` string is stored together with `attributes`
+% and is used to construct the return value of the
+% \luamref{writer->pop\_attributes}
 % method.
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function self.push_attributes(attributes, start_output, end_output)
+  function self.push_attributes(attribute_type, attributes,
+                                start_output, end_output)
     attributes = attributes or {}
     local buf = {}
+    -- handle slicing
     if attributes["#" .. self.slice_end_identifier] ~= nil and
        self.slice_end_type == "^" then
       if self.is_writing then
@@ -21952,7 +21951,8 @@ function M.writer.new(options)
       table.insert(buf, start_output)
     end
     table.insert(self.active_attributes,
-      {attributes, start_output, end_output})
+                 {attribute_type, attributes,
+                  start_output, end_output})
     return buf
   end
 
@@ -21961,32 +21961,41 @@ function M.writer.new(options)
 %
 % The \luamref{writer->pop\_attributes} method removes the most current of
 % active block-level attributes from \luamref{writer->active\_attributes}
-% and returns a rope constructed from the `end_output` string specified
-% in the call of \luamref{writer->push\_attributes} that produced the most
-% current attributes, and also from output produced as a result of slicing (see
-% \Opt{slice}).
+% until attributes of type `attribute_type` have been removed. The method
+% returns a rope constructed from the `end_output` string specified
+% in the calls of \luamref{writer->push\_attributes} that produced the most
+% current attributes, and also from output produced as a result of slicing
+% (see \Opt{slice}).
 %
 % \end{markdown}
 %  \begin{macrocode}
-  function self.pop_attributes()
+  function self.pop_attributes(attribute_type)
     local buf = {}
-    local attributes, _, end_output = table.unpack(
-      self.active_attributes[#self.active_attributes])
-    if self.is_writing and end_output ~= nil then
-      table.insert(buf, end_output)
-    end
-    table.remove(self.active_attributes, #self.active_attributes)
-    if attributes["#" .. self.slice_end_identifier] ~= nil
-       and self.slice_end_type == "$" then
-      if self.is_writing then
-        table.insert(buf, tear_down_attributes())
+    -- pop attributes until we find attributes of correct type
+    -- or until no attributes remain
+    local current_attribute_type = false
+    while current_attribute_type ~= attribute_type and
+          #self.active_attributes > 0 do
+      local attributes, _, end_output
+      current_attribute_type, attributes, _, end_output = table.unpack(
+        self.active_attributes[#self.active_attributes])
+      if self.is_writing and end_output ~= nil then
+        table.insert(buf, end_output)
       end
-      self.is_writing = false
-    end
-    if attributes["#" .. self.slice_begin_identifier] ~= nil and
-       self.slice_begin_type == "$" then
-      self.is_writing = true
-      table.insert(buf, apply_attributes())
+      table.remove(self.active_attributes, #self.active_attributes)
+      -- handle slicing
+      if attributes["#" .. self.slice_end_identifier] ~= nil
+         and self.slice_end_type == "$" then
+        if self.is_writing then
+          table.insert(buf, tear_down_attributes())
+        end
+        self.is_writing = false
+      end
+      if attributes["#" .. self.slice_begin_identifier] ~= nil and
+         self.slice_begin_type == "$" then
+        self.is_writing = true
+        table.insert(buf, apply_attributes())
+      end
     end
     return buf
   end
@@ -22000,7 +22009,7 @@ function M.writer.new(options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local active_heading_attribute_indexes = {}
+  local current_heading_level = 0
   function self.heading(s, level, attributes)
     attributes = attributes or {}
     for i = 1, #attributes do
@@ -22008,26 +22017,21 @@ function M.writer.new(options)
     end
 
     local buf = {}
-    local attribute_change_buf
 
     -- push empty attributes for implied sections
-    while #active_heading_attribute_indexes < level - 1 do
-      attribute_change_buf = self.push_attributes(nil,
-                                                  "\\markdownRendererSectionBegin\n",
-                                                  "\n\\markdownRendererSectionEnd ")
-      table.insert(buf, attribute_change_buf)
-      table.insert(active_heading_attribute_indexes, #self.active_attributes)
+    while current_heading_level < level - 1 do
+      table.insert(buf,
+                   self.push_attributes("heading",
+                                        nil,
+                                        "\\markdownRendererSectionBegin\n",
+                                        "\n\\markdownRendererSectionEnd "))
+      current_heading_level = current_heading_level + 1
     end
 
     -- pop attributes for sections that have ended
-    while #active_heading_attribute_indexes >= level do
-      while #self.active_attributes >= active_heading_attribute_indexes[
-                                      #active_heading_attribute_indexes] do
-        attribute_change_buf = self.pop_attributes()
-        table.insert(buf, attribute_change_buf)
-      end
-      table.remove(active_heading_attribute_indexes,
-                  #active_heading_attribute_indexes)
+    while current_heading_level >= level do
+      table.insert(buf, self.pop_attributes("heading"))
+      current_heading_level = current_heading_level - 1
     end
 
     -- push attributes for the new section
@@ -22035,16 +22039,20 @@ function M.writer.new(options)
     local end_output = {}
     table.insert(start_output, "\\markdownRendererSectionBegin\n")
     if options.headerAttributes and #attributes > 0 then
-      table.insert(start_output, "\\markdownRendererHeaderAttributeContextBegin\n")
+      table.insert(start_output,
+                   "\\markdownRendererHeaderAttributeContextBegin\n")
       table.insert(start_output, self.attributes(attributes))
-      table.insert(end_output, "\n\\markdownRendererHeaderAttributeContextEnd ")
+      table.insert(end_output,
+                   "\n\\markdownRendererHeaderAttributeContextEnd ")
     end
     table.insert(end_output, "\n\\markdownRendererSectionEnd ")
 
-    attribute_change_buf = self.push_attributes(
-      attributes, start_output, end_output)
-    table.insert(buf, attribute_change_buf)
-    table.insert(active_heading_attribute_indexes, #self.active_attributes)
+    table.insert(buf, self.push_attributes("heading",
+                                           attributes,
+                                           start_output,
+                                           end_output))
+    current_heading_level = current_heading_level + 1
+    assert(current_heading_level == level)
 
     -- produce the renderer
     local cmd
@@ -24766,16 +24774,29 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 % \par
 % \begin{markdown}
 %
-% Define \luamdef{writer->div} as a function that will transform an input
-% fenced div with content `c` and with attributes `attr` to the output format.
+% Define \luamdef{writer->div_begin} as a function that will transform the
+% beginning of an input fenced div with with attributes `attributes` to the
+% output format.
 %
 % \end{markdown}
 %  \begin{macrocode}
-      function self.div(c, attr)
-        return {"\\markdownRendererFencedDivAttributeContextBegin",
-                self.attributes(attr),
-                c,
-                "\\markdownRendererFencedDivAttributeContextEnd"}
+      function self.div_begin(attributes)
+        local start_output = {"\\markdownRendererFencedDivAttributeContextBegin\n",
+                              self.attributes(attributes)}
+        local end_output = {"\n\\markdownRendererFencedDivAttributeContextEnd "}
+        return self.push_attributes("div", attributes, start_output, end_output)
+      end
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->div_end} as a function that will produce the end of a
+% fenced div in the output format.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      function self.div_end()
+        return self.pop_attributes("div")
       end
     end, extend_reader = function(self)
       local parsers = self.parsers
@@ -24828,7 +24849,16 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                  , "div_level")
       end
 
-      local FencedDiv = fenced_div_begin * increment_div_level(1)
+      local FencedDiv = fenced_div_begin
+                      / function (infostring)
+                          local attr = lpeg.match(Ct(parsers.attributes), infostring)
+                          if attr == nil then
+                            attr = {"." .. infostring}
+                          end
+                          return attr
+                        end
+                      / writer.div_begin
+                      * increment_div_level(1)
                       * parsers.skipblanklines
                       * Ct( (V("Block") - fenced_div_end)^-1
                           * ( parsers.blanklines
@@ -24838,14 +24868,7 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                             * (V("Block") - fenced_div_end))^0)
                       * parsers.skipblanklines
                       * fenced_div_end * increment_div_level(-1)
-                      / function (infostring, div)
-                          local attr = lpeg.match(Ct(parsers.attributes), infostring)
-                          if attr == nil then
-                            attr = {"." .. infostring}
-                          end
-                          return div, attr
-                        end
-                      / writer.div
+                      * (Cc("") / writer.div_end)
 
       self.insert_pattern("Block after Verbatim",
                           FencedDiv, "FencedDiv")

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -5613,6 +5613,35 @@ defaultOptions.fencedCodeAttributes = false
 
 % \end{markdown}
 % \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[fencedDivs]{markdown}
+\begin{document}
+\begin{markdown}{slice=special}
+Here is a regular paragraph.
+
+::::: {#special}
+Here is a special paragraph.
+:::::
+
+And here is another regular paragraph.
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> Here is a special paragraph.
+
 %</manual-options>
 %<*tex>
 % \fi

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21931,7 +21931,12 @@ function M.writer.new(options)
 %  \begin{macrocode}
   function self.push_attributes(attribute_type, attributes,
                                 start_output, end_output)
+    -- index attributes in a hash table for easy lookup
     attributes = attributes or {}
+    for i = 1, #attributes do
+      attributes[attributes[i]] = true
+    end
+
     local buf = {}
     -- handle slicing
     if attributes["#" .. self.slice_end_identifier] ~= nil and
@@ -22011,11 +22016,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   local current_heading_level = 0
   function self.heading(s, level, attributes)
-    attributes = attributes or {}
-    for i = 1, #attributes do
-      attributes[attributes[i]] = true
-    end
-
     local buf = {}
 
     -- push empty attributes for implied sections
@@ -22038,7 +22038,7 @@ function M.writer.new(options)
     local start_output = {}
     local end_output = {}
     table.insert(start_output, "\\markdownRendererSectionBegin\n")
-    if options.headerAttributes and #attributes > 0 then
+    if options.headerAttributes and attributes ~= nil and #attributes > 0 then
       table.insert(start_output,
                    "\\markdownRendererHeaderAttributeContextBegin\n")
       table.insert(start_output, self.attributes(attributes))
@@ -23211,12 +23211,10 @@ function M.reader.new(writer, options)
 
   parsers.Paragraph    = parsers.nonindentspace * Ct(parsers.Inline^1)
                        * ( parsers.newline
-                       * ( parsers.blankline^1
-                         + #parsers.hash
-                         + #(parsers.leader * parsers.more * parsers.space^-1)
-                         + parsers.eof
+                         * ( parsers.blankline^1
+                           + #V("EndlineExceptions")
                          )
-                       + parsers.eof )
+                         + parsers.eof)
                        / writer.paragraph
 
   parsers.Plain        = parsers.nonindentspace * Ct(parsers.Inline^1)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21350,6 +21350,11 @@ function M.writer.new(options)
     self.slice_end = "$" .. slice_specifiers[1]
   end
 
+  self.slice_begin_type = self.slice_begin:sub(1, 1)
+  self.slice_begin_identifier = self.slice_begin:sub(2) or ""
+  self.slice_end_type = self.slice_end:sub(1, 1)
+  self.slice_end_identifier = self.slice_end:sub(2) or ""
+
   if self.slice_begin == "^" and self.slice_end ~= "^" then
     self.is_writing = true
   else
@@ -21828,19 +21833,13 @@ function M.writer.new(options)
 % \end{markdown}
 %  \begin{macrocode}
   function self.document(d)
-    local active_attributes = self.active_attributes
     local buf = {"\\markdownRendererDocumentBegin\n", d}
+    local attribute_change_buf
 
-    -- pop attributes for sections that have ended
-    if options.headerAttributes and self.is_writing then
-      while #active_attributes > 0 do
-        local attributes = active_attributes[#active_attributes]
-        if #attributes > 0 then
-          table.insert(buf, "\\markdownRendererHeaderAttributeContextEnd")
-        end
-        table.insert(buf, "\\markdownRendererSectionEnd")
-        table.remove(active_attributes, #active_attributes)
-      end
+    -- pop all attributes
+    while #self.active_attributes > 0 do
+      attribute_change_buf = self.pop_attributes()
+      table.insert(buf, attribute_change_buf)
     end
 
     table.insert(buf, "\\markdownRendererDocumentEnd")
@@ -21881,13 +21880,116 @@ function M.writer.new(options)
 % \par
 % \begin{markdown}
 %
-% Define \luamdef{writer->active\_attributes} as a stack of attributes
-% of the headings that are currently active. The
-% \luamdef{writer->active\_headings} member variable is mutable.
+% Define \luamdef{writer->active\_attributes} as a stack of block-level
+% attributes that are currently active. The
+% \luamref{writer->active\_attributes} member variable is mutable.
 %
 % \end{markdown}
 %  \begin{macrocode}
   self.active_attributes = {}
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Define \luamdef{writer->push\_attributes} and
+% \luamdef{writer->pop\_attributes} as functions that will add a new set
+% of active block-level attributes or remove the most current attributes
+% from \luamref{writer->active\_attributes}.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  local function apply_attributes()
+    local buf = {}
+    for i = 1, #self.active_attributes do
+      local start_output = self.active_attributes[i][2]
+      if start_output ~= nil then
+        table.insert(buf, start_output)
+      end
+    end
+    return buf
+  end
+
+  local function tear_down_attributes()
+    local buf = {}
+    for i = #self.active_attributes, 1, -1 do
+      local end_output = self.active_attributes[i][3]
+      if end_output ~= nil then
+        table.insert(buf, end_output)
+      end
+    end
+    return buf
+  end
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The \luamref{writer->push\_attributes} method adds `attributes`
+% to \luamref{writer->active\_attributes}. The `start_output` string
+% is used to construct a rope that will be returned by this function,
+% together with output produced as a result of slicing (see \Opt{slice}).
+% The `end_output` string is stored together with `attributes` and is
+% used to construct the return value of the \luamref{writer->pop\_attributes}
+% method.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  function self.push_attributes(attributes, start_output, end_output)
+    attributes = attributes or {}
+    local buf = {}
+    if attributes["#" .. self.slice_end_identifier] ~= nil and
+       self.slice_end_type == "^" then
+      if self.is_writing then
+        table.insert(buf, tear_down_attributes())
+      end
+      self.is_writing = false
+    end
+    if attributes["#" .. self.slice_begin_identifier] ~= nil and
+       self.slice_begin_type == "^" then
+      self.is_writing = true
+      table.insert(buf, apply_attributes())
+      self.is_writing = true
+    end
+    if self.is_writing and start_output ~= nil then
+      table.insert(buf, start_output)
+    end
+    table.insert(self.active_attributes,
+      {attributes, start_output, end_output})
+    return buf
+  end
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The \luamref{writer->pop\_attributes} method removes the most current of
+% active block-level attributes from \luamref{writer->active\_attributes}
+% and returns a rope constructed from the `end_output` string specified
+% in the call of \luamref{writer->push\_attributes} that produced the most
+% current attributes, and also from output produced as a result of slicing (see
+% \Opt{slice}).
+%
+% \end{markdown}
+%  \begin{macrocode}
+  function self.pop_attributes()
+    local buf = {}
+    local attributes, _, end_output = table.unpack(
+      self.active_attributes[#self.active_attributes])
+    if self.is_writing and end_output ~= nil then
+      table.insert(buf, end_output)
+    end
+    table.remove(self.active_attributes, #self.active_attributes)
+    if attributes["#" .. self.slice_end_identifier] ~= nil
+       and self.slice_end_type == "$" then
+      if self.is_writing then
+        table.insert(buf, tear_down_attributes())
+      end
+      self.is_writing = false
+    end
+    if attributes["#" .. self.slice_begin_identifier] ~= nil and
+       self.slice_begin_type == "$" then
+      self.is_writing = true
+      table.insert(buf, apply_attributes())
+    end
+    return buf
+  end
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -21898,96 +22000,53 @@ function M.writer.new(options)
 %
 % \end{markdown}
 %  \begin{macrocode}
+  local active_heading_attribute_indexes = {}
   function self.heading(s, level, attributes)
     attributes = attributes or {}
     for i = 1, #attributes do
       attributes[attributes[i]] = true
     end
 
-    local active_attributes = self.active_attributes
-    local slice_begin_type = self.slice_begin:sub(1, 1)
-    local slice_begin_identifier = self.slice_begin:sub(2) or ""
-    local slice_end_type = self.slice_end:sub(1, 1)
-    local slice_end_identifier = self.slice_end:sub(2) or ""
-
     local buf = {}
+    local attribute_change_buf
 
     -- push empty attributes for implied sections
-    while #active_attributes < level-1 do
-      table.insert(active_attributes, {})
+    while #active_heading_attribute_indexes < level - 1 do
+      attribute_change_buf = self.push_attributes(nil,
+                                                  "\\markdownRendererSectionBegin\n",
+                                                  "\n\\markdownRendererSectionEnd ")
+      table.insert(buf, attribute_change_buf)
+      table.insert(active_heading_attribute_indexes, #self.active_attributes)
     end
 
     -- pop attributes for sections that have ended
-    while #active_attributes >= level do
-      local active_identifiers = active_attributes[#active_attributes]
-      -- tear down all active attributes at slice end
-      if active_identifiers["#" .. slice_end_identifier] ~= nil
-          and slice_end_type == "$" then
-        for header_level = #active_attributes, 1, -1 do
-          if options.headerAttributes and #active_attributes[header_level] > 0 then
-            table.insert(buf, "\\markdownRendererHeaderAttributeContextEnd")
-          end
-          table.insert(buf, "\\markdownRendererSectionEnd")
-        end
-        self.is_writing = false
+    while #active_heading_attribute_indexes >= level do
+      while #self.active_attributes >= active_heading_attribute_indexes[
+                                      #active_heading_attribute_indexes] do
+        attribute_change_buf = self.pop_attributes()
+        table.insert(buf, attribute_change_buf)
       end
-      table.remove(active_attributes, #active_attributes)
-      if self.is_writing then
-        if options.headerAttributes and #active_identifiers > 0 then
-          table.insert(buf, "\\markdownRendererHeaderAttributeContextEnd")
-        end
-        table.insert(buf, "\\markdownRendererSectionEnd")
-      end
-      -- apply all active attributes at slice beginning
-      if active_identifiers["#" .. slice_begin_identifier] ~= nil
-          and slice_begin_type == "$" then
-        for header_level = 1, #active_attributes do
-          table.insert(buf, "\\markdownRendererSectionBegin")
-          if options.headerAttributes and #active_attributes[header_level] > 0 then
-            table.insert(buf, "\\markdownRendererHeaderAttributeContextBegin")
-          end
-        end
-        self.is_writing = true
-      end
-    end
-
-    -- tear down all active attributes at slice end
-    if attributes["#" .. slice_end_identifier] ~= nil
-        and slice_end_type == "^" then
-      for header_level = #active_attributes, 1, -1 do
-        if options.headerAttributes and #active_attributes[header_level] > 0 then
-          table.insert(buf, "\\markdownRendererHeaderAttributeContextEnd")
-        end
-        table.insert(buf, "\\markdownRendererSectionEnd")
-      end
-      self.is_writing = false
+      table.remove(active_heading_attribute_indexes,
+                  #active_heading_attribute_indexes)
     end
 
     -- push attributes for the new section
-    table.insert(active_attributes, attributes)
-    if self.is_writing then
-      table.insert(buf, "\\markdownRendererSectionBegin")
-      if options.headerAttributes and #attributes > 0 then
-        table.insert(buf, "\\markdownRendererHeaderAttributeContextBegin")
-      end
+    local start_output = {}
+    local end_output = {}
+    table.insert(start_output, "\\markdownRendererSectionBegin\n")
+    if options.headerAttributes and #attributes > 0 then
+      table.insert(start_output, "\\markdownRendererHeaderAttributeContextBegin\n")
+      table.insert(start_output, self.attributes(attributes))
+      table.insert(end_output, "\n\\markdownRendererHeaderAttributeContextEnd ")
     end
+    table.insert(end_output, "\n\\markdownRendererSectionEnd ")
 
-    -- apply all active attributes at slice beginning
-    if attributes["#" .. slice_begin_identifier] ~= nil
-        and slice_begin_type == "^" then
-      for header_level = 1, #active_attributes do
-        table.insert(buf, "\\markdownRendererSectionBegin")
-        if options.headerAttributes and #active_attributes[header_level] > 0 then
-          table.insert(buf, "\\markdownRendererHeaderAttributeContextBegin")
-        end
-      end
-      self.is_writing = true
-    end
+    attribute_change_buf = self.push_attributes(
+      attributes, start_output, end_output)
+    table.insert(buf, attribute_change_buf)
+    table.insert(active_heading_attribute_indexes, #self.active_attributes)
 
-    if self.is_writing then
-      table.insert(buf, self.attributes(attributes))
-    end
-
+    -- produce the renderer
     local cmd
     level = level + options.shiftHeadings
     if level <= 1 then

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -5586,7 +5586,7 @@ defaultOptions.fencedCodeAttributes = false
 %</lua,lua-cli>
 %<*manual-options>
 
-#### Option `fencedDivs`
+#### Option `fencedDivs` {#fenced-divs}
 
 `fencedDivs` (default value: `false`)
 
@@ -7687,11 +7687,16 @@ defaultOptions.shiftHeadings = 0
 
      - The circumflex (`^`) selects the beginning of a document.
      - The dollar sign (`$`) selects the end of a document.
-     - `^`\meta{identifier} selects the beginning of a section with the
-%      \acro{HTML} attribute `#`\meta{identifier} (see the
-%      \Opt{headerAttributes} option).
+     - `^`\meta{identifier} selects the beginning of
+%      a section (see the \Opt{headerAttributes} option)
 %      \iffalse
-       [\acro{HTML} attribute](#header-attributes) `#`\meta{identifier}.
+       a [section](#header-attributes)
+%      \fi
+%      or a fenced div (see the \Opt{fencedDivs} option) with the \acro{HTML}
+%      attribute `#`\meta{identifier}.
+%      \iffalse
+       or a [fenced div](#fenced-divs)
+       with the \acro{HTML} attribute `#`\meta{identifier}.
 %      \fi
      - `$`\meta{identifier} selects the end of a section with the \acro{HTML}
        attribute `#`\meta{identifier}.

--- a/tests/testfiles/CommonMark_0.30/fenced-code.test
+++ b/tests/testfiles/CommonMark_0.30/fenced-code.test
@@ -282,6 +282,7 @@ interblockSeparator
 interblockSeparator
 interblockSeparator
 BEGIN section
+BEGIN section
 headingTwo: foo
 interblockSeparator
 BEGIN fencedCode
@@ -330,4 +331,5 @@ BEGIN fencedCode
 - src: ./_markdown_test/bf41e9999cfc44d815c2a227bc67b1ab.verbatim
 - infostring: 
 END fencedCode
+END section
 documentEnd

--- a/tests/testfiles/Markdown_1.0.3/markdown-documentation-basics.test
+++ b/tests/testfiles/Markdown_1.0.3/markdown-documentation-basics.test
@@ -448,4 +448,7 @@ inputVerbatim: ./_markdown_test/7d9f1e26a42e0270218d0c17064c2013.verbatim
 interblockSeparator
 interblockSeparator
 inputVerbatim: ./_markdown_test/e1de0455cbe83acebe6cfa078bdcb1cc.verbatim
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/Markdown_1.0.3/markdown-documentation-syntax.test
+++ b/tests/testfiles/Markdown_1.0.3/markdown-documentation-syntax.test
@@ -1554,4 +1554,7 @@ inputVerbatim: ./_markdown_test/48f8d6f10d4f5f67fd448d4d52284296.verbatim
 interblockSeparator
 interblockSeparator
 inputVerbatim: ./_markdown_test/04418d019c77b632c835de3e798283f7.verbatim
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/Markdown_1.0.3/ordered-and-unordered-lists.test
+++ b/tests/testfiles/Markdown_1.0.3/ordered-and-unordered-lists.test
@@ -134,6 +134,7 @@ This was an error in Markdown 1.0.1:
 >>>
 documentBegin
 BEGIN section
+BEGIN section
 headingTwo: Unordered
 interblockSeparator
 interblockSeparator
@@ -327,4 +328,6 @@ ulEndTight
 interblockSeparator
 ulItemEnd
 ulEnd
+END section
+END section
 documentEnd

--- a/tests/testfiles/PHP_Markdown/emphasis.test
+++ b/tests/testfiles/PHP_Markdown/emphasis.test
@@ -226,6 +226,7 @@ interblockSeparator
 emphasis: precious
 interblockSeparator
 BEGIN section
+BEGIN section
 headingTwo: Tricky Cases
 interblockSeparator
 strongEmphasis: Test
@@ -274,4 +275,6 @@ underscore
 underscore
 underscore
 underscore
+END section
+END section
 documentEnd

--- a/tests/testfiles/PHP_Markdown/headers.test
+++ b/tests/testfiles/PHP_Markdown/headers.test
@@ -11,6 +11,8 @@ Paragraph
 >>>
 documentBegin
 BEGIN section
+BEGIN section
+BEGIN section
 headingThree: Header
 interblockSeparator
 thematicBreak
@@ -18,4 +20,7 @@ interblockSeparator
 interblockSeparator
 thematicBreak
 interblockSeparator
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/PHP_Markdown/md5-hashes.test
+++ b/tests/testfiles/PHP_Markdown/md5-hashes.test
@@ -24,4 +24,5 @@ interblockSeparator
 interblockSeparator
 codeSpan: <p>test</p>
 interblockSeparator
+END section
 documentEnd

--- a/tests/testfiles/PHP_Markdown/php-specific-bugs.test
+++ b/tests/testfiles/PHP_Markdown/php-specific-bugs.test
@@ -41,4 +41,7 @@ interblockSeparator
 codeSpan: (underscore)Detab
 interblockSeparator
 inputVerbatim: ./_markdown_test/57e7cfa9cb0dc4b666bfe415c968fe70.verbatim
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/PHP_Markdown/tables.test
+++ b/tests/testfiles/PHP_Markdown/tables.test
@@ -333,4 +333,5 @@ BEGIN table (3 rows, 1 columns)
 - row 2, column 1: Cell
 - row 3, column 1: Cell
 END table
+END section
 documentEnd

--- a/tests/testfiles/PHP_Markdown/tight-blocks.test
+++ b/tests/testfiles/PHP_Markdown/tight-blocks.test
@@ -30,4 +30,5 @@ interblockSeparator
 interblockSeparator
 blockQuoteBegin
 blockQuoteEnd
+END section
 documentEnd

--- a/tests/testfiles/lunamark-markdown/no-header-attributes.test
+++ b/tests/testfiles/lunamark-markdown/no-header-attributes.test
@@ -44,4 +44,10 @@ headingFive: A level five heading (hash)(hash) (leftBrace)(hash)--not-7the-seven
 interblockSeparator
 BEGIN section
 headingSix: A level six heading (leftBrace)(hash)the-eighth-id attribute=value(rightBrace)
+END section
+END section
+END section
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/lunamark-markdown/no-shift-headings.test
+++ b/tests/testfiles/lunamark-markdown/no-shift-headings.test
@@ -44,4 +44,10 @@ headingFive: A level five heading
 interblockSeparator
 BEGIN section
 headingSix: A level six heading
+END section
+END section
+END section
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/lunamark-markdown/shift-headings-backwards.test
+++ b/tests/testfiles/lunamark-markdown/shift-headings-backwards.test
@@ -46,4 +46,10 @@ headingThree: A level five heading
 interblockSeparator
 BEGIN section
 headingFour: A level six heading
+END section
+END section
+END section
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/lunamark-markdown/shift-headings-forward.test
+++ b/tests/testfiles/lunamark-markdown/shift-headings-forward.test
@@ -46,4 +46,10 @@ headingSix: A level five heading
 interblockSeparator
 BEGIN section
 headingSix: A level six heading
+END section
+END section
+END section
+END section
+END section
+END section
 documentEnd

--- a/tests/testfiles/lunamark-markdown/slice-fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/slice-fenced-divs.test
@@ -1,0 +1,29 @@
+\def\markdownOptionHeaderAttributes{true}
+\def\markdownOptionFencedDivs{true}
+\def\markdownOptionSlice{sliced-div ^first-heading}
+<<<
+This test ensures that the Lua `slice` option applies to fenced divs.
+
+::: {.class-name}
+This text will be *ignored*.
+
+::: {#sliced-div}
+This text will be *displayed*.
+
+# This is an H1 {#first-heading}
+
+This text will be *ignored*.
+:::
+
+This text will be *ignored*.
+:::
+>>>
+documentBegin
+BEGIN fencedDivAttributeContext
+attributeClassName: class-name
+BEGIN fencedDivAttributeContext
+attributeIdentifier: sliced-div
+emphasis: displayed
+END fencedDivAttributeContext
+END fencedDivAttributeContext
+documentEnd


### PR DESCRIPTION
Closes #229.

### Tasks
- [x] Update documentation
- [x] Abstract the tracking of active block-level attributes away from headings
- [x] Add support for slicing of fenced divs
- [x] Unit-test slicing of fenced divs
- [x] Revert https://github.com/Witiko/markdown/commit/532cdb88e24a733ba5cda760eba1172da254076b
- [x] Update `CHANGES.md`