### PR TITLE
Use `\prg_new_conditional:Nnn` to define `\@@_if_option:n`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,15 +8,20 @@ Development:
   token renderer prototypes in the `\markdownSetup` LaTeX
   command using wildcards. (#232, #287)
 
+Fixes:
+
+- Remove extra space after inline elements with attributes.
+  (#288)
+
 Documentation:
 
 - Add a link to a preprint from TUGboat 44(1) to `README.md`.
   (#234, a4d9fbf)
 
-Fixes:
+Refactoring:
 
-- Remove extra space after inline elements with attributes.
-  (#288)
+- Use `\prg_new_conditional:Nnn` to define `\@@_if_option:n`.
+  (#289)
 
 ## 2.22.0 (2023-04-02)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -28839,8 +28839,9 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\cs_new:Nn
-  \@@_if_option:nTF
+\prg_new_conditional:Nnn
+  \@@_if_option:n
+  { TF, T, F }
   {
     \@@_get_option_type:nN
       { #1 }
@@ -28861,8 +28862,8 @@ end
     \str_if_eq:NNTF
       \l_tmpa_tl
       \c_@@_option_value_true_tl
-      { #2 }
-      { #3 }
+      { \prg_return_true: }
+      { \prg_return_false: }
   }
 \msg_new:nnn
   { markdown }
@@ -30967,7 +30968,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\@@_if_option:nTF
+\@@_if_option:nT
   { linkAttributes }
   {
     \RequirePackage{graphicx}
@@ -30991,7 +30992,6 @@ end
       },
     }
   }
-  { }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par


### PR DESCRIPTION
Previously, we used `\cs_new:Nn` to define the conditional function `\@@_if_option:nTF`. This works, but it does not allow us to automatically generate other variants of `\@@_if_option:nTF` such as `\@@_if_option:nT` and `\@@_if_option_p:n`. This pull request changes `\cs_new:Nn` to `\prg_new_conditional:Nnn`, which allows us to automatically generate other variants of `\@@_if_option:nTF`.