### PR TITLE
Correctly parse paragraphs with trailing spaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     steps:
       - name: Automatically merge pull request
         uses: pascalgn/automerge-action@v0.15.6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## 3.1.0
 
+Fixes:
+
+- Correctly parse paragraphs with trailing spaces.
+  (danopolan/istqb_latex#77, #345, #347)
+
+Unit Tests:
+
+- Add support for YAML metadata in testfiles. (#345, #347)
+
 ## 3.0.0 (2023-08-25)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -33687,11 +33687,9 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \startluacode
-  document.markdown_preserve_trailing_spaces = true
-  document.markdown_is_buffering = false
+  document.markdown_buffering = false
   local function preserve_trailing_spaces(line)
-    if document.markdown_is_buffering and
-       document.markdown_preserve_trailing_spaces then
+    if document.markdown_buffering then
       line = line:gsub("[ \t][ \t]$", "\t\t")
     end
     return line
@@ -33702,11 +33700,11 @@ end
   \catcode`\|=0%
   \catcode`\\=12%
   |gdef|startmarkdown{%
-    |ctxlua{document.markdown_is_buffering = true}%
+    |ctxlua{document.markdown_buffering = true}%
     |markdownReadAndConvert{\stopmarkdown}%
                            {|stopmarkdown}}%
   |gdef|stopmarkdown{%
-    |ctxlua{document.markdown_is_buffering = false}%
+    |ctxlua{document.markdown_buffering = false}%
     |markdownEnd}%
 |endgroup
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27904,7 +27904,7 @@ end
                                     + V("Blank")^0 / writer.interblocksep
                                     )
                                   )
-                                + ( V("Paragraph") + V("Plain") )
+                                + V("Paragraph")
                                 * ( V("Blank")^0 * parsers.eof
                                   + ( V("Blank")^2 / writer.paragraphsep
                                     + V("Blank")^0 / writer.interblocksep
@@ -27916,7 +27916,7 @@ end
                                     + V("Blank")^0 / writer.interblocksep
                                     )
                                   )
-                                + ( V("Paragraph") + V("Plain") )
+                                + V("Paragraph")
                                 * ( V("Blank")^0 * parsers.eof
                                   + V("Blank")^0 / writer.paragraphsep
                                   )

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27904,7 +27904,7 @@ end
                                     + V("Blank")^0 / writer.interblocksep
                                     )
                                   )
-                                + V("Paragraph")
+                                + ( V("Paragraph") + V("Plain") )
                                 * ( V("Blank")^0 * parsers.eof
                                   + ( V("Blank")^2 / writer.paragraphsep
                                     + V("Blank")^0 / writer.interblocksep
@@ -27916,7 +27916,7 @@ end
                                     + V("Blank")^0 / writer.interblocksep
                                     )
                                   )
-                                + V("Paragraph")
+                                + ( V("Paragraph") + V("Plain") )
                                 * ( V("Blank")^0 * parsers.eof
                                   + V("Blank")^0 / writer.paragraphsep
                                   )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 click~=8.1.6
 more-itertools~=10.0.0
+PyYAML~=6.0.1
 tqdm~=4.65.0

--- a/tests/templates/context-mkiv/verbatim/body.tex.m4
+++ b/tests/templates/context-mkiv/verbatim/body.tex.m4
@@ -4,8 +4,6 @@
 % Prevent the folding of characters into a single space token in logs.
 \catcode"09=12%  Tabs (U+0009)
 \catcode"20=12%  Spaces (U+0020)
-% Do not preserve trailing spaces in input buffer for parity with other TeX formats.
-\ctxlua{document.markdown_preserve_trailing_spaces = false}
 % Disable active characters of the TeX engine.
 \catcode"7E=12%  Tildes (U+007E)
 % Perform the test.

