### PR TITLE
Run continuous integration on self-hosted runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,12 +177,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: Fix ownership of repository
-        if: matrix.texlive == 'latest'
-        run: |
-          set -ex
-          DOCKER_IMAGE=witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
-          docker run --rm -v "$PWD":/git-repo -w /git-repo "$DOCKER_IMAGE" chown -R root:root /git-repo
       - name: Build distribution archives
         if: matrix.texlive == 'latest'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,20 +93,23 @@ jobs:
           pip install pytype
       - name: Run Pytype
         run: pytype tests/test.py
-  test-and-publish:
-    name: Test and publish
+  build-docker-image:
+    name: Build Docker image
     needs:
       - shellcheck
       - luacheck
       - markdownlint
       - pytype
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         texlive:
           - TL2022-historic
           - latest
+    outputs:
+      TL2022-historic: ${{ steps.temporary-tags.outputs.TL2022-historic }}
+      latest: ${{ steps.temporary-tags.outputs.latest }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -115,19 +118,71 @@ jobs:
           submodules: true
       - name: Build Docker image
         run: make docker-image TEXLIVE_TAG=${{ matrix.texlive }}
-      - name: Fix ownership of repository
-        run: docker run --rm -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} chown -R root:root /git-repo
+      - name: Authenticate Docker registry
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Publish Docker image with a temporary tag
+        run: make docker-push-temporary-tag TEXLIVE_TAG=${{ matrix.texlive }}
+      - name: Store the temporary tag
+        id: temporary-tags
+        run: |
+          TEMPORARY_TAG="$(make docker-print-temporary-tag TEXLIVE_TAG=${{ matrix.texlive }})"
+          echo "${{ matrix.texlive }}=$TEMPORARY_TAG" >> $GITHUB_OUTPUT
+  test:
+    name: Test Docker image
+    needs:
+      - build-docker-image
+    strategy:
+      fail-fast: true
+      matrix:
+        texlive:
+          - TL2022-historic
+          - latest
+    runs-on: ubuntu-latest  # TODO: Replace with self-hosted.
+    container:
+      image: witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: Test Lua command-line interface
         run: |
-          RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' |
-                    docker run --rm -i witiko/markdown:${{ matrix.texlive }} markdown-cli hybrid=true underscores=false |
-                    tee /dev/stderr)"
+          RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | markdown-cli hybrid=true underscores=false | tee /dev/stderr)"
           test "$RESULT" = '\markdownRendererDocumentBegin'$'\n''Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
       - name: Run unit tests
-        run: docker run --rm -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} make FAIL_FAST=${{ github.ref != 'refs/heads/main' }} test
+        run: make FAIL_FAST=${{ github.ref != 'refs/heads/main' }} test
+  publish:
+    name: Publish Docker image and artefacts
+    needs:
+      - build-docker-image
+      - test
+    strategy:
+      fail-fast: true
+      matrix:
+        texlive:
+          - TL2022-historic
+          - latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Fix ownership of repository
+        if: matrix.texlive == 'latest'
+        run: |
+          DOCKER_IMAGE=witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
+          docker run --rm -v "$PWD":/git-repo -w /git-repo "$DOCKER_IMAGE" chown -R root:root /git-repo
       - name: Build distribution archives
         if: matrix.texlive == 'latest'
-        run: docker run --rm -v "$PWD":/git-repo -w /git-repo witiko/markdown:${{ matrix.texlive }} make dist gh-pages
+        run: |
+          DOCKER_IMAGE=witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
+          docker run --rm -v "$PWD":/git-repo -w /git-repo "$DOCKER_IMAGE" make dist gh-pages
       - name: Upload artifact markdown.tds.zip
         if: matrix.texlive == 'latest'
         uses: actions/upload-artifact@v2
@@ -173,7 +228,7 @@ jobs:
             markdown.ctan.zip
             markdown.zip
             markdown.pdf
-      - name: Authenticate registry
+      - name: Authenticate Docker registry
         if: github.ref == 'refs/heads/main'
         uses: azure/docker-login@v1
         with:
@@ -181,11 +236,11 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Publish Docker image
         if: github.ref == 'refs/heads/main'
-        run: docker push witiko/markdown --all-tags
+        run: make docker-push-release-tag TEXLIVE_TAG=${{ matrix.texlive }}
   automerge:
     name: Automatically merge pull request
     needs:
-      - test-and-publish
+      - publish
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Store the temporary tag
         id: temporary-tags
         run: |
+          set -ex
           TEMPORARY_TAG="$(make docker-print-temporary-tag TEXLIVE_TAG=${{ matrix.texlive }})"
           echo "${{ matrix.texlive }}=$TEMPORARY_TAG" >> $GITHUB_OUTPUT
   test:
@@ -151,6 +152,7 @@ jobs:
           submodules: true
       - name: Test Lua command-line interface
         run: |
