### PR TITLE
Add support of bulk redefinition of token renderers and token renderer prototypes in the `\markdownSetup` command using enumeration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ Development:
   (contributed by @lostenderman, #237, #238, lostenderman/markdown#153,
    #315, #354)
 - Add support of bulk redefinition of token renderers and token renderer
-  prototypes in the `\markdownSetup` command using enumeration. (#232, #361)
+  prototypes in the `\markdownSetup` command using enumeration.
+  (#232, #361..#363)
 
 Fixes:
 
@@ -33,7 +34,8 @@ Unit Tests:
 - Restore CommonMark testfiles with trailing tabs and spaces.
   (contributed by @lostenderman, #348, #353,
    lostenderman/markdown#2)
-- Fail faster during batch bisection. (#354)
+- Fail faster during batch bisection. (5177ef6)
+- Speed up tests by running ConTeXt MkIV only once. (61f36e6d)
 - Use `BEGIN document` and `END document` instead of `documentBegin`
   and `documentEnd` for consistence with other renderers. (0be6be4)
 
@@ -41,7 +43,7 @@ Continuous Integration:
 
 - Do not rebuild existing Docker images when we rerun the
   continuous integration for the same commit multiple times.
-  (#354)
+  (ae390ec, 70c5f2e5)
 
 Default Renderer Prototypes:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -19217,7 +19217,35 @@ following text:
 % ```````
 %
 % In addition to exact token renderer names, we also support wildcards
-% that match multiple token renderer names.
+% and enumerations that match multiple token renderer names:
+% ``` tex
+% \markdownSetup{
+%   renderers = {
+%     heading* = {{\bf #1}},    \% Render headings using the bold face.
+%     jekyllData(String|Number) = {   \% Render YAML string and numbers
+%       {\it #2}\%                                     \% using italics.
+%     },
+%   }
+% }
+% ```````
+%
+% Wildcards and enumerations can be combined:
+% ``` tex
+% \markdownSetup{
+%   renderers = {
+%     *lItem(|End) = {"},           \% Quote ordered/bullet list items.
+%   }
+% }
+% ```````
+%
+% To determine the current token renderer, you can use the parameter `#0`:
+% ``` tex
+% \markdownSetup{
+%   renderers = {
+%     heading* = {#0: #1},      \% Render headings as the renderer name
+%   }                                  \% followed by the heading text.
+% }
+% ```````
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -19798,8 +19826,37 @@ following text:
 % }
 % ```````
 %
-% In addition to exact token renderer prototype names, we also support
-% wildcards that match multiple token renderer prototype names.
+% In addition to exact token renderer names, we also support wildcards
+% and enumerations that match multiple token renderer prototype names:
+% ``` tex
+% \markdownSetup{
+%   rendererPrototypes = {
+%     heading* = {{\bf #1}},    \% Render headings using the bold face.
+%     jekyllData(String|Number) = {   \% Render YAML string and numbers
+%       {\it #2}\%                                     \% using italics.
+%     },
+%   }
+% }
+% ```````
+%
+% Wildcards and enumerations can be combined:
+% ``` tex
+% \markdownSetup{
+%   rendererPrototypes = {
+%     *lItem(|End) = {"},           \% Quote ordered/bullet list items.
+%   }
+% }
+% ```````
+%
+% To determine the current token renderer prototype, you can use the
+% parameter `#0`:
+% ``` tex
+% \markdownSetup{
+%   rendererPrototypes = {
+%     heading* = {#0: #1}, \% Render headings as the renderer prototype
+%   }                             \% name followed by the heading text.
+% }
+% ```````
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -797,7 +797,7 @@ abbr {
 \RequirePackage{etoolbox}
 \markdownSetup{
   renderers = {
-    headingFour = {%
+    head*Four = {%
       \paragraph{#1}\leavevmode
       \def\markdownRendererInterblockSeparator{%
         \let\markdownRendererInterblockSeparator\par
@@ -807,7 +807,7 @@ abbr {
   },
   rendererPrototypes = {
     codeSpan = {\inline{#1}},
-    jekyllDataEnd = {%
+    jekyllData(End) = {%
       \AfterEndPreamble{%
         \printtitlepage
         \tableofcontents

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -19259,8 +19259,8 @@ following text:
   {
     \tl_set:Nn
       \l_@@_current_glob_tl
-      { #1 }
-    \prop_get:NoNTF
+      { ^ #1 $ }
+    \prop_get:NeNTF
       \g_@@_glob_cache_prop
       { #2 / \l_@@_current_glob_tl }
       \l_tmpa_clist
@@ -19304,7 +19304,7 @@ following text:
         \clist_set_from_seq:NN
           \l_tmpa_clist
           #3
-        \prop_gput:NoV
+        \prop_gput:NeV
           \g_@@_glob_cache_prop
           { #2 / \l_@@_current_glob_tl }
           \l_tmpa_clist
@@ -19319,7 +19319,7 @@ following text:
   { NV }
 \cs_generate_variant:Nn
   \prop_gput:Nnn
-  { NoV }
+  { NeV }
 \seq_new:N
   \l_@@_renderer_glob_results_seq
 \keys_define:nn
@@ -19355,7 +19355,7 @@ following text:
               \int_set:Nn
                 \l_tmpa_int
                 \l_tmpb_tl
-              \tl_set:Nn
+              \tl_set:NV
                 \l_tmpb_tl
                 \l_@@_renderer_definition_tl
               \regex_replace_all:nnN
@@ -19867,7 +19867,7 @@ following text:
   { markdown/options/renderer-prototypes }
   {
     unknown .code:n = {
-      \@@_glob_seq:VNN
+      \@@_glob_seq:VnN
         \l_keys_key_str
         { g_@@_renderers_seq }
         \l_@@_renderer_prototype_glob_results_seq
@@ -19896,7 +19896,7 @@ following text:
               \int_set:Nn
                 \l_tmpa_int
                 \l_tmpb_tl
-              \tl_set:Nn
+              \tl_set:NV
                 \l_tmpb_tl
                 \l_@@_renderer_prototype_definition_tl
               \regex_replace_all:nnN

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -19161,27 +19161,23 @@ following text:
   \l_@@_renderer_definition_tl
 \cs_new:Nn \@@_define_renderer:nNn
   {
-    \@@_with_various_cases:nn
-      { #1 }
+    \keys_define:nn
+      { markdown/options/renderers }
       {
-        \keys_define:nn
-          { markdown/options/renderers }
-          {
-            ##1 .code:n = {
-              \tl_set:Nn
-                \l_@@_renderer_definition_tl
-                { ####1 }
-              \regex_replace_all:nnN
-                { \cP\#0 }
-                { #1 }
-                \l_@@_renderer_definition_tl
-              \cs_generate_from_arg_count:NNnV
-                #2
-                \cs_set:Npn
-                { #3 }
-                \l_@@_renderer_definition_tl
-            },
-          }
+        #1 .code:n = {
+          \tl_set:Nn
+            \l_@@_renderer_definition_tl
+            { ##1 }
+          \regex_replace_all:nnN
+            { \cP\#0 }
+            { #1 }
+            \l_@@_renderer_definition_tl
+          \cs_generate_from_arg_count:NNnV
+            #2
+            \cs_set:Npn
+            { #3 }
+            \l_@@_renderer_definition_tl
+        },
       }
   }
 \cs_generate_variant:Nn
@@ -19272,33 +19268,23 @@ following text:
       {
         \seq_clear:N
           #3
-        \regex_match:nVT
+        \regex_replace_all:nnN
           { \* }
+          { .* }
           \l_@@_current_glob_tl
-          {
-            \regex_replace_all:nnN
-              { \* }
-              { .* }
-              \l_@@_current_glob_tl
-          }
         \regex_set:NV
           \l_tmpa_regex
           \l_@@_current_glob_tl
         \seq_map_inline:cn
           { #2 }
           {
-            \@@_with_various_cases:nn
+            \regex_match:NnT
+              \l_tmpa_regex
               { ##1 }
               {
-                \regex_match:NnT
-                  \l_tmpa_regex
-                  { ####1 }
-                  {
-                    \seq_put_right:Nn
-                      #3
-                      { ##1 }
-                    \@@_with_various_cases_break:
-                  }
+                \seq_put_right:Nn
+                  #3
+                  { ##1 }
               }
           }
         \clist_set_from_seq:NN
@@ -19311,9 +19297,6 @@ following text:
       }
   }
 \prg_generate_conditional_variant:Nnn
-  \regex_match:nn
-  { nV }
-  { T }
 \cs_generate_variant:Nn
   \regex_set:Nn
   { NV }
@@ -19766,27 +19749,23 @@ following text:
   \l_@@_renderer_prototype_definition_tl
 \cs_new:Nn \@@_define_renderer_prototype:nNn
   {
-    \@@_with_various_cases:nn
-      { #1 }
+    \keys_define:nn
+      { markdown/options/renderer-prototypes }
       {
-        \keys_define:nn
-          { markdown/options/renderer-prototypes }
-          {
-            ##1 .code:n = {
-              \tl_set:Nn
-                \l_@@_renderer_prototype_definition_tl
-                { ####1 }
-              \regex_replace_all:nnN
-                { \cP\#0 }
-                { #1 }
-                \l_@@_renderer_prototype_definition_tl
-              \cs_generate_from_arg_count:NNnV
-                #2
-                \cs_set:Npn
-                { #3 }
-                \l_@@_renderer_prototype_definition_tl
-            },
-          }
+        #1 .code:n = {
+          \tl_set:Nn
+            \l_@@_renderer_prototype_definition_tl
+            { ##1 }
+          \regex_replace_all:nnN
+            { \cP\#0 }
+            { #1 }
+            \l_@@_renderer_prototype_definition_tl
+          \cs_generate_from_arg_count:NNnV
+            #2
+            \cs_set:Npn
+            { #3 }
+            \l_@@_renderer_prototype_definition_tl
+        },
       }
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -19157,6 +19157,8 @@ following text:
         \tl_tail:n { #1 }
       }
   }
+\tl_new:N
+  \l_@@_renderer_definition_tl
 \cs_new:Nn \@@_define_renderer:nNn
   {
     \@@_with_various_cases:nn
@@ -19166,11 +19168,18 @@ following text:
           { markdown/options/renderers }
           {
             ##1 .code:n = {
-              \cs_generate_from_arg_count:NNnn
+              \tl_set:Nn
+                \l_@@_renderer_definition_tl
+                { ####1 }
+              \regex_replace_all:nnN
+                { \cP\#0 }
+                { #1 }
+                \l_@@_renderer_definition_tl
+              \cs_generate_from_arg_count:NNnV
                 #2
                 \cs_set:Npn
                 { #3 }
-                { ####1 }
+                \l_@@_renderer_definition_tl
             },
           }
       }
@@ -19178,6 +19187,9 @@ following text:
 \cs_generate_variant:Nn
   \@@_define_renderer:nNn
   { ncV }
+\cs_generate_variant:Nn
+  \cs_generate_from_arg_count:NNnn
+  { NNnV }
 \keys_define:nn
   { markdown/options }
   {
@@ -19282,8 +19294,6 @@ following text:
   { NoV }
 \seq_new:N
   \l_@@_renderer_glob_results_seq
-\tl_new:N
-  \l_@@_renderer_definition_tl
 \keys_define:nn
   { markdown/options/renderers }
   {
@@ -19314,11 +19324,21 @@ following text:
                 \g_@@_renderer_arities_prop
                 { ##1 }
                 \l_tmpb_tl
+              \int_set:Nn
+                \l_tmpa_int
+                \l_tmpb_tl
+              \tl_set:Nn
+                \l_tmpb_tl
+                \l_@@_renderer_definition_tl
+              \regex_replace_all:nnN
+                { \cP\#0 }
+                { ##1 }
+                \l_tmpb_tl
               \cs_generate_from_arg_count:cNVV
                 { \l_tmpa_tl }
                 \cs_set:Npn
+                \l_tmpa_int
                 \l_tmpb_tl
-                \l_@@_renderer_definition_tl
             }
         }
     },
@@ -19714,6 +19734,8 @@ following text:
         Prototype
       }
   }
+\tl_new:N
+  \l_@@_renderer_prototype_definition_tl
 \cs_new:Nn \@@_define_renderer_prototype:nNn
   {
     \@@_with_various_cases:nn
@@ -19723,11 +19745,18 @@ following text:
           { markdown/options/renderer-prototypes }
           {
             ##1 .code:n = {
-              \cs_generate_from_arg_count:NNnn
+              \tl_set:Nn
+                \l_@@_renderer_prototype_definition_tl
+                { ####1 }
+              \regex_replace_all:nnN
+                { \cP\#0 }
+                { #1 }
+                \l_@@_renderer_prototype_definition_tl
+              \cs_generate_from_arg_count:NNnV
                 #2
                 \cs_set:Npn
                 { #3 }
-                { ####1 }
+                \l_@@_renderer_prototype_definition_tl
             },
           }
       }
@@ -19777,8 +19806,6 @@ following text:
 \ExplSyntaxOn
 \seq_new:N
   \l_@@_renderer_prototype_glob_results_seq
-\tl_new:N
-  \l_@@_renderer_prototype_definition_tl
 \keys_define:nn
   { markdown/options/renderer-prototypes }
   {
@@ -19809,11 +19836,21 @@ following text:
                 \g_@@_renderer_arities_prop
                 { ##1 }
                 \l_tmpb_tl
+              \int_set:Nn
+                \l_tmpa_int
+                \l_tmpb_tl
+              \tl_set:Nn
+                \l_tmpb_tl
+                \l_@@_renderer_prototype_definition_tl
+              \regex_replace_all:nnN
+                { \cP\#0 }
+                { ##1 }
+                \l_tmpb_tl
               \cs_generate_from_arg_count:cNVV
                 { \l_tmpa_tl }
                 \cs_set:Npn
+                \l_tmpa_int
                 \l_tmpb_tl
-                \l_@@_renderer_prototype_definition_tl
             }
         }
     },

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -19296,7 +19296,11 @@ following text:
           \l_tmpa_clist
       }
   }
+% TODO: Remove in TeX Live 2023.
 \prg_generate_conditional_variant:Nnn
+  \prop_get:NnN
+  { NeN }
+  { TF }
 \cs_generate_variant:Nn
   \regex_set:Nn
   { NV }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -19215,14 +19215,14 @@ following text:
 \tl_new:N
   \l_@@_current_glob_tl
 \cs_new:Nn
-  \@@_glob_seq:nNN
+  \@@_glob_seq:nnN
   {
     \tl_set:Nn
       \l_@@_current_glob_tl
       { #1 }
-    \prop_get:NVNTF
+    \prop_get:NoNTF
       \g_@@_glob_cache_prop
-      \l_@@_current_glob_tl
+      { #2 / \l_@@_current_glob_tl }
       \l_tmpa_clist
       {
         \seq_set_from_clist:NN
@@ -19244,8 +19244,8 @@ following text:
         \regex_set:NV
           \l_tmpa_regex
           \l_@@_current_glob_tl
-        \seq_map_inline:Nn
-          #2
+        \seq_map_inline:cn
+          { #2 }
           {
             \@@_with_various_cases:nn
               { ##1 }
@@ -19264,9 +19264,9 @@ following text:
         \clist_set_from_seq:NN
           \l_tmpa_clist
           #3
-        \prop_gput:NVV
+        \prop_gput:NoV
           \g_@@_glob_cache_prop
-          \l_@@_current_glob_tl
+          { #2 / \l_@@_current_glob_tl }
           \l_tmpa_clist
       }
   }
@@ -19277,6 +19277,9 @@ following text:
 \cs_generate_variant:Nn
   \regex_set:Nn
   { NV }
+\cs_generate_variant:Nn
+  \prop_gput:Nnn
+  { NoV }
 \seq_new:N
   \l_@@_renderer_glob_results_seq
 \tl_new:N
@@ -19285,9 +19288,9 @@ following text:
   { markdown/options/renderers }
   {
     unknown .code:n = {
-      \@@_glob_seq:VNN
+      \@@_glob_seq:VnN
         \l_keys_key_str
-        \g_@@_renderers_seq
+        { g_@@_renderers_seq }
         \l_@@_renderer_glob_results_seq
       \seq_if_empty:NTF
         \l_@@_renderer_glob_results_seq
@@ -19327,8 +19330,8 @@ following text:
     Renderer~#1~is~undefined.
   }
 \cs_generate_variant:Nn
-  \@@_glob_seq:nNN
-  { VNN }
+  \@@_glob_seq:nnN
+  { VnN }
 \cs_generate_variant:Nn
   \cs_generate_from_arg_count:NNnn
   { cNVV }
@@ -19782,7 +19785,7 @@ following text:
     unknown .code:n = {
       \@@_glob_seq:VNN
         \l_keys_key_str
-        \g_@@_renderers_seq
+        { g_@@_renderers_seq }
         \l_@@_renderer_prototype_glob_results_seq
       \seq_if_empty:NTF
         \l_@@_renderer_prototype_glob_results_seq

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -797,7 +797,7 @@ abbr {
 \RequirePackage{etoolbox}
 \markdownSetup{
   renderers = {
-    head*Four = {%
+    headingFour = {%
       \paragraph{#1}\leavevmode
       \def\markdownRendererInterblockSeparator{%
         \let\markdownRendererInterblockSeparator\par
@@ -807,7 +807,7 @@ abbr {
   },
   rendererPrototypes = {
     codeSpan = {\inline{#1}},
-    jekyllData(End) = {%
+    jekyllDataEnd = {%
       \AfterEndPreamble{%
         \printtitlepage
         \tableofcontents

--- a/tests/support/keyval-setup.tex
+++ b/tests/support/keyval-setup.tex
@@ -1,13 +1,13 @@
 renderers = {%
   attributeIdentifier = {%
-    \TYPE{attributeIdentifier:   #1}},
+    \TYPE{#0: #1}},
   attributeClassName = {%
-    \TYPE{attributeClassName:    #1}},
+    \TYPE{#0: #1}},
   attributeKeyValue = {%
-    \TYPE{BEGIN attributeKeyValue}%
-    \TYPE{- key:                 #1}%
-    \TYPE{- value:               #2}%
-    \TYPE{END attributeKeyValue}},
+    \TYPE{BEGIN #0}%
+    \TYPE{- key:   #1}%
+    \TYPE{- value: #2}%
+    \TYPE{END #0}},
   fencedCodeAttributeContextBegin = {%
     \TYPE{BEGIN fencedCodeAttributeContext}},
   fencedCodeAttributeContextEnd = {%
@@ -45,20 +45,14 @@ renderers = {%
     \TYPE{BEGIN document}},
   documentEnd = {%
     \TYPE{END document}},
-  interblockSeparator = {%
-    \TYPE{interblockSeparator}%
+  *Separator = {%
+    \TYPE{#0}%
     \GOBBLE},
-  paragraphSeparator = {%
-    \TYPE{paragraphSeparator}%
-    \GOBBLE},
-  softLineBreak = {%
-    \TYPE{softLineBreak}%
-    \GOBBLE},
-  hardLineBreak = {%
-    \TYPE{hardLineBreak}%
+  *LineBreak = {%
+    \TYPE{#0}%
     \GOBBLE},
   ellipsis = {%
-    \TYPE{ellipsis}%
+    \TYPE{#0}%
     \GOBBLE},
   sectionBegin = {%
     \TYPE{BEGIN section}},
@@ -69,250 +63,146 @@ renderers = {%
   headerAttributeContextEnd = {%
     \TYPE{END headerAttributeContext}},
   nbsp = {%
-    \TYPE{nbsp}%
+    \TYPE{#0}%
     \GOBBLE},
   leftBrace = {%
-    \TYPE{leftBrace}%
+    \TYPE{#0}%
     \GOBBLE},
   rightBrace = {%
-    \TYPE{rightBrace}%
+    \TYPE{#0}%
     \GOBBLE},
   dollarSign = {%
-    \TYPE{dollarSign}%
+    \TYPE{#0}%
     \GOBBLE},
   percentSign = {%
-    \TYPE{percentSign}%
+    \TYPE{#0}%
     \GOBBLE},
   ampersand = {%
-    \TYPE{ampersand}%
+    \TYPE{#0}%
     \GOBBLE},
   underscore = {%
-    \TYPE{underscore}%
+    \TYPE{#0}%
     \GOBBLE},
   hash = {%
-    \TYPE{hash}%
+    \TYPE{#0}%
     \GOBBLE},
   circumflex = {%
-    \TYPE{circumflex}%
+    \TYPE{#0}%
     \GOBBLE},
   backslash = {%
-    \TYPE{backslash}%
+    \TYPE{#0}%
     \GOBBLE},
   tilde = {%
-    \TYPE{tilde}%
+    \TYPE{#0}%
     \GOBBLE},
   pipe = {%
-    \TYPE{pipe}%
+    \TYPE{#0}%
     \GOBBLE},
   codeSpan = {%
-    \TYPE{codeSpan:              #1}},
-  link = {%
-    \TYPE{BEGIN link}%
-    \TYPE{- label:               #1}%
-    \TYPE{- URI:                 #3}%
-    \TYPE{- title:               #4}%
-    \TYPE{END link}},
-  image = {%
-    \TYPE{BEGIN image}%
-    \TYPE{- label:               #1}%
-    \TYPE{- URI:                 #3}%
-    \TYPE{- title:               #4}%
-    \TYPE{END image}},
-  contentBlock = {%
-    \TYPE{BEGIN contentBlock}%
-    \TYPE{- suffix:              #1}%
-    \TYPE{- URI:                 #3}%
-    \TYPE{- title:               #4}%
-    \TYPE{END contentBlock}},
-  contentBlockOnlineImage = {%
-    \TYPE{BEGIN contentBlockOnlineImage}%
-    \TYPE{- suffix:              #1}%
-    \TYPE{- URI:                 #3}%
-    \TYPE{- title:               #4}%
-    \TYPE{END contentBlockOnlineImage}},
+    \TYPE{#0: #1}},
+  (link|image) = {%
+    \TYPE{BEGIN #0}%
+    \TYPE{- label:  #1}%
+    \TYPE{- URI:    #3}%
+    \TYPE{- title:  #4}%
+    \TYPE{END #0}},
+  contentBlock(|OnlineImage) = {%
+    \TYPE{BEGIN #0}%
+    \TYPE{- suffix: #1}%
+    \TYPE{- URI:    #3}%
+    \TYPE{- title:  #4}%
+    \TYPE{END #0}},
   contentBlockCode = {%
-    \TYPE{BEGIN contentBlockCode}%
-    \TYPE{- suffix:              #1}%
-    \TYPE{- language:            #2}%
-    \TYPE{- URI:                 #4}%
-    \TYPE{- title:               #5}%
-    \TYPE{END contentBlockCode}},
-  ulBegin = {%
-    \TYPE{ulBegin}},
-  ulBeginTight = {%
-    \TYPE{ulBeginTight}},
-  ulItem = {%
-    \TYPE{ulItem}},
-  ulItemEnd = {%
-    \TYPE{ulItemEnd}},
-  ulEnd = {%
-    \TYPE{ulEnd}},
-  ulEndTight = {%
-    \TYPE{ulEndTight}},
-  olBegin = {%
-    \TYPE{olBegin}},
-  olBeginTight = {%
-    \TYPE{olBeginTight}},
-  fancyOlBegin = {%
-    \TYPE{BEGIN fancyOlBegin}%
-    \TYPE{- numstyle:            #1}%
-    \TYPE{- numdelim:            #2}%
-    \TYPE{END fancyOlBegin}},
-  fancyOlBeginTight = {%
-    \TYPE{BEGIN fancyOlBeginTight}%
-    \TYPE{- numstyle:            #1}%
-    \TYPE{- numdelim:            #2}%
-    \TYPE{END fancyOlBeginTight}},
-  olItem = {%
-    \TYPE{olItem}},
-  olItemEnd = {%
-    \TYPE{olItemEnd}},
-  olItemWithNumber = {%
-    \TYPE{olItemWithNumber:      #1}},
-  fancyOlItem = {%
-    \TYPE{fancyOlItem}},
-  fancyOlItemEnd = {%
-    \TYPE{fancyOlItemEnd}},
-  fancyOlItemWithNumber = {%
-    \TYPE{fancyOlItemWithNumber: #1}},
-  olEnd = {%
-    \TYPE{olEnd}},
-  olEndTight = {%
-    \TYPE{olEndTight}},
-  fancyOlEnd = {%
-    \TYPE{fancyOlEnd}},
-  fancyOlEndTight = {%
-    \TYPE{fancyOlEndTight}},
-  dlBegin = {%
-    \TYPE{dlBegin}},
-  dlBeginTight = {%
-    \TYPE{dlBeginTight}},
+    \TYPE{BEGIN #0}%
+    \TYPE{- suffix:   #1}%
+    \TYPE{- language: #2}%
+    \TYPE{- URI:      #4}%
+    \TYPE{- title:    #5}%
+    \TYPE{END #0}},
+  (o|u|d)l(Begin|End)(|Tight) = {%
+    \TYPE{#0}},
+  ((o|fancyO)|u)lItem(|End) = {%
+    \TYPE{#0}},
+  (o|fancyO)lItemWithNumber = {%
+    \TYPE{#0: #1}},
+  fancyOlBegin(|Tight) = {%
+    \TYPE{BEGIN #0}%
+    \TYPE{- numstyle: #1}%
+    \TYPE{- numdelim: #2}%
+    \TYPE{END #0}},
+  fancyOlEnd(|Tight) = {%
+    \TYPE{#0}},
   dlItem = {%
-    \TYPE{dlItem:                #1}},
+    \TYPE{#0: #1}},
   dlItemEnd = {%
-    \TYPE{dlItemEnd}},
-  dlDefinitionBegin = {%
-    \TYPE{dlDefinitionBegin}},
-  dlDefinitionEnd = {%
-    \TYPE{dlDefinitionEnd}},
-  dlEnd = {%
-    \TYPE{dlEnd}},
-  dlEndTight = {%
-    \TYPE{dlEndTight}},
-  emphasis = {%
-    \TYPE{emphasis:              #1}},
-  strongEmphasis = {%
-    \TYPE{strongEmphasis:        #1}},
-  blockQuoteBegin = {%
-    \TYPE{blockQuoteBegin}},
-  blockQuoteEnd = {%
-    \TYPE{blockQuoteEnd}},
-  lineBlockBegin = {%
-    \TYPE{lineBlockBegin}},
-  lineBlockEnd = {%
-    \TYPE{lineBlockEnd}},
+    \TYPE{#0}},
+  dlDefinition(Begin|End) = {%
+    \TYPE{#0}},
+  (e|StrongE)mphasis = {%
+    \TYPE{#0: #1}},
+  blockQuote(Begin|End) = {%
+    \TYPE{#0}},
+  lineBlock(Begin|End) = {%
+    \TYPE{#0}},
   inputVerbatim = {%
-    \TYPE{inputVerbatim:         #1}},
+    \TYPE{#0: #1}},
   inputFencedCode = {%
     \TYPE{BEGIN fencedCode}%
-    \TYPE{- src:                 #1}%
-    \TYPE{- infostring:          #3}%
+    \TYPE{- src:        #1}%
+    \TYPE{- infostring: #3}%
     \TYPE{END fencedCode}},
-  headingOne = {%
-    \TYPE{headingOne:            #1}},
-  headingTwo = {%
-    \TYPE{headingTwo:            #1}},
-  headingThree = {%
-    \TYPE{headingThree:          #1}},
-  headingFour = {%
-    \TYPE{headingFour:           #1}},
-  headingFive = {%
-    \TYPE{headingFive:           #1}},
-  headingSix = {%
-    \TYPE{headingSix:            #1}},
+  heading* = {%
+    \TYPE{#0: #1}},
   thematicBreak = {%
-    \TYPE{thematicBreak}},
+    \TYPE{#0}},
   note = {%
-    \TYPE{note:              #1}},
-  cite = {%
-    \CITATIONS{#1}},
-  textCite = {%
-    \TEXTCITATIONS{#1}},
+    \TYPE{#0: #1}},
+  (c|textC)ite = {%
+    \CITATIONS{#0}{#1}},
   table = {%
     \TABLE{#1}{#2}{#3}},
-  inlineHtmlComment = {%
-    \TYPE{inlineHtmlComment:     #1}},
-  inlineHtmlTag = {%
-    \TYPE{inlineHtmlTag:         #1}},
+  inlineHtml(Comment|Tag) = {%
+    \TYPE{#0: #1}},
   inputBlockHtmlElement = {%
-    \TYPE{inputBlockHtmlElement: #1}},
-  tickedBox = {%
-    \TYPE{tickedBox}%
+    \TYPE{#0: #1}},
+  (ticked|halfTicked|unticked)Box = {%
+    \TYPE{#0}%
     \GOBBLE},
-  halfTickedBox = {%
-    \TYPE{halfTickedBox}%
-    \GOBBLE},
-  untickedBox = {%
-    \TYPE{untickedBox}%
-    \GOBBLE},
-  jekyllDataBoolean = {%
-    \TYPE{BEGIN jekyllDataBoolean}%
-    \TYPE{- key:                 #1}%
-    \TYPE{- value:               #2}%
-    \TYPE{END jekyllDataBoolean}},
+  jekyllData(Boolean|Number|String) = {%
+    \TYPE{BEGIN #0}%
+    \TYPE{- key:   #1}%
+    \TYPE{- value: #2}%
+    \TYPE{END #0}},
   jekyllDataEmpty = {%
-    \TYPE{jekyllDataEmpty:       #1}},%
-  jekyllDataNumber = {%
-    \TYPE{BEGIN jekyllDataNumber}%
-    \TYPE{- key:                 #1}%
-    \TYPE{- value:               #2}%
-    \TYPE{END jekyllDataNumber}},
-  jekyllDataString = {%
-    \TYPE{BEGIN jekyllDataString}%
-    \TYPE{- key:                 #1}%
-    \TYPE{- value:               #2}%
-    \TYPE{END jekyllDataString}},
-  jekyllDataBegin = {%
-    \TYPE{jekyllDataBegin}},
-  jekyllDataEnd = {%
-    \TYPE{jekyllDataEnd}},
-  jekyllDataSequenceBegin = {%
-    \TYPE{BEGIN jekyllDataSequenceBegin}%
-    \TYPE{- key:                 #1}%
-    \TYPE{- length:              #2}%
-    \TYPE{END jekyllDataSequenceBegin}},
-  jekyllDataSequenceEnd = {%
-    \TYPE{jekyllDataSequenceEnd}},
-  jekyllDataMappingBegin = {%
-    \TYPE{BEGIN jekyllDataMappingBegin}%
-    \TYPE{- key:                 #1}%
-    \TYPE{- length:              #2}%
-    \TYPE{END jekyllDataMappingBegin}},
-  jekyllDataMappingEnd = {%
-    \TYPE{jekyllDataMappingEnd}},
+    \TYPE{#0: #1}},%
+  jekyllData(Begin|End) = {%
+    \TYPE{#0}},
+  jekyllData(Sequence|Mapping)Begin = {%
+    \TYPE{BEGIN #0}%
+    \TYPE{- key:    #1}%
+    \TYPE{- length: #2}%
+    \TYPE{END #0}},
+  jekyllData(Sequence|Mapping)End = {%
+    \TYPE{#0}},
   mark = {%
-    \TYPE{mark:                  #1}},
+    \TYPE{#0: #1}},
   strikeThrough = {%
-    \TYPE{strikeThrough:         #1}},
-  superscript = {%
-    \TYPE{superscript:           #1}},
-  subscript = {%
-    \TYPE{subscript:             #1}},
-  displayMath = {%
-    \TYPE{displayMath:           #1}},
-  inlineMath = {%
-    \TYPE{inlineMath:            #1}},
+    \TYPE{#0: #1}},
+  (super|sub)script = {%
+    \TYPE{#0: #1}},
+  (display|inline)Math = {%
+    \TYPE{#0: #1}},
   inputRawInline = {%
     \TYPE{BEGIN rawInline}%
-    \TYPE{- src:                 #1}%
-    \TYPE{- raw attribute:       #2}%
+    \TYPE{- src:           #1}%
+    \TYPE{- raw attribute: #2}%
     \TYPE{END rawInline}},
   inputRawBlock = {%
     \TYPE{BEGIN rawBlock}%
-    \TYPE{- src:                 #1}%
-    \TYPE{- raw attribute:       #2}%
+    \TYPE{- src:           #1}%
+    \TYPE{- raw attribute: #2}%
     \TYPE{END rawBlock}},
   replacementCharacter = {%
-    \TYPE{replacementCharacter}%
+    \TYPE{#0}%
     \GOBBLE},
 }%

--- a/tests/support/keyval-setup.tex
+++ b/tests/support/keyval-setup.tex
@@ -138,7 +138,7 @@ renderers = {%
     \TYPE{#0}},
   dlDefinition(Begin|End) = {%
     \TYPE{#0}},
-  (e|StrongE)mphasis = {%
+  (e|strongE)mphasis = {%
     \TYPE{#0: #1}},
   blockQuote(Begin|End) = {%
     \TYPE{#0}},

--- a/tests/support/setup.tex
+++ b/tests/support/setup.tex
@@ -40,44 +40,24 @@
 % Citations parsing
 \newcount\CITATIONSCOUNTER
 
-%% Regular citations
-\def\DOCITATIONS#1#2#3#4{%
+%% Citations
+\def\DOCITATIONS#1#2#3#4#5{%
   \advance\CITATIONSCOUNTER by 1\relax
-  \CITE{#1}{#2}{#3}{#4}%
+  \CITE{#1}{#2}{#3}{#4}{#5}%
   \ifnum\CITATIONSCOUNTER>\CITATIONSTOTAL\relax
-    \TYPE{END cites}%
+    \TYPE{END #1s}%
+    \expandafter\expandafter\expandafter\GOBBLE
     \expandafter\GOBBLE
-  \fi\DOCITATIONS}%
-\def\CITE#1#2#3#4{%
-  \TYPE{BEGIN cite}%
-  \TYPE{- suppressAuthor: \if#1+false\else true\fi}%
-  \TYPE{- prenote:        #2}%
-  \TYPE{- postnote:       #3}%
-  \TYPE{- name:           #4}%
-  \TYPE{END cite}}%
-\def\CITATIONS#1{%
-  \TYPE{BEGIN cites}%
+  \fi\DOCITATIONS{#1}}%
+\def\CITE#1#2#3#4#5{%
+  \TYPE{BEGIN #1}%
+  \TYPE{- suppressAuthor: \if#2+false\else true\fi}%
+  \TYPE{- prenote:        #3}%
+  \TYPE{- postnote:       #4}%
+  \TYPE{- name:           #5}%
+  \TYPE{END #1}}%
+\def\CITATIONS#1#2{%
+  \TYPE{BEGIN #1s}%
   \CITATIONSCOUNTER=1%
-  \def\CITATIONSTOTAL{#1}%
-  \DOCITATIONS}%
-
-%% Text citations
-\def\DOTEXTCITATIONS#1#2#3#4{%
-  \advance\CITATIONSCOUNTER by 1\relax
-  \TEXTCITE{#1}{#2}{#3}{#4}%
-  \ifnum\CITATIONSCOUNTER>\CITATIONSTOTAL\relax
-    \TYPE{END textCites}%
-    \expandafter\GOBBLE
-  \fi\DOTEXTCITATIONS}%
-\def\TEXTCITE#1#2#3#4{%
-  \TYPE{BEGIN textCite}%
-  \TYPE{- suppressAuthor: \if#1+false\else true\fi}%
-  \TYPE{- prenote:        #2}%
-  \TYPE{- postnote:       #3}%
-  \TYPE{- name:           #4}%
-  \TYPE{END textCite}}%
-\def\TEXTCITATIONS#1{%
-  \TYPE{BEGIN textCites}%
-  \CITATIONSCOUNTER=1%
-  \def\CITATIONSTOTAL{#1}%
-  \DOTEXTCITATIONS}%
+  \def\CITATIONSTOTAL{#2}%
+  \DOCITATIONS{#1}}%

--- a/tests/templates/context-mkiv/COMMANDS.m4
+++ b/tests/templates/context-mkiv/COMMANDS.m4
@@ -1,1 +1,1 @@
-context                                     --luatex --nonstopmode  TEST_FILENAME
+context                              --once --luatex --nonstopmode  TEST_FILENAME


### PR DESCRIPTION
Closes #362.