### PR TITLE
Run continuous integration on a self-hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - luacheck
       - markdownlint
       - pytype
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
To improve the speed of building the docker image and running tests, we have set up a number of dedicated self-hosted runners that have many CPU threads.

### Tasks

- [x] Try running continuous integration with a single self-hosted runner.
- [ ] Update the configuration to:
  - [ ] Make a self-hosted runner able to delete the checked-out repo in [the Post checkout repository step][1].
  - [ ] Properly clean up by untagging the produced image.
  - [ ] Use a GitHub runner when all self-hosted runners are occupied.
- [ ] Ping @Texhackse to add a second self-hosted runner and try running continuous integration.
- [ ] Update `CHANGES.md`.

 [1]: https://github.com/Witiko/markdown/actions/runs/5906000081/job/16021170672