### PR TITLE
Add alt text to figures

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -32164,7 +32164,7 @@ end
   image = {%
     \begin{figure}%
       \begin{center}%
-        \includegraphics{#3}%
+        \includegraphics[alt={#1}]{#3}%
       \end{center}%
       \ifx\empty#4\empty\else
         \caption{#4}%


### PR DESCRIPTION
This PR uses the label of a markdown image to produce the alt text of an image in the default renderer prototypes for LaTeX.