+          set -ex
           RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | markdown-cli hybrid=true underscores=false | tee /dev/stderr)"
           test "$RESULT" = '\markdownRendererDocumentBegin'$'\n''Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
       - name: Run unit tests
@@ -176,11 +178,13 @@ jobs:
       - name: Fix ownership of repository
         if: matrix.texlive == 'latest'
         run: |
+          set -ex
           DOCKER_IMAGE=witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
           docker run --rm -v "$PWD":/git-repo -w /git-repo "$DOCKER_IMAGE" chown -R root:root /git-repo
       - name: Build distribution archives
         if: matrix.texlive == 'latest'
         run: |
+          set -ex
           DOCKER_IMAGE=witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
           docker run --rm -v "$PWD":/git-repo -w /git-repo "$DOCKER_IMAGE" make dist gh-pages
       - name: Upload artifact markdown.tds.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,8 +158,8 @@ jobs:
           Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
       - name: Run unit tests
         run: make FAIL_FAST=${{ github.ref != 'refs/heads/main' }} test
-  publish:
-    name: Publish Docker image and artefacts
+  publish-docker-image:
+    name: Publish Docker image
     needs:
       - build-docker-image
       - test
@@ -177,12 +177,37 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - name: Authenticate Docker registry
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Publish Docker image
+        run: make docker-push-release-tag TEXLIVE_TAG=${{ matrix.texlive }}
+  publish-artefacts:
+    name: Publish artefacts and create a prerelease
+    needs:
+      - build-docker-image
+      - test
+    strategy:
+      fail-fast: true
+      matrix:
+        texlive:
+          - TL2022-historic
+          - latest
+    runs-on: ubuntu-latest
+    container:
+      image: witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: Build distribution archives
         if: matrix.texlive == 'latest'
-        run: |
-          set -ex
-          DOCKER_IMAGE=witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
-          docker run --rm -v "$PWD":/git-repo -w /git-repo "$DOCKER_IMAGE" make dist gh-pages
+        run: make dist gh-pages
       - name: Upload artifact markdown.tds.zip
         if: matrix.texlive == 'latest'
         uses: actions/upload-artifact@v2
@@ -228,13 +253,6 @@ jobs:
             markdown.ctan.zip
             markdown.zip
             markdown.pdf
-      - name: Authenticate Docker registry
-        uses: azure/docker-login@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Publish Docker image
-        run: make docker-push-release-tag TEXLIVE_TAG=${{ matrix.texlive }}
   automerge:
     name: Automatically merge pull request
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,9 +170,9 @@ jobs:
           - TL2022-historic
           - latest
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
-        if: github.ref == 'refs/heads/main' || matrix.texlive == 'latest'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -214,7 +214,7 @@ jobs:
           name: markdown.pdf
           path: markdown.pdf
       - name: Publish user manual
-        if: github.ref == 'refs/heads/main' && matrix.texlive == 'latest'
+        if: matrix.texlive == 'latest'
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages
@@ -222,7 +222,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a prerelease
-        if: github.ref == 'refs/heads/main' && matrix.texlive == 'latest'
+        if: matrix.texlive == 'latest'
         uses: marvinpinto/action-automatic-releases@latest
         with:
           title: The latest version
@@ -235,18 +235,16 @@ jobs:
             markdown.zip
             markdown.pdf
       - name: Authenticate Docker registry
-        if: github.ref == 'refs/heads/main'
         uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Publish Docker image
-        if: github.ref == 'refs/heads/main'
         run: make docker-push-release-tag TEXLIVE_TAG=${{ matrix.texlive }}
   automerge:
     name: Automatically merge pull request
     needs:
-      - publish
+      - test
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
         texlive:
           - TL2022-historic
           - latest
-    runs-on: ubuntu-latest  # TODO: Replace with self-hosted.
+    runs-on: self-hosted
     container:
       image: witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
+        if: github.ref == 'refs/heads/main' || matrix.texlive == 'latest'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,8 +153,9 @@ jobs:
       - name: Test Lua command-line interface
         run: |
           set -ex
-          RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | markdown-cli hybrid=true underscores=false | tee /dev/stderr)"
-          test "$RESULT" = '\markdownRendererDocumentBegin'$'\n''Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
+          RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | markdown-cli hybrid=true underscores=false"
+          test "$RESULT" = '\markdownRendererDocumentBegin
+          Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
       - name: Run unit tests
         run: make FAIL_FAST=${{ github.ref != 'refs/heads/main' }} test
   publish:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Test Lua command-line interface
         run: |
           set -ex
