### PR TITLE
Restore CommonMark testfiles with trailing tabs and spaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ Documentation:
 - Add a link to a preprint from TUGboat 44:3 to `README.md`.
   (cf6b3d7b, dc57af7)
 
+Unit Tests:
+
+- Restore CommonMark testfiles with trailing tabs and spaces.
+  (contributed by @lostenderman, #348, #353,
+   lostenderman/markdown#2)
+
 ## 3.1.0 (2023-09-27)
 
 Development:

--- a/tests/testfiles/CommonMark_0.30/code_spans/008.test
+++ b/tests/testfiles/CommonMark_0.30/code_spans/008.test
@@ -1,16 +1,19 @@
+if: template == 'input'
+---
+
 %   ---RESULT--- "example": 335,
 %   
-%   <p><code>foo bar baz</code></p>
+%   <p><code>foo bar   baz</code></p>
 %   
 %   ---\RESULT---
 
 <<<
 ``
 foo
-bar
+bar  
 baz
 ``
 >>>
 documentBegin
-codeSpan: foo bar baz
+codeSpan: foo bar   baz
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/code_spans/009.test
+++ b/tests/testfiles/CommonMark_0.30/code_spans/009.test
@@ -1,0 +1,17 @@
+if: template == 'input'
+---
+
+%   ---RESULT--- "example": 336,
+%   
+%   <p><code>foo </code></p>
+%   
+%   ---\RESULT---
+
+<<<
+``
+foo 
+``
+>>>
+documentBegin
+codeSpan: foo 
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/code_spans/010.test
+++ b/tests/testfiles/CommonMark_0.30/code_spans/010.test
@@ -1,13 +1,16 @@
+if: template == 'input'
+---
+
 %   ---RESULT--- "example": 337,
 %   
-%   <p><code>foo   bar baz</code></p>
+%   <p><code>foo   bar  baz</code></p>
 %   
 %   ---\RESULT---
 
 <<<
-`foo   bar
+`foo   bar 
 baz`
 >>>
 documentBegin
-codeSpan: foo   bar baz
+codeSpan: foo   bar  baz
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/fenced_code_blocks/011.test
+++ b/tests/testfiles/CommonMark_0.30/fenced_code_blocks/011.test
@@ -1,7 +1,10 @@
+if: template == 'input'
+---
+
 %   ---RESULT--- "example": 129,
 %   
 %   <pre><code>
-%   
+%     
 %   </code></pre>
 %   
 %   ---\RESULT---
@@ -9,12 +12,12 @@
 <<<
 ```
 
-
+  
 ```
 >>>
 documentBegin
 BEGIN fencedCode
-- src: ./_markdown_test/68b329da9893e34099c7d8ad5cb9c940.verbatim
+- src: ./_markdown_test/f67be96ce768fb5b40aecf0438f97886.verbatim
 - infostring: 
 END fencedCode
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/001.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/001.test
@@ -1,0 +1,17 @@
+if: format == 'context-mkiv' or template == 'input'
+---
+
+%   ---RESULT--- "example": 633,
+%   
+%   <p>foo<br />
+%   baz</p>
+%   
+%   ---\RESULT---
+
+<<<
+foo  
+baz
+>>>
+documentBegin
+hardLineBreak
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/003.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/003.test
@@ -1,0 +1,17 @@
+if: format == 'context-mkiv' or template == 'input'
+---
+
+%   ---RESULT--- "example": 635,
+%   
+%   <p>foo<br />
+%   baz</p>
+%   
+%   ---\RESULT---
+
+<<<
+foo       
+baz
+>>>
+documentBegin
+hardLineBreak
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/004.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/004.test
@@ -1,0 +1,17 @@
+if: format == 'context-mkiv' or template == 'input'
+---
+
+%   ---RESULT--- "example": 636,
+%   
+%   <p>foo<br />
+%   bar</p>
+%   
+%   ---\RESULT---
+
+<<<
+foo  
+     bar
+>>>
+documentBegin
+hardLineBreak
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/006.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/006.test
@@ -1,0 +1,17 @@
+if: format == 'context-mkiv' or template == 'input'
+---
+
+%   ---RESULT--- "example": 638,
+%   
+%   <p><em>foo<br />
+%   bar</em></p>
+%   
+%   ---\RESULT---
+
+<<<
+*foo  
+bar*
+>>>
+documentBegin
+emphasis: foo(hardLineBreak)bar
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/008.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/008.test
@@ -1,0 +1,16 @@
+if: template == 'input'
+---
+
+%   ---RESULT--- "example": 640,
+%   
+%   <p><code>code   span</code></p>
+%   
+%   ---\RESULT---
+
+<<<
+`code  
+span`
+>>>
+documentBegin
+codeSpan: code   span
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/hard_line_breaks/010.test
+++ b/tests/testfiles/CommonMark_0.30/hard_line_breaks/010.test
@@ -1,0 +1,17 @@
+if: template == 'input'
+---
+
+%   ---RESULT--- "example": 642,
+%   
+%   <p><a href="foo  
+%   bar"></p>
+%   
+%   ---\RESULT---
+
+<<<
+<a href="foo  
+bar">
+>>>
+documentBegin
+inlineHtmlTag: <a href="foo   bar">
+documentEnd

--- a/tests/testfiles/CommonMark_0.30/indented_code_blocks/005.test
+++ b/tests/testfiles/CommonMark_0.30/indented_code_blocks/005.test
@@ -1,4 +1,4 @@
-if: not (format == 'context-mkiv' and template == 'verbatim')
+if: template == 'input'
 ---
 
 %   ---RESULT--- "example": 111,

--- a/tests/testfiles/CommonMark_0.30/indented_code_blocks/006.test
+++ b/tests/testfiles/CommonMark_0.30/indented_code_blocks/006.test
@@ -1,10 +1,10 @@
-if: not (format == 'context-mkiv' and template == 'verbatim')
+if: template == 'input'
 ---
 
 %   ---RESULT--- "example": 112,
 %   
 %   <pre><code>chunk1
-%   
+%     
 %     chunk2
 %   </code></pre>
 %   
@@ -12,9 +12,9 @@ if: not (format == 'context-mkiv' and template == 'verbatim')
 
 <<<
     chunk1
-    
+      
       chunk2
 >>>
 documentBegin
-inputVerbatim: ./_markdown_test/baeeb37d6c9237faa1bcd55e3102e279.verbatim
+inputVerbatim: ./_markdown_test/d6bc1998e8030f4c5bc9338f5ed4bbf4.verbatim
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/indented_code_blocks/012.test
+++ b/tests/testfiles/CommonMark_0.30/indented_code_blocks/012.test
@@ -1,13 +1,16 @@
+if: template == 'input'
+---
+
 %   ---RESULT--- "example": 118,
 %   
-%   <pre><code>foo
+%   <pre><code>foo  
 %   </code></pre>
 %   
 %   ---\RESULT---
 
 <<<
-    foo
+    foo  
 >>>
 documentBegin
-inputVerbatim: ./_markdown_test/acbd18db4cc2f85cedef654fccc4a4d8.verbatim
+inputVerbatim: ./_markdown_test/e8d2133b16be538460e59776bb34676a.verbatim
 documentEnd

--- a/tests/testfiles/CommonMark_0.30/paragraphs/008.test
+++ b/tests/testfiles/CommonMark_0.30/paragraphs/008.test
@@ -1,0 +1,19 @@
+if: format == 'context-mkiv' or template == 'input'
+---
+
+%   ---RESULT--- "example": 226,
+%   
+%   <p><em>aaa</em><br />
+%   <em>bbb</em></p>
+%   
+%   ---\RESULT---
+
+<<<
+*aaa*     
+*bbb*     
+>>>
+documentBegin
+emphasis: aaa
+hardLineBreak
+emphasis: bbb
+documentEnd


### PR DESCRIPTION
Closes #348.