### PR TITLE
Push temporary Docker images to GitHub Packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
           - latest
     runs-on: self-hosted
     container:
-      image: witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
+      image: ghcr.io/witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -200,7 +200,7 @@ jobs:
           - latest
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
+      image: ghcr.io/witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ on:
     - cron: '30 4 * * MON'
 env:
   DEBIAN_FRONTEND: noninteractive
-permissions:
-  contents: write
 jobs:
   shellcheck:
     name: Style check (Bash)
@@ -110,6 +108,8 @@ jobs:
       TL2022-historic: ${{ steps.temporary-tags.outputs.TL2022-historic }}
       latest: ${{ steps.temporary-tags.outputs.latest }}
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -264,6 +264,8 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event_name == 'pull_request'
     steps:
       - name: Automatically merge pull request

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,11 +120,12 @@ jobs:
         run: |
           make docker-image TEXLIVE_TAG=${{ matrix.texlive }} \
                             NO_DOCUMENTATION=${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
-      - name: Authenticate Docker registry
-        uses: azure/docker-login@v1
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Docker image with a temporary tag
         run: make docker-push-temporary-tag TEXLIVE_TAG=${{ matrix.texlive }}
       - name: Store the temporary tag
@@ -179,8 +180,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: Authenticate Docker registry
-        uses: azure/docker-login@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Continuous Integration:
 
 - In draft pull requests, do not build documentation or examples
   and do not run pkgcheck. (#337, #338)
+- Push temporary Docker images to GitHub Packages. (#340, #341)
 
 ## 3.0.0-alpha.2 (2023-08-01)
 

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,9 @@ endif
 VERSION=$(shell git describe --tags --always --long --exclude latest)
 LASTMODIFIED=$(shell git log -1 --date=format:%Y-%m-%d --format=%ad)
 
-DOCKER_IMAGE=witiko/markdown
+DOCKER_TEMPORARY_IMAGE=ghcr.io/witiko/markdown
 DOCKER_TEMPORARY_TAG=$(VERSION)-$(TEXLIVE_TAG)
+DOCKER_RELEASE_IMAGE=witiko/markdown
 DOCKER_RELEASE_TAG=$(TEXLIVE_TAG)
 
 PANDOC_INPUT_FORMAT=markdown+tex_math_single_backslash+tex_math_double_backslash-raw_tex
@@ -81,12 +82,12 @@ base: $(INSTALLABLES) $(LIBRARIES)
 docker-image:
 	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(TEXLIVE_TAG) \
 	                               --build-arg NO_DOCUMENTATION=$(NO_DOCUMENTATION) \
-	                               -t $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG) .
+	                               -t $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) .
 
 # This pseudo-targed pushes the built witiko/markdown Docker image to
 # a Docker registry with a temporary tag.
 docker-push-temporary-tag:
-	docker push $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG)
+	docker push $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG)
 
 # This pseudo-target prints the temporary tag that we used to tag the
 # built witiko/markdown Docker image before pushing it to the Docker
@@ -97,10 +98,13 @@ docker-print-temporary-tag:
 # This pseudo-targed pushes the built witiko/markdown Docker image to
 # a Docker registry with a release tag.
 docker-push-release-tag:
-	docker pull $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG)
-	docker tag $(DOCKER_IMAGE):$(DOCKER_TEMPORARY_TAG) \
-	           $(DOCKER_IMAGE):$(DOCKER_RELEASE_TAG)
-	docker push $(DOCKER_IMAGE):$(DOCKER_RELEASE_TAG)
+	docker pull $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG)
+	docker tag $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) \
+	           $(DOCKER_RELEASE_IMAGE):$(DOCKER_TEMPORARY_TAG)
+	docker tag $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) \
+	           $(DOCKER_RELEASE_IMAGE):$(DOCKER_RELEASE_TAG)
+	docker push $(DOCKER_RELEASE_IMAGE):$(DOCKER_TEMPORARY_TAG)
+	docker push $(DOCKER_RELEASE_IMAGE):$(DOCKER_RELEASE_TAG)
 
 # This targets produces a directory with files for the GitHub Pages service.
 $(GITHUB_PAGES): $(HTML_USER_MANUAL)


### PR DESCRIPTION
[GitHub security policy][1] disallows sharing secrets with forks in public repositories. However, we need pull requests to push temporary Docker images to a registry, which requires access to secrets unless we use GitHub Packages, which [only require the `GITHUB_TOKEN` secret][2] that is shared with workflows triggered by pull requests from public repositories.

This pull request causes temporary Docker images to be pushed to GitHub Packages.

 [1]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 [2]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-in-a-github-actions-workflow