-          RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | markdown-cli hybrid=true underscores=false"
+          RESULT="$(printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | markdown-cli hybrid=true underscores=false)"
           test "$RESULT" = '\markdownRendererDocumentBegin
           Hello \markdownRendererEmphasis{Markdown}! $a_x + b_x = c_x$\markdownRendererDocumentEnd'
       - name: Run unit tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ Unit Tests:
 
 - Batch unit tests to improve speed.
   (#245, #316, 8bfd0b3, #317, #319..#325, #327, #328, e3b31696)
+- Use self-hosted GitHub runners for tests to improve tests.
+  (#326, #330, #331, contributed by @TeXhackse)
 
 ## 3.0.0-alpha.2 (2023-08-01)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Unit Tests:
 - Batch unit tests to improve speed.
   (#245, #316, 8bfd0b3, #317, #319..#325, #327, #328, e3b31696,
    #331, #332, #334)
-- Use self-hosted GitHub runners for tests to improve tests.
+- Use self-hosted GitHub runners for tests to improve speed.
   (#326, #330, #331, contributed by @TeXhackse)
 
 ## 3.0.0-alpha.2 (2023-08-01)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Unit Tests:
 
 - Batch unit tests to improve speed.
   (#245, #316, 8bfd0b3, #317, #319..#325, #327, #328, e3b31696,
-   #332, #334)
+   #331, #332, #334)
 - Use self-hosted GitHub runners for tests to improve tests.
   (#326, #330, #331, contributed by @TeXhackse)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all base clean implode dist test docker-image force
+.PHONY: all base clean implode dist test force \
+  docker-image docker-push-temporary-tag docker-print-temporary-tag \
+  docker-push-release-tag
 
 SHELL=/bin/bash
 
@@ -54,6 +56,10 @@ GITHUB_PAGES=gh-pages
 VERSION=$(shell git describe --tags --always --long --exclude latest)
 LASTMODIFIED=$(shell git log -1 --date=format:%Y-%m-%d --format=%ad)
 
+DOCKER_IMAGE=witiko/markdown
+DOCKER_TEMPORARY_TAG=$(VERSION)-$(TEXLIVE_TAG)
+DOCKER_RELEASE_TAG=$(TEXLIVE_TAG)
+
 PANDOC_INPUT_FORMAT=markdown+tex_math_single_backslash+tex_math_double_backslash-raw_tex
 
 # This is the default pseudo-target. It typesets the manual,
@@ -69,8 +75,26 @@ base: $(INSTALLABLES) $(LIBRARIES)
 # This pseudo-target builds a witiko/markdown Docker image.
 docker-image:
 	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(TEXLIVE_TAG) \
-	                               -t witiko/markdown:$(TEXLIVE_TAG) \
-	                               -t witiko/markdown:$(VERSION)-$(TEXLIVE_TAG) .
+	                               -t $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG) .
+
+# This pseudo-targed pushes the built witiko/markdown Docker image to
+# a Docker registry with a temporary tag.
+docker-push-temporary-tag:
+	docker push $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG)
+
+# This pseudo-target prints the temporary tag that we used to tag the
+# built witiko/markdown Docker image before pushing it to the Docker
+# registry.
+docker-print-temporary-tag:
+	@echo $(DOCKER_TEMPORARY_TAG)
+
+# This pseudo-targed pushes the built witiko/markdown Docker image to
+# a Docker registry with a release tag.
+docker-push-release-tag:
+	docker pull $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG)
+	docker tag $(DOCKER_IMAGE):$(TEMPORARY_TAG) \
+	           $(DOCKER_IMAGE):$(RELEASE_TAG)
+	docker push $(DOCKER_IMAGE):$(DOCKER_RELEASE_TAG)
 
 # This targets produces a directory with files for the GitHub Pages service.
 $(GITHUB_PAGES): $(HTML_USER_MANUAL)


### PR DESCRIPTION
Closes https://github.com/Witiko/markdown/issues/330.

### Tasks

- [x] Split the CI job *Test and publish* into several subjobs:
  - *Build Docker Image* will run on a free runner and build the Docker image and push it to the Docker registry with only the unique tag witiko/markdown:$(VERSION)-$(TEXLIVE_TAG) such as witiko/markdown:3.0.0-alpha.2-95-g6918a31-latest, not the general tag witiko/markdown:$(TEXLIVE_TAG) such as witiko/markdown:latest.
  - *Test Docker image* will run on either a self-hosted runner, if available, or on a free runner otherwise and will test the Lua CLI and run unit tests. This entire job will run inside a container of the Docker image witiko/markdown:$(VERSION)-$(TEXLIVE_TAG) that the runner will fetch from the Docker registry.
  - *Publish Docker image and artefacts* will run on a free runner and build distribution archives, upload artefacts, create a prerelease on GitHub, and push the Docker image with the tag witiko/markdown:$(TEXLIVE_TAG) to the Docker registry.
- [x] Add a first self-hosted runner and try running the CI with it.
      Set up clean-up of the downloaded witiko/markdown:$(VERSION)-$(TEXLIVE_TAG) Docker images.
- [x] Ping @TeXhackse to add a second self-hoster runner and try running the CI with it.
- [x] Determine whether the speed increase is substantial enough to complicate the code base.
- [x] Update `CHANGES.md`.