### PR TITLE
Allow refences in fenced divs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Default Renderer Prototypes:
 - Do not force line breaks after high-level headings in LaTeX,
   but allow the text to follow the heading on the same line. (df8562c)
 
+Fixes:
+
+- Allow refences in fenced divs. (#307)
+
 ## 2.23.0 (2023-04-27)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26773,7 +26773,10 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                       * increment_div_level(1)
                       * parsers.skipblanklines
                       * Ct( (V("Block") - fenced_div_end)^-1
-                          * ( V("Blank")^0 / writer.interblocksep
+                          * ( V("Blank")^0
+                            / function()
+                                return writer.interblocksep
+                              end
                             * (V("Block") - fenced_div_end))^0)
                       * V("Blank")^0
                       * fenced_div_end * increment_div_level(-1)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26773,12 +26773,9 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                       * increment_div_level(1)
                       * parsers.skipblanklines
                       * Ct( (V("Block") - fenced_div_end)^-1
-                          * ( parsers.blanklines
-                            / function()
-                                return writer.interblocksep
-                              end
+                          * ( V("Blank")^0 / writer.interblocksep
                             * (V("Block") - fenced_div_end))^0)
-                      * parsers.skipblanklines
+                      * V("Blank")^0
                       * fenced_div_end * increment_div_level(-1)
                       * (Cc("") / writer.div_end)
 

--- a/tests/testfiles/lunamark-markdown/fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/fenced-divs.test
@@ -98,7 +98,9 @@ I am a _fenced_ div
 
 ::: {.cit custom-style=raggedleft}
 
-I am a _fenced_ div
+I am a _fenced_ div with [a reference][1]
+
+ [1]: https://foo.bar/
 
 :::
 
@@ -222,6 +224,11 @@ BEGIN attributeKeyValue
 - value: raggedleft
 END attributeKeyValue
 emphasis: fenced
+BEGIN link
+- label: a reference
+- URI: https://foo.bar/
+- title: 
+END link
 END fencedDivAttributeContext
 interblockSeparator
 leftBrace


### PR DESCRIPTION
Our implementation of fenced divs does not allow for reference definitions. This is because our implementation uses the `parsers.blankline` pattern instead of the `Blank` rule, which includes blank lines and references, among other things.