### PR TITLE
Make tinyyaml a standalone CTAN package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,11 @@ Refactoring:
 - Use `\prg_new_conditional:Nnn` to define `\@@_if_option:n`.
   (#289)
 
+Libraries:
+
+- Make tinyyaml a standalone CTAN package. (contributed by
+  @zepinglee, #218, #294)
+
 ## 2.22.0 (2023-04-02)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1203,7 +1203,8 @@ end)()
 %     (subset) parser that is used to read \acro{yaml} metadata when the
 %     \Opt{jekyllData} option is enabled. We carry a copy of the library
 %     in file `markdown-tinyyaml.lua` distributed together with the Markdown
-%     package.
+%     package. <!-- TODO: Stop carrying the copy of the library in TeX Live
+%     2023. -->
 %
 % \end{markdown}
 % \iffalse
@@ -27878,6 +27879,7 @@ M.extensions.jekyll_data = function(expect_jekyll_data)
                          , function(s, i, text) -- luacheck: ignore s i
                              local data
                              local ran_ok, _ = pcall(function()
+                               -- TODO: Replace with `require("tinyyaml")` in TeX Live 2023
                                local tinyyaml = require("markdown-tinyyaml")
                                data = tinyyaml.parse(text, {timestamps=false})
                              end)


### PR DESCRIPTION
Closes #218.

### Tasks

- [x] Update `libraries/tinyyaml` submodule.
- [x] Add a TODO in `markdown.dtx` for replacing `require("markdown-tinyyaml")` with `require("tinyyaml")` after we have dropped support for TeX Live 2022.
- [x] Update `CHANGES.md` (section Libraries).