--- a/tests/test.py
+++ b/tests/test.py
@@ -690,8 +690,8 @@ def should_process_testfile(read_testfile_result: ReadTestFile, test_parameters:
     metadata = yaml.safe_load(read_testfile_result.metadata)
     if not isinstance(metadata, dict) or 'if' not in metadata:
         return True  # The testfile has no restrictions on the parameters.
-    local_variables = {'format': test_parameters.tex_format, 'template': test_parameters.template.name}
-    should_process_testfile = eval(metadata['if'], globals={}, locals=local_variables)
+    variables = {'format': test_parameters.tex_format, 'template': test_parameters.template.name}
+    should_process_testfile = eval(metadata['if'], variables)
     return should_process_testfile
 
 

--- a/tests/testfiles/CommonMark_0.30/indented_code_blocks/005.test
+++ b/tests/testfiles/CommonMark_0.30/indented_code_blocks/005.test
@@ -1,3 +1,6 @@
+if: not (format == 'context-mkiv' and template == 'verbatim')
+---
+
 %   ---RESULT--- "example": 111,
 %   
 %   <pre><code>chunk1

--- a/tests/testfiles/CommonMark_0.30/indented_code_blocks/006.test
+++ b/tests/testfiles/CommonMark_0.30/indented_code_blocks/006.test
@@ -1,3 +1,6 @@
+if: not (format == 'context-mkiv' and template == 'verbatim')
+---
+
 %   ---RESULT--- "example": 112,
 %   
 %   <pre><code>chunk1

--- a/tests/testfiles/README.md
+++ b/tests/testfiles/README.md
@@ -1,6 +1,8 @@
 This directory contains subdirectories with test files, which can be recognized
 by the `.test` suffix. A test file has the following syntax:
 
+    Optional YAML metadata
+    ---
     The test setup TeX source code
     <<<
     The test markdown source code
@@ -11,11 +13,17 @@ The test setup TeX source code can be used to configure the Markdown package
 through its plain TeX interface before the test markdown source code is
 processed.
 
+The optional YAML metadata may contain any useful information, although we
+currently only process the `if` key that can be used to specify for which
+TeX formats and templates the testfile should run using Python syntax:
+
+``` yaml
+if: format == 'context-mkiv' or template == 'verbatim'
+```
+
+If no YAML metadata are specified, the `---` delimiter may also be omitted.
+
 The test markdown source code is the markdown code that will be processed
 during the test. The majority of markdown tokens are configured by the support
 files to produce output to the log file. This output will be compared against
 the expected test output.
-
-The `<<<` and `>>>` markers may be surrounded by optional whitespaces. If the
-last section beginning with `>>>` is not present, it will be automatically
-generated during the testing and appended to the test file.

--- a/tests/testfiles/lunamark-markdown/fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/fenced-divs.test
@@ -1,8 +1,7 @@
 \def\markdownOptionFencedDivs{true}
-\def\markdownOptionFencedCode{true}
 <<<
-This test ensures that the Lua `fencedDivs` and `fencedCode` options correctly
-propagates through the plain TeX interface.
+This test ensures that the Lua `fencedDivs` option correctly propagates through
+the plain TeX interface.
 
 :::
 This is not a div
@@ -115,7 +114,6 @@ This is not a div
 >>>
 documentBegin
 codeSpan: fencedDivs
-codeSpan: fencedCode
 softLineBreak
 paragraphSeparator
 softLineBreak

--- a/tests/testfiles/lunamark-markdown/hard-line-breaks.test
+++ b/tests/testfiles/lunamark-markdown/hard-line-breaks.test
@@ -1,4 +1,4 @@
-if: format == 'context-mkiv' or template == 'verbatim'
+if: format == 'context-mkiv' or template == 'input'
 ---
 <<<
 This test ensures that two and more trailing spaces or one or more trailing
@@ -12,9 +12,10 @@ Here is a line with three trailing spaces, producing a hard line break.
 Here is a line with four trailing spaces at the end of a paragraph.    
 
 Here is a line with no trailing tabs, producing a soft line break.
-Here is a line with a single trailing tab, producing a hard line break.	
+Here is a line with a single trailing tab, producing a soft line break.	
 Here is a line with two trailing tabs, producing a hard line break.		
-Here is a line with three trailing spaces at the end of the document.			
+Here is a line with three trailing tabs, producing a hard line break.			
+Here is a line with four trailing tabs at the end of the document.				
 >>>
 documentBegin
 softLineBreak
@@ -26,6 +27,7 @@ softLineBreak
 hardLineBreak
 hardLineBreak
 paragraphSeparator
+softLineBreak
 softLineBreak
 hardLineBreak
 hardLineBreak

--- a/tests/testfiles/lunamark-markdown/hard-line-breaks.test
+++ b/tests/testfiles/lunamark-markdown/hard-line-breaks.test
@@ -19,6 +19,7 @@ Here is a line with three trailing spaces at the end of the document.
 documentBegin
 softLineBreak
 softLineBreak
+codeSpan: input
 paragraphSeparator
 softLineBreak
 softLineBreak

--- a/tests/testfiles/lunamark-markdown/hard-line-breaks.test
+++ b/tests/testfiles/lunamark-markdown/hard-line-breaks.test
@@ -1,0 +1,31 @@
+if: format == 'context-mkiv' or template == 'verbatim'
+---
+<<<
+This test ensures that two and more trailing spaces or one or more trailing
+tabs produce a hard line break for all templates of the ConTeXt MkIV format
+and for the `input` templates of all other formats.
+
+Here is a line with no trailing spaces, producing a soft line break.
+Here is a line with a single trailing space, producing a soft line break. 
+Here is a line with two trailing spaces, producing a hard line break.  
+Here is a line with three trailing spaces, producing a hard line break.   
+Here is a line with four trailing spaces at the end of a paragraph.    
+
+Here is a line with no trailing tabs, producing a soft line break.
+Here is a line with a single trailing tab, producing a hard line break.	
+Here is a line with two trailing tabs, producing a hard line break.		
+Here is a line with three trailing spaces at the end of the document.			
+>>>
+documentBegin
+softLineBreak
+softLineBreak
+paragraphSeparator
+softLineBreak
+softLineBreak
+hardLineBreak
+hardLineBreak
+paragraphSeparator
+softLineBreak
+hardLineBreak
+hardLineBreak
+documentEnd

--- a/tests/testfiles/lunamark-markdown/no-fenced-code-attributes.test
+++ b/tests/testfiles/lunamark-markdown/no-fenced-code-attributes.test
@@ -1,8 +1,6 @@
-\def\markdownOptionFencedCode{true}
 <<<
-This test ensures that the Lua `fencedCode` option correctly propagates through
-the plain TeX interface and that the `fencedCodeAttributes` option is disabled
-by default.
+This test ensures that the Lua `fencedCodeAttributes` option is disabled by
+default.
 
 The following fenced code block attributes should be recognized as a part of
 the infostring.
@@ -12,8 +10,6 @@ bar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 >>>
 documentBegin
-codeSpan: fencedCode
-softLineBreak
 codeSpan: fencedCodeAttributes
 softLineBreak
 paragraphSeparator

--- a/tests/testfiles/lunamark-markdown/no-fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/no-fenced-divs.test
@@ -1,8 +1,5 @@
-\def\markdownOptionFencedCode{true}
 <<<
-This test ensures that the Lua `fencedDivs` option is disabled by default
-and that the `fencedCode` option correctly propagates through the plain TeX
-interface.
+This test ensures that the Lua `fencedDivs` option is disabled by default.
 
 :::
 This is not a div
@@ -108,9 +105,6 @@ This is not a div
 >>>
 documentBegin
 codeSpan: fencedDivs
-softLineBreak
-codeSpan: fencedCode
-softLineBreak
 paragraphSeparator
 softLineBreak
 softLineBreak

--- a/tests/testfiles/lunamark-markdown/no-slice.test
+++ b/tests/testfiles/lunamark-markdown/no-slice.test
@@ -87,9 +87,9 @@ Term 1
 *Term 2*
 
 :   Definition 2
-    
+
         Some code, part of Definition 2
-    
+
     Third paragraph of Definition 2.
 
 :   Definition 3
@@ -117,14 +117,14 @@ Here is a note reference[^1] and another.[^longnote]
 Here is an inline note.^[Inlines notes are easier to
 write, since you don't have to pick an identifier and
 move down to type the note.]
-  
+
 [^1]: Here is the note.
 
 [^longnote]: Here's one with multiple blocks.
-  
+
     Subsequent paragraphs are indented to show that they
 belong to the previous note.
-  
+
         Some code
 
     The whole paragraph can be indented, or just the first


### PR DESCRIPTION
Closes #345 and continues https://github.com/danopolan/istqb_latex/pull/77.

### Tasks

- [x] Fix the parsing of document `example.md` from https://github.com/Witiko/markdown/issues/345#issuecomment-1700952575 by fixing a regression introduced by https://github.com/Witiko/markdown/pull/306.
- [x] Add a regression test for the issue:
    - [x] Add and document support for YAML blocks in testfiles, as described in https://github.com/Witiko/markdown/issues/345#issuecomment-1704050058.
      - [x] Instead of processing all testfiles with all templates and commands and only masking the results, remove disabled testfiles from batches.
    - [x] Enable special treatment of trailing spaces in tests for ConTeXt MkIV by removing the following lines:
          https://github.com/Witiko/markdown/blob/c1af40672e26eea5e041df840a1c881da42e4103/tests/templates/context-mkiv/verbatim/body.tex.m4#L7-L8
    - [x] Add a test `hard-line-breaks.test`, as described in https://github.com/Witiko/markdown/issues/345#issuecomment-1704050058.
      - [x] Ensure that the test also acts as a regression test for this issue by testing e.g. that trailing spaces at the end of a paragraph do not produce a hard line break.
- [x] Update `CHANGES.md`.

### Nice to haves

- [ ] Find all CommonMark examples that test the behavior of trailing tabs and spaces and add them as testfiles that only run with the ConTeXt MkIV format or with the `verbatim` template.
- [ ] Add and document optional fields `title`, `author`, and `date` to YAML blocks. Display these fields in addition to the name of a testfile in `test.py`.