### PR TITLE
Add support for universal (cross-format) themes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ Documentation:
   (#381, #382, contributed by @solernou)
 - Encourage alternatives to the `hybrid` option in the user manual. (#382)
 
+Speed Improvements:
+
+- Optimize needless catcode switching in package code. (3eb7231)
+
 Default Renderer Prototypes:
 
 - Fix the typesetting of level four headings with attributes for LaTeX document

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 3.3.0
 
+Development:
+
+- Add support for universal (cross-format) themes. (#276, #373)
+
 Fixes:
 
 - Prevent unwanted space tokens before `*ContextEnd` renderers. (#373)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 3.3.0
 
+Fixes:
+
+- Prevent unwanted space tokens before `*ContextEnd` renderers. (#373)
+
 Documentation:
 
 - Improve the discoverability of the `\markdownInput` macro.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,13 @@ Documentation:
   (#381, #382, contributed by @solernou)
 - Encourage alternatives to the `hybrid` option in the user manual. (#382)
 
+Default Renderer Prototypes:
+
+- Fix the typesetting of level four headings with attributes for LaTeX document
+  classes without the `\chapter` command such as `article` and level five
+  headings for LaTeX document classes with the `\chapter` command such as
+  `book`. (86eefc0)
+
 ## 3.2.1 (2023-11-23)
 
 Fixes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,11 +80,11 @@ mkdir -p                                               ${INSTALL_DIR}/scripts/ma
 cp ${BUILD_DIR}/markdown-cli.lua                       ${INSTALL_DIR}/scripts/markdown/
 mkdir -p                                               ${INSTALL_DIR}/tex/generic/markdown/
 cp ${BUILD_DIR}/markdown.tex                           ${INSTALL_DIR}/tex/generic/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_tilde.tex          ${INSTALL_DIR}/tex/generic/markdown/
 mkdir -p                                               ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdown.sty                           ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_dot.sty            ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_graphicx_http.sty  ${INSTALL_DIR}/tex/latex/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_tilde.sty          ${INSTALL_DIR}/tex/latex/markdown/
 mkdir -p                                               ${INSTALL_DIR}/tex/context/third/markdown/
 cp ${BUILD_DIR}/t-markdown.tex                         ${INSTALL_DIR}/tex/context/third/markdown/
 

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	    -e 's#(((VERSION)))#$(VERSION)#g' \
 	    -e 's#(((LASTMODIFIED)))#$(LASTMODIFIED)#g' \
 	    $(INSTALLABLES)
+	sed -i \
+	    -e '/\\ExplSyntaxOff/{N;/\\ExplSyntaxOn/d;}' \
+	    $(INSTALLABLES)
 
 # This target produces the version file.
 $(VERSION_FILE): force

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ DOCUMENTATION=$(TECHNICAL_DOCUMENTATION) $(HTML_USER_MANUAL) $(ROOT_README) $(VE
 LIBRARIES=libraries/markdown-tinyyaml.lua
 INSTALLABLES=markdown.lua markdown-cli.lua markdown.tex markdown.sty t-markdown.tex \
   markdownthemewitiko_dot.sty markdownthemewitiko_graphicx_http.sty \
-  markdownthemewitiko_tilde.sty
+  markdownthemewitiko_tilde.tex
 EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES)
 MAKEABLES=$(TECHNICAL_DOCUMENTATION) $(USER_MANUAL) $(INSTALLABLES) $(EXAMPLES)
 RESOURCES=$(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(EXAMPLES) \
@@ -142,6 +142,8 @@ $(TECHNICAL_DOCUMENTATION): $(DTXARCHIVE) $(TECHNICAL_DOCUMENTATION_RESOURCES)
 
 # This pseudotarget continuously typesets the manual.
 preview: $(DTXARCHIVE) $(TECHNICAL_DOCUMENTATION_RESOURCES)
+	-mkdir markdown/
+	-ln -s ../markdown.tex markdown/markdown.tex
 	latexmk -silent -pvc $<
 
 # These targets typeset the examples.
@@ -209,9 +211,9 @@ $(TDSARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(INSTALLABLES) $(DOCUMENTATION) $(EXA
 	  tex/context/third/markdown scripts/markdown
 	cp markdown.lua $(LIBRARIES) tex/luatex/markdown/
 	cp markdown-cli.lua scripts/markdown/
-	cp markdown.sty markdownthemewitiko_dot.sty markdownthemewitiko_graphicx_http.sty \
-	  markdownthemewitiko_tilde.sty tex/latex/markdown/
-	cp markdown.tex tex/generic/markdown/
+	cp markdown.sty markdownthemewitiko_graphicx_http.sty markdownthemewitiko_dot.sty \
+	  tex/latex/markdown/
+	cp markdown.tex markdownthemewitiko_tilde.tex tex/generic/markdown/
 	cp t-markdown.tex tex/context/third/markdown/
 	@# Installing the documentation.
 	mkdir -p doc/generic/markdown doc/latex/markdown/examples \

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ $(LIBRARIES): force
 # This target typesets the manual.
 $(TECHNICAL_DOCUMENTATION): $(DTXARCHIVE) $(TECHNICAL_DOCUMENTATION_RESOURCES)
 	latexmk -silent $< || (cat $(basename $@).log 1>&2; exit 1)
-	test `tail $(basename $<).log | sed -rn 's/.*\(([0-9]*) pages.*/\1/p'` -gt 350
+	test `tail $(basename $<).log | sed -rn 's/.*\(([0-9]*) pages.*/\1/p'` -ge 380
 
 # This pseudotarget continuously typesets the manual.
 preview: $(DTXARCHIVE) $(TECHNICAL_DOCUMENTATION_RESOURCES)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11913,7 +11913,7 @@ A PDF document named `document.pdf` should be produced and contain the text
 % \fi
 % \begin{markdown}
 
-#### Themes {#themes}
+### Themes {#themes}
 
 User-defined themes for the Markdown package provide a domain-specific
 interpretation of Markdown tokens. Themes allow the authors to achieve
@@ -12125,7 +12125,7 @@ following text, where the middot (`·`) denotes a non-breaking space:
 % Please, see Section <#sec:themes-implementation> for implementation
 % details of the example themes.
 
-#### Snippets {#snippets}
+### Snippets {#snippets}
 
 % \end{markdown}
 % \iffalse
@@ -20958,13 +20958,52 @@ package. Setting the option after loading the package will have no effect.
   { false }
 \ExplSyntaxOff
 %    \end{macrocode}
+% \begin{markdown}
+%
+%#### Generating Plain \TeX{} Option, Token Renderer, and Token Renderer Prototype Macros and Key-Values
+%
+% If \LaTeX{} is the top layer, we use the
+% \mref{@@_define_option_commands_and_keyvals:}, \mref{@@_define_renderers:},
+% and \mref{@@_define_renderer_prototypes:} macro to define plain \TeX{}
+% option, token renderer, and token renderer prototype macros and key-values
+% immediately. Otherwise, we postpone the definition until the upper layers
+% have been loaded.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\str_if_eq:VVT
+  \c_@@_top_layer_tl
+  \c_@@_option_layer_latex_tl
+  {
+    \@@_define_option_commands_and_keyvals:
+    \@@_define_renderers:
+    \@@_define_renderer_prototypes:
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The following example \LaTeX{} code showcases a possible configuration of
+% plain \TeX{} interface options \Opt{hybrid}, \Opt{smartEllipses}, and
+% \Opt{cacheDir}.
+% ``` tex
+% \markdownSetup{
+%   hybrid,
+%   smartEllipses,
+%   cacheDir = /tmp,
+% }
+% ```````
+%
+% \end{markdown}
 % \iffalse
 %</latex>
 %<*manual-options>
 % \fi
 % \begin{markdown}
 
-#### Themes {#latexthemes}
+### Themes {#latexthemes}
 
 % In Section~\ref{sec:themes}, we described the concept of themes.
 In \LaTeX{}, we expand on the concept of
@@ -21236,54 +21275,13 @@ following image:
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-graphicx-http>
-%<*latex>
+%<*context>
 % \fi
 % \par
 % \begin{markdown}
 %
 % Please, see Section <#sec:latex-themes-implementation> for implementation
 % details of the example themes.
-%
-%#### Generating Plain \TeX{} Option, Token Renderer, and Token Renderer Prototype Macros and Key-Values
-%
-% If \LaTeX{} is the top layer, we use the
-% \mref{@@_define_option_commands_and_keyvals:}, \mref{@@_define_renderers:},
-% and \mref{@@_define_renderer_prototypes:} macro to define plain \TeX{}
-% option, token renderer, and token renderer prototype macros and key-values
-% immediately. Otherwise, we postpone the definition until the upper layers
-% have been loaded.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\str_if_eq:VVT
-  \c_@@_top_layer_tl
-  \c_@@_option_layer_latex_tl
-  {
-    \@@_define_option_commands_and_keyvals:
-    \@@_define_renderers:
-    \@@_define_renderer_prototypes:
-  }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% The following example \LaTeX{} code showcases a possible configuration of
-% plain \TeX{} interface options \Opt{hybrid}, \Opt{smartEllipses}, and
-% \Opt{cacheDir}.
-% ``` tex
-% \markdownSetup{
-%   hybrid,
-%   smartEllipses,
-%   cacheDir = /tmp,
-% }
-% ```````
-%
-% \iffalse
-%</latex>
-%<*context>
-% \fi
 %
 % \Hologo{ConTeXt} Interface {#contextinterface}
 %----------------------------
@@ -31968,7 +31966,7 @@ end
 % \par
 % \begin{markdown}
 %
-%### Plain TeX Themes {#themes-implementation}
+%### Themes {#themes-implementation}
 %
 % This section implements the theme-loading mechanism and the example themes
 % provided with the Markdown package.
@@ -33141,7 +33139,18 @@ end
 % \par
 % \begin{markdown}
 %
-%#### \LaTeX{} Themes {#latex-themes-implementation}
+%### Options
+% The supplied package options are processed using the \mref{markdownSetup} macro.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\DeclareOption*{%
+  \expandafter\markdownSetup\expandafter{\CurrentOption}}%
+\ProcessOptions\relax
+%    \end{macrocode}
+% \begin{markdown}
+%
+%### Themes {#latex-themes-implementation}
 %
 % This section overrides the plain \TeX{} implementation of the theme-loading
 % mechanism from Section <#sec:themes-implementation>. Futhermore, this section
@@ -33452,17 +33461,6 @@ end
 %<*latex>
 % \fi
 % \par
-% \begin{markdown}
-%
-%### Options
-% The supplied package options are processed using the \mref{markdownSetup} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\DeclareOption*{%
-  \expandafter\markdownSetup\expandafter{\CurrentOption}}%
-\ProcessOptions\relax
-%    \end{macrocode}
 % \begin{markdown}
 %
 %### Token Renderer Prototypes {#latex-default-renderer-prototypes}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -769,12 +769,6 @@ abbr {
   volume    = {B},
   location  = {Reading, MA},
   publisher = {Addison-Wesley}}
-@online{novotny21,
-  author    = {Novotný, Vít},
-  title     = {\Hologo{LaTeX2e} no longer keys packages by pathnames},
-  date      = {2021-02-20},
-  url       = {https://github.com/latex3/latex2e/issues/510},
-  urldate   = {2021-02-21}}
 @book{eijkhout92,
   author    = {Victor Eijkhout},
   title     = {\TeX{} by Topic},
@@ -11843,6 +11837,41 @@ A PDF document named `document.pdf` should be produced and contain the text
 %    \end{macrocode}
 % \iffalse
 %</tex>
+%<*manual-options>
+% \fi
+% \begin{markdown}
+
+#### Themes {#themes}
+
+User-defined themes for the Markdown package provide a domain-specific
+interpretation of Markdown tokens. Themes allow the authors to achieve
+a specific look and other high-level goals without low-level programming.
+
+% The key-values `theme`=\meta{theme name} and `import`=\meta{theme name} load
+% a \TeX{} document (further referred to as *a theme*) named
+% `markdowntheme`\meta{munged theme name}`.tex`, where the *munged theme name*
+% is the *theme name* after the substitution of all forward slashes (`/`) for
+% an underscore (`_`). The theme name is *qualified* and contains no
+% underscores. A theme name is qualified if and only if it contains at least
+% one forward slash. Themes are inspired by the Beamer \LaTeX{} package, which
+% provides similar functionality with its `\usetheme` macro [@tantau21, Section
+% 15.1].
+%
+% Theme names must be qualified to minimize naming conflicts between different
+% themes with a similar purpose. The preferred format of a theme name is
+% \meta{theme author}`/`\meta{theme purpose}`/`\meta{private naming
+% scheme}, where the *private naming scheme* may contain additional forward
+% slashes. For example, a theme by a user `witiko` for the MU theme of the
+% Beamer document class may have the name `witiko/beamer/MU`.
+%
+% Theme names are munged to allow structure inside theme names without
+% dictating where the themes should be located inside the \TeX{} directory
+% structure. For example, loading a theme named `witiko/beamer/MU` would
+% load a \TeX{} document package named `markdownthemewitiko_beamer_MU.tex`.
+%
+% \end{markdown}
+% \iffalse
+%</manual-options>
 %<*manual-tokens>
 
 ## Markdown Tokens
@@ -20327,46 +20356,38 @@ package. Setting the option after loading the package will have no effect.
 % \fi
 % \begin{markdown}
 
-#### \LaTeX{} themes {#latexthemes}
+#### Themes {#latexthemes}
 
-User-defined \LaTeX{} themes for the Markdown package provide a domain-specific
-interpretation of Markdown tokens. Similarly to \LaTeX{} packages, themes
-allow the authors to achieve a specific look and other high-level goals
-without low-level programming.
+% In Section~\ref{sec:themes}, we described the concept of themes.
+In \LaTeX{}, we expand on the concept of
+% themes
+% \iffalse
+[themes](#themes)
+% \fi
+by allowing a theme to be a full-blown \LaTeX{} package. Specifically, the
+key-values `theme`=\meta{theme name} and `import`=\meta{theme name} load a
+\LaTeX{} package named `markdowntheme`\meta{munged theme name}`.sty` if it
+exists and a \TeX{} document named `markdowntheme`\meta{munged theme
+name}`.tex` otherwise.
 
-% The \LaTeX{} option `import`=\meta{theme name} loads a \LaTeX{} package
-% (further referred to as *a theme*) named `markdowntheme`\meta{munged theme
-% name}`.sty`, where the *munged theme name* is the *theme name* after the
-% substitution of all forward slashes (`/`) for an underscore (`_`), the theme
-% *name* is *qualified* and contains no underscores, and a value is qualified
-% if and only if it contains at least one forward slash. Themes are inspired
-% by the Beamer \LaTeX{} package, which provides similar functionality with
-% its `\usetheme` macro [@tantau21, Section 15.1].
-%
-% Theme names must be qualified to minimize naming conflicts between different
-% themes intended for a single \LaTeX{} document class or for a single \LaTeX{}
-% package. The preferred format of a theme name is \meta{theme author}`/`<!--
-% -->\meta{target \LaTeX{} document class or package}`/`\meta{private naming
-% scheme}, where the *private naming scheme* may contain additional forward
-% slashes. For example, a theme by a user `witiko` for the MU theme of the
-% Beamer document class may have the name `witiko/beamer/MU`.
-%
-% Theme names are munged, because \LaTeX{} packages are identified only by
-% their filenames, not by their pathnames. [@novotny21] Therefore, we can't
-% store the qualified theme names directly using directories, but we must
-% encode the individual segments of the qualified theme in the filename. For
-% example, loading a theme named `witiko/beamer/MU` would load a \LaTeX{}
-% package named `markdownthemewitiko_beamer_MU.sty`.
-%
-% If the \LaTeX{} option with key `theme` is (repeatedly) specified in the
-% `\usepackage` macro, the loading of the theme(s) will be postponed in
-% first-in-first-out order until after the Markdown \LaTeX{} package has been
-% loaded. Otherwise, the theme(s) will be loaded immediately. For example,
-% there is a theme named `witiko/dot`, which typesets fenced code blocks with
-% the `dot` infostring as images of directed graphs rendered by the Graphviz
-% tools. The following code would first load the Markdown package, then the
-% `markdownthemewitiko_beamer_MU.sty` \LaTeX{} package, and finally the
-% `markdownthemewitiko_dot.sty` \LaTeX{} package:
+Having the Markdown package automatically load either the generic `.tex`
+*theme file* or the \LaTeX-specific `.sty` theme file allows developers
+to have a single *theme file*, when the theme is small or the difference
+between \TeX{} formats is unimportant, and scale up to separate theme files
+native to different \TeX{} formats for large multi-format themes, where
+different code is needed for different \TeX{} formats. To enable code reuse,
+developers can load the `.tex` theme file from the `.sty` theme file using the
+\mdef{markdownSuper} command.
+
+% If the \LaTeX{} option with keys `theme` or `import` is (repeatedly)
+% specified in the `\usepackage` macro, the loading of the theme(s) will be
+% postponed in first-in-first-out order until after the Markdown \LaTeX{}
+% package has been loaded. Otherwise, the theme(s) will be loaded immediately.
+% For example, there is a theme named `witiko/dot`, which typesets fenced code
+% blocks with the `dot` infostring as images of directed graphs rendered by the
+% Graphviz tools. The following code would first load the Markdown package,
+% then the `markdownthemewitiko_beamer_MU.sty` \LaTeX{} package, and finally
+% the `markdownthemewitiko_dot.sty` \LaTeX{} package:
 % \end{markdown}
 % \iffalse
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20682,23 +20682,6 @@ Due to limitations of \LaTeX{}, themes may not be loaded after the
 beginning of a \LaTeX{} document.
 
 % \end{markdown}
-% \iffalse
-%</manual-options>
-%<*latex>
-% \fi
-%  \begin{macrocode}
-\ExplSyntaxOn
-\iffalse  % TODO: Write logic for loading LaTeX themes after preamble.
-\@onlypreamble
-  \@@_set_latex_theme:n
-\fi
-\ExplSyntaxOff
-%    \end{macrocode}
-% \iffalse
-%</latex>
-%<*manual-options>
-% \fi
-% \par
 % \markdownBegin
 
 Example themes provided with the Markdown package include:
@@ -33122,24 +33105,77 @@ end
 \cs_gset:Nn
   \@@_load_theme:nn
   {
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% If the Markdown package has already been loaded, determine whether
+% a file named `markdowntheme`\meta{munged theme name}`.sty` exists
+% and whether we are still in the preamble.
+%
+% \end{markdown}
+%  \begin{macrocode}
     \ifmarkdownLaTeXLoaded
-      \file_if_exist:nTF
-        { markdown theme #2.sty }
-        {
-          \markdownInfo
-            { Loading~Markdown~theme~#1 }
-          \RequirePackage
-            { markdown theme #2 }
-        }
-        {
-          \@@_load_theme_plain_tex:nn
-            { #1 }
-            { #2 }
-        }
+      \ifx\@onlypreamble\@notprerr
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the Markdown package has already been loaded and we are already past the
+% preamble, try loading a plain \TeX{} theme instead. Log a warning if there
+% exists a \LaTeX{} theme that we would have loaded if we were still in the
+% preamble.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \file_if_exist:nT
+          { markdown theme #2.sty }
+          {
+            \markdownWarning
+              {
+                File~markdown theme #2.sty~exists,~but~we~are~past~
+                the~preamble.~Therefore,~I~will~try~loading~file~
+                markdown theme #2.tex~instead.
+              }
+          }
+        \@@_load_theme_plain_tex:nn
+          { #1 }
+          { #2 }
+      \else
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the Markdown package has already been loaded but we are still in the
+% preamble, load a \LaTeX{} theme if it exists or load a plain \TeX{} theme
+% otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \file_if_exist:nTF
+          { markdown theme #2.sty }
+          {
+            \markdownInfo
+              { Loading~Markdown~theme~#1 }
+            \RequirePackage
+              { markdown theme #2 }
+          }
+          {
+            \@@_load_theme_plain_tex:nn
+              { #1 }
+              { #2 }
+          }
+      \fi
     \else
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the Markdown package has not yet been loaded, postpone the loading until
+% the Markdown package has finished loading.
+%
+% \end{markdown}
+%  \begin{macrocode}
       \markdownInfo
         {
-          Deferring~loading~Markdown~theme~#1~until~
+          Postponing~loading~Markdown~theme~#1~until~
           Markdown~package~has~finished~loading
         }
       \AtEndOfPackage

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11872,7 +11872,136 @@ a specific look and other high-level goals without low-level programming.
 % \end{markdown}
 % \iffalse
 %</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\ExplSyntaxOn
+\keys_define:nn
+  { markdown/options }
+  {
+    theme .code:n = {
+      \@@_set_theme:n
+        { #1 }
+    },
+    import .code:n = {
+      \tl_set:Nn
+        \l_tmpa_tl
+        { #1 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To ensure that keys containing forward slashes get passed correctly, we
+% replace all forward slashes in the input with backslash tokens with category
+% code letter and then undo the replacement. This means that if any unbraced
+% backslash tokens with category code letter exist in the input, they will be
+% replaced with forward slashes. However, this should be extremely rare.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      \tl_replace_all:NnV
+        \l_tmpa_tl
+        { / }
+        \c_backslash_str
+      \keys_set:nV
+        { markdown/options/import }
+        \l_tmpa_tl
+    },
+  }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To keep track of the current theme when themes are nested, we will
+% maintain the \mdef{g_\@\@_themes_seq} stack of theme names.
+% For convenience, the name of the current theme is also available in the
+% \mdef{markdownThemeName} macro.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\seq_new:N
+  \g_@@_themes_seq
+\tl_new:N
+  \markdownThemeName
+\tl_gset:Nn
+  \markdownThemeName
+  { }
+\seq_gput_right:NV
+  \g_@@_themes_seq
+  \markdownThemeName
+\cs_new:Nn
+  \@@_set_theme:n
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% First, we validate the theme name.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \str_if_in:nnF
+      { #1 }
+      { / }
+      {
+        \markdownError
+        { Won't~load~theme~with~unqualified~name~#1 }
+        { Theme~names~must~contain~at~least~one~forward~slash }
+      }
+    \str_if_in:nnT
+      { #1 }
+      { _ }
+      {
+        \markdownError
+        { Won't~load~theme~with~an~underscore~in~its~name~#1 }
+        { Theme~names~must~not~contain~underscores~in~their~names }
+      }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Next, we munge the theme name.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \tl_set:Nn
+      \l_tmpa_str
+      { #1 }
+    \str_replace_all:Nnn
+      \l_tmpa_str
+      { / }
+      { _ }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Finally, we load the theme.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \tl_gset:Nn
+      \markdownThemeName
+      { #1 / }
+    \seq_gput_right:NV
+      \g_@@_themes_seq
+      \markdownThemeName
+    \@@_load_theme:nV
+      { #1 }
+      \l_tmpa_str
+    \seq_gpop_right:NN
+      \g_@@_themes_seq
+      \l_tmpa_tl
+    \seq_get_right:NN
+      \g_@@_themes_seq
+      \l_tmpa_tl
+    \tl_gset:NV
+      \markdownThemeName
+      \l_tmpa_tl
+  }
+\cs_generate_variant:Nn
+  \tl_replace_all:Nnn
+  { NnV }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \iffalse
+%</tex>
 %<*manual-tokens>
+% \fi
 
 ## Markdown Tokens
 
@@ -20414,73 +20543,6 @@ would use the following code in the preamble of your document:
 \newif\ifmarkdownLaTeXLoaded
   \markdownLaTeXLoadedfalse
 \AtEndOfPackage{\markdownLaTeXLoadedtrue}
-\ExplSyntaxOn
-\tl_new:N \markdownLaTeXThemePackageName
-\cs_new:Nn
-  \@@_set_latex_theme:n
-  {
-    \str_if_in:nnF
-      { #1 }
-      { / }
-      {
-        \markdownError
-        { Won't~load~theme~with~unqualified~name~#1 }
-        { Theme~names~must~contain~at~least~one~forward~slash }
-      }
-    \str_if_in:nnT
-      { #1 }
-      { _ }
-      {
-        \markdownError
-        { Won't~load~theme~with~an~underscore~in~its~name~#1 }
-        { Theme~names~must~not~contain~underscores~in~their~names }
-      }
-    \tl_set:Nn \markdownLaTeXThemePackageName { #1 }
-    \str_replace_all:Nnn
-      \markdownLaTeXThemePackageName
-      { / }
-      { _ }
-    \edef\markdownLaTeXThemePackageName{
-      markdowntheme\markdownLaTeXThemePackageName}
-    \expandafter\markdownLaTeXThemeLoad\expandafter{
-      \markdownLaTeXThemePackageName}{#1/}
-  }
-\keys_define:nn
-  { markdown/options }
-  {
-    import .code:n = {
-      \tl_set:Nn
-        \l_tmpa_tl
-        { #1 }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% To ensure that keys containing forward slashes get passed correctly, we
-% replace all forward slashes in the input with backslash tokens with category
-% code letter and then undo the replacement. This means that if any unbraced
-% backslash tokens with category code letter exist in the input, they will be
-% replaced with forward slashes. However, this should be extremely rare.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      \tl_replace_all:NnV
-        \l_tmpa_tl
-        { / }
-        \c_backslash_str
-      \keys_set:nV
-        { markdown/options/import }
-        \l_tmpa_tl
-    },
-  }
-\cs_generate_variant:Nn
-  \tl_replace_all:Nnn
-  { NnV }
-\keys_define:nn
-  { markdown/options }
-  {
-    theme .code:n = { \@@_set_latex_theme:n { #1 } },
-  }
-\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</latex>
@@ -20499,8 +20561,10 @@ beginning of a \LaTeX{} document.
 % \fi
 %  \begin{macrocode}
 \ExplSyntaxOn
+\iffalse  % TODO: Write logic for loading LaTeX themes after preamble.
 \@onlypreamble
   \@@_set_latex_theme:n
+\fi
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
@@ -20803,15 +20867,15 @@ options locally.
       { #1 }
       {
         \markdownWarning
-          {Redefined~snippet~\markdownLaTeXThemeName#1}
+          {Redefined~snippet~\markdownThemeName#1}
         \csname markdownLaTeXSetupSnippet%
-          \markdownLaTeXThemeName#1\endcsname={#2}
+          \markdownThemeName#1\endcsname={#2}
       }
       {
         \newtoks\next
           \next={#2}
         \expandafter\let\csname markdownLaTeXSetupSnippet%
-          \markdownLaTeXThemeName#1\endcsname=\next
+          \markdownThemeName#1\endcsname=\next
       }
   }
 \let\markdownSetupSnippet=\@@_latex_setup_snippet:nn
@@ -20826,7 +20890,7 @@ options locally.
 %  \begin{macrocode}
 \newcommand\markdownIfSnippetExists[3]{%
   \@ifundefined
-    {markdownLaTeXSetupSnippet\markdownLaTeXThemeName#1}%
+    {markdownLaTeXSetupSnippet\markdownThemeName#1}%
     {#3}{#2}}%
 %    \end{macrocode}
 % \begin{markdown}
@@ -20844,7 +20908,7 @@ options locally.
         {
           \expandafter\markdownSetup\expandafter{
             \the\csname markdownLaTeXSetupSnippet
-            \markdownLaTeXThemeName#1\endcsname}
+            \markdownThemeName#1\endcsname}
         }{
           \markdownError
             {Can't~invoke~setup~snippet~#1}
@@ -21055,7 +21119,7 @@ variant of the `import` \LaTeX{} option:
 %
 % \end{markdown}
 %  \begin{macrocode}
-      \@@_set_latex_theme:V
+      \@@_set_theme:V
         \l_@@_latex_import_current_theme_tl
     },
   }
@@ -21063,7 +21127,7 @@ variant of the `import` \LaTeX{} option:
   \tl_replace_all:Nnn
   { NVn }
 \cs_generate_variant:Nn
-  \@@_set_latex_theme:n
+  \@@_set_theme:n
   { V }
 \cs_generate_variant:Nn
   \@@_latex_setup_snippet:nn
@@ -32941,35 +33005,23 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\newcommand\markdownLaTeXThemeName{}
-\seq_new:N \g_@@_latex_themes_seq
-\seq_gput_right:NV
-  \g_@@_latex_themes_seq
-  \markdownLaTeXThemeName
-\newcommand\markdownLaTeXThemeLoad[2]{
-  \def\@tempa{%
-    \def\markdownLaTeXThemeName{#2}
-    \seq_gput_right:NV
-      \g_@@_latex_themes_seq
-      \markdownLaTeXThemeName
-    \RequirePackage{#1}
-    \seq_pop_right:NN
-      \g_@@_latex_themes_seq
-      \l_tmpa_tl
-    \seq_get_right:NN
-      \g_@@_latex_themes_seq
-      \l_tmpa_tl
-    \exp_args:NNV
-      \def
-      \markdownLaTeXThemeName
-      \l_tmpa_tl}
-  \ifmarkdownLaTeXLoaded
-    \@tempa
-  \else
-    \exp_args:No
+\cs_new:Nn
+  \@@_load_theme:nn
+  {
+    \ifmarkdownLaTeXLoaded
+      \RequirePackage
+        { markdown theme #2 }
+    \else
       \AtEndOfPackage
-      { \@tempa }
-  \fi}
+        {
+          \RequirePackage
+            { markdown theme #2 }
+        }
+    \fi
+  }
+\cs_generate_variant:Nn
+  \@@_load_theme:nn
+  { nV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12124,10 +12124,310 @@ following text, where the middot (`·`) denotes a non-breaking space:
 %
 % Please, see Section <#sec:themes-implementation> for implementation
 % details of the example themes.
-%
+
+#### Snippets {#snippets}
+
 % \end{markdown}
 % \iffalse
+
+User-defined themes provide global control over high-level goals.
+However, it is often desirable to change only some local aspects of a document.
+Snippets provide syntactic sugar for defining and invoking various
+options locally.
+
 %</manual-options>
+%<*tex>
+% \fi
+% \par
+% \begin{markdown}
+%
+% We may set up options as *snippets* using the
+% \mdef{markdownSetupSnippet} macro and invoke them later. The
+% \mref{markdownSetupSnippet} macro receives two arguments: the name
+% of the snippet and the options to store.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Nn
+  \@@_setup_snippet:nn
+  {
+    \markdownIfSnippetExists
+      { #1 }
+      {
+        \markdownWarning
+          { Redefined~snippet~\markdownThemeName#1 }
+        \csname markdownLaTeXSetupSnippet%
+          \markdownThemeName#1\endcsname={#2}
+      }
+      {
+        \newtoks\next
+          \next={#2}
+        \expandafter\let\csname markdownLaTeXSetupSnippet%
+          \markdownThemeName#1\endcsname=\next
+      }
+  }
+\let\markdownSetupSnippet=\@@_setup_snippet:nn
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To decide whether a snippet exists, we can use the
+% \mdef{markdownIfSnippetExists} macro.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\cs_new:Npn
+  \markdownIfSnippetExists
+  #1 #2 #3
+  {
+    \@ifundefined
+      { markdownLaTeXSetupSnippet\markdownThemeName#1 }%
+      { #3 }
+      { #2 }
+  }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The option with key `snippet` invokes a snippet named \meta{value}.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\keys_define:nn
+  { markdown/options }
+  {
+    snippet .code:n = {
+      \markdownIfSnippetExists{#1}
+        {
+          \expandafter\markdownSetup\expandafter{
+            \the\csname markdownLaTeXSetupSnippet
+            \markdownThemeName#1\endcsname}
+        }{
+          \markdownError
+            { Can't~invoke~setup~snippet~#1 }
+            { The~setup~snippet~is~undefined }
+        }
+    }
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*manual-options>
+% \fi
+% \par
+% \markdownBegin
+
+Here is how we can use snippets to store options and invoke them later
+in \LaTeX{}:
+
+``` tex
+\markdownSetupSnippet{romanNumerals}{
+  renderers = {
+      olItemWithNumber = {%
+          \item[\romannumeral#1\relax.]%
+      },
+  },
+}
+\begin{markdown}
+
+The following ordered list will be preceded by arabic numerals:
+
+1. wahid
+2. aithnayn
+
+\end{markdown}
+\begin{markdown}[snippet=romanNumerals]
+
+The following ordered list will be preceded by roman numerals:
+
+3. tres
+4. quattuor
+
+\end{markdown}
+```````
+
+If the `romanNumerals` snippet were defined in the `jdoe/lists` theme,
+we could import the `jdoe/lists` theme and use the qualified name
+`jdoe/lists/romanNumerals` to invoke the snippet:
+
+``` tex
+\markdownSetup{import=jdoe/lists}
+\begin{markdown}[snippet=jdoe/lists/romanNumerals]
+
+The following ordered list will be preceded by roman numerals:
+
+3. tres
+4. quattuor
+
+\end{markdown}
+```````
+
+Alternatively, we can use the extended variant of the `import` \LaTeX{}
+option that allows us to import the `romanNumerals` snippet to the
+current namespace for easier access:
+
+``` tex
+\markdownSetup{
+  import = {
+    jdoe/lists = romanNumerals,
+  },
+}
+\begin{markdown}[snippet=romanNumerals]
+
+The following ordered list will be preceded by roman numerals:
+
+3. tres
+4. quattuor
+
+\end{markdown}
+```````
+
+Furthermore, we can also specify the name of the snippet in the current 
+namespace, which can be different from the name of the snippet in the
+`jdoe/lists` theme. For example, we can make the snippet
+`jdoe/lists/romanNumerals` available under the name `roman`.
+
+``` tex
+\markdownSetup{
+  import = {
+    jdoe/lists = romanNumerals as roman,
+  },
+}
+\begin{markdown}[snippet=roman]
+
+The following ordered list will be preceded by roman numerals:
+
+3. tres
+4. quattuor
+
+\end{markdown}
+```````
+
+Several themes and/or snippets can be loaded at once using the extended
+variant of the `import` \LaTeX{} option:
+
+``` tex
+\markdownSetup{
+  import = {
+    jdoe/longpackagename/lists = {
+      arabic as arabic1,
+      roman,
+      alphabetic,
+    },
+    jdoe/anotherlongpackagename/lists = {
+      arabic as arabic2,
+    },
+    jdoe/yetanotherlongpackagename,
+  },
+}
+```````
+
+% \markdownEnd
+% \iffalse
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\ExplSyntaxOn
+\tl_new:N
+  \l_@@_import_current_theme_tl
+\keys_define:nn
+  { markdown/options/import }
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If a theme name is given without a list of snippets to import,
+% we assume that an empty list was given.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    unknown .default:n = {},
+    unknown .code:n = {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% To ensure that keys containing forward slashes get passed correctly, we
+% replace all forward slashes in the input with backslash tokens with category
+% code letter and then undo the replacement. This means that if any unbraced
+% backslash tokens with category code letter exist in the input, they will be
+% replaced with forward slashes. However, this should be extremely rare.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      \tl_set_eq:NN
+        \l_@@_import_current_theme_tl
+        \l_keys_key_str
+      \tl_replace_all:NVn
+        \l_@@_import_current_theme_tl
+        \c_backslash_str
+        { / }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Here, we import the snippets.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      \clist_map_inline:nn
+        { #1 }
+        {
+          \regex_extract_once:nnNTF
+            { ^(.*?)\s+as\s+(.*?)$ }
+            { ##1 }
+            \l_tmpa_seq
+            {
+              \seq_pop:NN
+                \l_tmpa_seq
+                \l_tmpa_tl
+              \seq_pop:NN
+                \l_tmpa_seq
+                \l_tmpa_tl
+              \seq_pop:NN
+                \l_tmpa_seq
+                \l_tmpb_tl
+            }
+            {
+              \tl_set:Nn
+                \l_tmpa_tl
+                { ##1 }
+              \tl_set:Nn
+                \l_tmpb_tl
+                { ##1 }
+            }
+          \tl_put_left:Nn
+            \l_tmpa_tl
+            { / }
+          \tl_put_left:NV
+            \l_tmpa_tl
+            \l_@@_import_current_theme_tl
+          \@@_setup_snippet:Vx
+            \l_tmpb_tl
+            { snippet = { \l_tmpa_tl } }
+        }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Here, we load the theme.
+%
+% \end{markdown}
+%  \begin{macrocode}
+      \@@_set_theme:V
+        \l_@@_import_current_theme_tl
+    },
+  }
+\cs_generate_variant:Nn
+  \tl_replace_all:Nnn
+  { NVn }
+\cs_generate_variant:Nn
+  \@@_set_theme:n
+  { V }
+\cs_generate_variant:Nn
+  \@@_setup_snippet:nn
+  { Vx }
+%    \end{macrocode}
+% \iffalse
+%</tex>
 %<*manual-tokens>
 
 ## Markdown Tokens
@@ -20393,7 +20693,7 @@ pdflatex --shell-escape document.tex
 % base variant of the `import` key that loads a single \LaTeX{} theme
 % (see Section <#sec:latexthemes>) can be used, the extended variant
 % that can load multiple themes and import snippets from them (see
-% Section <#sec:latexsnippets>). This limitation is due to the way
+% Section <#sec:snippets>). This limitation is due to the way
 % \Hologo{LaTeX2e} parses package options.
 %
 % \end{markdown}
@@ -20472,7 +20772,7 @@ pdflatex --shell-escape document.tex
 %
 % Except for the `plain` option described in Section <#sec:latexplain>,
 % the \LaTeX{} themes described in Section <#sec:latexthemes>, and the
-% \LaTeX{} snippets described in Section <#sec:latexsnippets>,
+% snippets described in Section <#sec:snippets>,
 % \LaTeX{} options map directly to the options recognized by the plain
 % \TeX{} interface (see Section <#sec:tex-options>) and to the markdown token
 % renderers and their prototypes recognized by the plain \TeX{} interface (see
@@ -20884,312 +21184,13 @@ following image:
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-graphicx-http>
-%<*manual-options>
+%<*latex>
 % \fi
 % \par
 % \begin{markdown}
 %
 % Please, see Section <#sec:latex-themes-implementation> for implementation
 % details of the example themes.
-
-#### \LaTeX{} snippets {#latexsnippets}
-
-% \end{markdown}
-% \iffalse
-
-User-defined \LaTeX{} themes provide global control over high-level goals.
-However, it is often desirable to change only some local aspects of a document.
-\LaTeX{} snippets provide syntactic sugar for defining and invoking various
-options locally.
-
-%</manual-options>
-%<*latex>
-% \fi
-% \par
-% \begin{markdown}
-%
-% We may set up \LaTeX{} options as *snippets* using the
-% \mdef{markdownSetupSnippet} macro and invoke them later. The
-% \mref{markdownSetupSnippet} macro receives two arguments: the name
-% of the snippet and the options to store.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\cs_new:Nn
-  \@@_latex_setup_snippet:nn
-  {
-    \markdownIfSnippetExists
-      { #1 }
-      {
-        \markdownWarning
-          {Redefined~snippet~\markdownThemeName#1}
-        \csname markdownLaTeXSetupSnippet%
-          \markdownThemeName#1\endcsname={#2}
-      }
-      {
-        \newtoks\next
-          \next={#2}
-        \expandafter\let\csname markdownLaTeXSetupSnippet%
-          \markdownThemeName#1\endcsname=\next
-      }
-  }
-\let\markdownSetupSnippet=\@@_latex_setup_snippet:nn
-\ExplSyntaxOff
-%    \end{macrocode}
-% \begin{markdown}
-%
-% To decide whether a snippet exists, we can use the
-% \mdef{markdownIfSnippetExists} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\newcommand\markdownIfSnippetExists[3]{%
-  \@ifundefined
-    {markdownLaTeXSetupSnippet\markdownThemeName#1}%
-    {#3}{#2}}%
-%    \end{macrocode}
-% \begin{markdown}
-%
-% The \LaTeX{} option with key `snippet` invokes a snippet named \meta{value}.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\keys_define:nn
-  { markdown/options }
-  {
-    snippet .code:n = {
-      \markdownIfSnippetExists{#1}
-        {
-          \expandafter\markdownSetup\expandafter{
-            \the\csname markdownLaTeXSetupSnippet
-            \markdownThemeName#1\endcsname}
-        }{
-          \markdownError
-            {Can't~invoke~setup~snippet~#1}
-            {The~setup~snippet~is~undefined}
-        }
-    }
-  }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \iffalse
-%</latex>
-%<*manual-options>
-% \fi
-% \par
-% \markdownBegin
-
-Here is how we can use snippets to store options and invoke them later:
-
-``` tex
-\markdownSetupSnippet{romanNumerals}{
-  renderers = {
-      olItemWithNumber = {%
-          \item[\romannumeral#1\relax.]%
-      },
-  },
-}
-\begin{markdown}
-
-The following ordered list will be preceded by arabic numerals:
-
-1. wahid
-2. aithnayn
-
-\end{markdown}
-\begin{markdown}[snippet=romanNumerals]
-
-The following ordered list will be preceded by roman numerals:
-
-3. tres
-4. quattuor
-
-\end{markdown}
-```````
-
-If the `romanNumerals` snippet were defined in the `jdoe/lists` theme,
-we could import the `jdoe/lists` theme and use the qualified name
-`jdoe/lists/romanNumerals` to invoke the snippet:
-
-``` tex
-\markdownSetup{import=jdoe/lists}
-\begin{markdown}[snippet=jdoe/lists/romanNumerals]
-
-The following ordered list will be preceded by roman numerals:
-
-3. tres
-4. quattuor
-
-\end{markdown}
-```````
-
-Alternatively, we can use the extended variant of the `import` \LaTeX{}
-option that allows us to import the `romanNumerals` snippet to the
-current namespace for easier access:
-
-``` tex
-\markdownSetup{
-  import = {
-    jdoe/lists = romanNumerals,
-  },
-}
-\begin{markdown}[snippet=romanNumerals]
-
-The following ordered list will be preceded by roman numerals:
-
-3. tres
-4. quattuor
-
-\end{markdown}
-```````
-
-Furthermore, we can also specify the name of the snippet in the current 
-namespace, which can be different from the name of the snippet in the
-`jdoe/lists` theme. For example, we can make the snippet
-`jdoe/lists/romanNumerals` available under the name `roman`.
-
-``` tex
-\markdownSetup{
-  import = {
-    jdoe/lists = romanNumerals as roman,
-  },
-}
-\begin{markdown}[snippet=roman]
-
-The following ordered list will be preceded by roman numerals:
-
-3. tres
-4. quattuor
-
-\end{markdown}
-```````
-
-Several themes and/or snippets can be loaded at once using the extended
-variant of the `import` \LaTeX{} option:
-
-``` tex
-\markdownSetup{
-  import = {
-    jdoe/longpackagename/lists = {
-      arabic as arabic1,
-      roman,
-      alphabetic,
-    },
-    jdoe/anotherlongpackagename/lists = {
-      arabic as arabic2,
-    },
-    jdoe/yetanotherlongpackagename,
-  },
-}
-```````
-
-% \markdownEnd
-% \iffalse
-%</manual-options>
-%<*latex>
-% \fi
-%  \begin{macrocode}
-\ExplSyntaxOn
-\tl_new:N
-  \l_@@_latex_import_current_theme_tl
-\keys_define:nn
-  { markdown/options/import }
-  {
-%    \end{macrocode}
-% \begin{markdown}
-%
-% If a theme name is given without a list of snippets to import,
-% we assume that an empty list was given.
-%
-% \end{markdown}
-%  \begin{macrocode}
-    unknown .default:n = {},
-    unknown .code:n = {
-%    \end{macrocode}
-% \begin{markdown}
-%
-% To ensure that keys containing forward slashes get passed correctly, we
-% replace all forward slashes in the input with backslash tokens with category
-% code letter and then undo the replacement. This means that if any unbraced
-% backslash tokens with category code letter exist in the input, they will be
-% replaced with forward slashes. However, this should be extremely rare.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      \tl_set_eq:NN
-        \l_@@_latex_import_current_theme_tl
-        \l_keys_key_str
-      \tl_replace_all:NVn
-        \l_@@_latex_import_current_theme_tl
-        \c_backslash_str
-        { / }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Here, we import the \LaTeX{} snippets.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      \clist_map_inline:nn
-        { #1 }
-        {
-          \regex_extract_once:nnNTF
-            { ^(.*?)\s+as\s+(.*?)$ }
-            { ##1 }
-            \l_tmpa_seq
-            {
-              \seq_pop:NN
-                \l_tmpa_seq
-                \l_tmpa_tl
-              \seq_pop:NN
-                \l_tmpa_seq
-                \l_tmpa_tl
-              \seq_pop:NN
-                \l_tmpa_seq
-                \l_tmpb_tl
-            }
-            {
-              \tl_set:Nn
-                \l_tmpa_tl
-                { ##1 }
-              \tl_set:Nn
-                \l_tmpb_tl
-                { ##1 }
-            }
-          \tl_put_left:Nn
-            \l_tmpa_tl
-            { / }
-          \tl_put_left:NV
-            \l_tmpa_tl
-            \l_@@_latex_import_current_theme_tl
-          \@@_latex_setup_snippet:Vx
-            \l_tmpb_tl
-            { snippet = { \l_tmpa_tl } }
-        }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Here, we load the \LaTeX{} theme.
-%
-% \end{markdown}
-%  \begin{macrocode}
-      \@@_set_theme:V
-        \l_@@_latex_import_current_theme_tl
-    },
-  }
-\cs_generate_variant:Nn
-  \tl_replace_all:Nnn
-  { NVn }
-\cs_generate_variant:Nn
-  \@@_set_theme:n
-  { V }
-\cs_generate_variant:Nn
-  \@@_latex_setup_snippet:nn
-  { Vx }
-%    \end{macrocode}
-% \begin{markdown}
 %
 %#### Generating Plain \TeX{} Option, Token Renderer, and Token Renderer Prototype Macros and Key-Values
 %
@@ -21202,6 +21203,7 @@ variant of the `import` \LaTeX{} option:
 %
 % \end{markdown}
 %  \begin{macrocode}
+\ExplSyntaxOn
 \str_if_eq:VVT
   \c_@@_top_layer_tl
   \c_@@_option_layer_latex_tl
@@ -33420,7 +33422,7 @@ end
 %
 % After processing the options, activate the `code` key, which can be used
 % to immediately expand and execute code. This can be especially useful in
-% \LaTeX{} snippets.
+% snippets.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -32100,6 +32100,9 @@ end
       \l_tmpa_str
   }
 \cs_generate_variant:Nn
+  \tl_set:Nn
+  { Ne }
+\cs_generate_variant:Nn
   \@@_plain_tex_load_theme:nn
   { VV }
 \ExplSyntaxOff

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -31928,6 +31928,29 @@ end
 % \par
 % \begin{markdown}
 %
+%### Plain TeX Themes {#themes-implementation}
+%
+% This section implements the theme-loading mechanism and the example themes
+% provided with the Markdown package.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Nn
+  \@@_load_theme:nn
+  {
+    \markdownInfo
+      { Loading~Markdown~theme~#1 }
+    \file_input:n
+      { markdown theme #2 }
+  }
+\cs_generate_variant:Nn
+  \@@_load_theme:nn
+  { nV }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+%
 %### Token Renderer Prototypes {#tex-token-renderer-prototypes}
 %
 % The following definitions should be considered placeholder.
@@ -33061,37 +33084,47 @@ end
 %
 %#### \LaTeX{} Themes {#latex-themes-implementation}
 %
-% This section implements the theme-loading mechanism and the example themes
-% provided with the Markdown package.
+% This section overrides the plain \TeX{} implementation of the theme-loading
+% mechanism from Section <#sec:themes-implementation>. Futhermore, this section
+% also implements the example themes provided with the Markdown package.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-%    \end{macrocode}
-% \begin{markdown}
-%
-% To keep track of our current place when packages themes have been nested,
-% we will maintain the \mdef{g_\@\@_latex_themes_seq} stack of theme names.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\cs_new:Nn
+\cs_gset_eq:NN
+  \@@_load_theme_plain_tex:nn
+  \@@_load_theme:nn
+\cs_gset:Nn
   \@@_load_theme:nn
   {
     \ifmarkdownLaTeXLoaded
-      \RequirePackage
-        { markdown theme #2 }
-    \else
-      \AtEndOfPackage
+      \file_if_exist:nTF
+        { markdown theme #2.sty }
         {
+          \markdownInfo
+            { Loading~Markdown~theme~#1 }
           \RequirePackage
             { markdown theme #2 }
         }
+        {
+          \@@_load_theme_plain_tex:nn
+            { #1 }
+            { #2 }
+        }
+    \else
+      \markdownInfo
+        {
+          Deferring~loading~Markdown~theme~#1~until~
+          Markdown~package~has~finished~loading
+        }
+      \AtEndOfPackage
+        {
+          \@@_load_theme:nn
+            { #1 }
+            { #2 }
+        }
     \fi
   }
-\cs_generate_variant:Nn
-  \@@_load_theme:nn
-  { nV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -25132,7 +25132,7 @@ end
     end
 
     if self.is_writing and #normalized_attributes > 0 then
-      table.insert(buf, "\n\\markdownRendererHeaderAttributeContextEnd ")
+      table.insert(buf, "\\markdownRendererHeaderAttributeContextEnd ")
     end
 
     return buf
@@ -30151,7 +30151,7 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       function self.div_begin(attributes)
         local start_output = {"\\markdownRendererFencedDivAttributeContextBegin\n",
                               self.attributes(attributes)}
-        local end_output = {"\n\\markdownRendererFencedDivAttributeContextEnd "}
+        local end_output = {"\\markdownRendererFencedDivAttributeContextEnd "}
         return self.push_attributes("div", attributes, start_output, end_output)
       end
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -33121,25 +33121,29 @@ end
 % \begin{markdown}
 %
 % If the Markdown package has already been loaded and we are already past the
-% preamble, try loading a plain \TeX{} theme instead. Log a warning if there
-% exists a \LaTeX{} theme that we would have loaded if we were still in the
-% preamble.
+% preamble, determine whether a file named `markdowntheme`\meta{munged theme
+% name}`.sty` exists. If it does, end with an error, since we cannot load
+% \LaTeX{} themes after the preamble. Otherwise, try loading a plain \TeX{}
+% theme instead.
 %
 % \end{markdown}
 %  \begin{macrocode}
-        \file_if_exist:nT
+        \file_if_exist:nTF
           { markdown theme #2.sty }
           {
-            \markdownWarning
+            \markdownError
               {
-                File~markdown theme #2.sty~exists,~but~we~are~past~
-                the~preamble.~Therefore,~I~will~try~loading~file~
-                markdown theme #2.tex~instead.
+                Cannot~load~file~markdown theme #2.sty~after~preamble.
+              }
+              {
+                Load~Markdown~theme~#1~before~\begin{document}.
               }
           }
-        \@@_load_theme_plain_tex:nn
-          { #1 }
-          { #2 }
+          {
+            \@@_load_theme_plain_tex:nn
+              { #1 }
+              { #2 }
+          }
       \else
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -31974,14 +31974,35 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\prop_new:N \g_@@_plain_tex_loaded_themes_linenos_prop
 \cs_new:Nn
   \@@_load_theme:nn
   {
-    \markdownInfo
-      { Loading~plain~TeX~Markdown~theme~#1 }
-    \file_input:n
-      { markdown theme #2 }
+    \prop_get:NnNTF
+      \g_@@_plain_tex_loaded_themes_linenos_prop
+      { #1 }
+      \l_tmpa_tl
+      {
+        \markdownInfo
+          {
+            Plain~TeX~Markdown~theme~#1~was~previously~
+            loaded~on~line~\l_tmpa_tl,~not~loading~it~again
+          }
+      }
+      {
+        \markdownInfo
+          { Loading~plain~TeX~Markdown~theme~#1 }
+        \prop_gput:Nnx
+          \g_@@_plain_tex_loaded_themes_linenos_prop
+          { #1 }
+          { \tex_the:D \tex_inputlineno:D }
+        \file_input:n
+          { markdown theme #2 }
+      }
   }
+\cs_generate_variant:Nn
+  \prop_gput:Nnn
+  { Nnx }
 \cs_generate_variant:Nn
   \@@_load_theme:nn
   { nV }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20602,10 +20602,24 @@ following text:
 |endgroup
 %    \end{macrocode}
 % \begin{markdown}
-% The macro is exposed in the interface, so that the user can create their own
+% The macro is exposed in the interface, so that users can create their own
 % markdown environments. Due to the way the arguments are passed to Lua, the
 % first argument may not contain the string `]]` (regardless of the category
-% code of the bracket symbol (`]`)).
+% code of the bracket symbol).
+%
+% The `code` key, which can be used to immediately expand and execute code.
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\keys_define:nn
+  { markdown/options }
+  {
+    code .code:n = { #1 },
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+% This can be especially useful in snippets.
 %
 % \end{markdown}
 % \iffalse
@@ -33448,22 +33462,6 @@ end
 \DeclareOption*{%
   \expandafter\markdownSetup\expandafter{\CurrentOption}}%
 \ProcessOptions\relax
-%    \end{macrocode}
-% \begin{markdown}
-%
-% After processing the options, activate the `code` key, which can be used
-% to immediately expand and execute code. This can be especially useful in
-% snippets.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\keys_define:nn
-  { markdown/options }
-  {
-    code .code:n = { #1 },
-  }
-\ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20745,7 +20745,7 @@ pdflatex --shell-escape document.tex
 % base variant of the `import` key that loads a single \LaTeX{} theme
 % (see Section <#sec:latexthemes>) can be used, the extended variant
 % that can load multiple themes and import snippets from them (see
-% Section <#sec:snippets>). This limitation is due to the way
+% Section <#sec:snippets>) cannot. This limitation is due to the way
 % \Hologo{LaTeX2e} parses package options.
 %
 % \end{markdown}
@@ -21520,9 +21520,41 @@ following text:
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
+% \iffalse
+%</context>
+%<*manual-options>
+% \fi
 % \begin{markdown}
-%
+
+### Themes
+
+% In Section~\ref{sec:themes}, we described the concept of themes.
+In \Hologo{ConTeXt}, we expand on the concept of
+% themes\iffalse
+[themes](#themes)
+% \fi
+by allowing a theme to be a full-blown \Hologo{ConTeXt} module. Specifically,
+the key-values `theme`=\meta{theme name} and `import`=\meta{theme name} load a
+\Hologo{ConTeXt} module named `t-markdowntheme`\meta{munged theme name}`.tex`
+if it exists and a \TeX{} document named `markdowntheme`\meta{munged theme
+name}`.tex` otherwise.
+
+Having the Markdown package automatically load either the generic `.tex`
+*theme file* or the \Hologo{ConTeXt}-specific `t-*.tex` theme file allows
+developers to have a single *theme file*, when the theme is small or the
+difference between \TeX{} formats is unimportant, and scale up to separate
+theme files native to different \TeX{} formats for large multi-format themes,
+where different code is needed for different \TeX{} formats. To enable code
+reuse, developers can load the `.tex` theme file from the `t-*.tex` theme file
+using the \mref{markdownLoadPlainTeXTheme} macro.
+
+For example, to load a theme named `witiko/tilde` in your document:
+
+``` tex
+\usemodule[t][markdown]
+\setupmarkdown[import=witiko/tilde]
+```````
+
 % Implementation {#implementation}
 %================
 %
@@ -21539,7 +21571,7 @@ following text:
 %
 % \end{markdown}
 % \iffalse
-%</context>
+%</manual-options>
 %<*lua>
 % \fi
 % \begin{markdown}
@@ -31976,7 +32008,7 @@ end
 \ExplSyntaxOn
 \prop_new:N \g_@@_plain_tex_loaded_themes_linenos_prop
 \cs_new:Nn
-  \@@_load_theme:nn
+  \@@_plain_tex_load_theme:nn
   {
     \prop_get:NnNTF
       \g_@@_plain_tex_loaded_themes_linenos_prop
@@ -32003,9 +32035,73 @@ end
 \cs_generate_variant:Nn
   \prop_gput:Nnn
   { Nnx }
+\cs_gset_eq:NN
+  \@@_load_theme:nn
+  \@@_plain_tex_load_theme:nn
 \cs_generate_variant:Nn
   \@@_load_theme:nn
   { nV }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Developers can use the \mref{markdownLoadPlainTeXTheme} macro to load a
+% corresponding plain \TeX{} theme from within themes for higher-level \TeX{}
+% formats such as \LaTeX{} and \Hologo{ConTeXt}.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\cs_new:Npn
+  \markdownLoadPlainTeXTheme
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% First, we extract the name of the current theme from the
+% \mref{g_@@_current_theme_tl} macro.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \tl_set:NV
+      \l_tmpa_tl
+      \g_@@_current_theme_tl
+    \tl_reverse:N
+      \l_tmpa_tl
+    \tl_set:Ne
+      \l_tmpb_tl
+      {
+        \tl_tail:V
+          \l_tmpa_tl
+      }
+    \tl_reverse:N
+      \l_tmpb_tl
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Next, we munge the theme name.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \str_set:NV
+      \l_tmpa_str
+      \l_tmpb_tl
+    \str_replace_all:Nnn
+      \l_tmpa_str
+      { / }
+      { _ }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Finally, we load the plain \TeX{} theme.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \@@_plain_tex_load_theme:VV
+      \l_tmpb_tl
+      \l_tmpa_str
+  }
+\cs_generate_variant:Nn
+  \@@_plain_tex_load_theme:nn
+  { VV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
@@ -33180,9 +33276,6 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\cs_gset_eq:NN
-  \@@_load_theme_plain_tex:nn
-  \@@_load_theme:nn
 \cs_gset:Nn
   \@@_load_theme:nn
   {
@@ -33201,9 +33294,7 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% If the Markdown package has already been loaded and we are already past the
-% preamble, determine whether a file named `markdowntheme`\meta{munged theme
-% name}`.sty` exists. If it does, end with an error, since we cannot load
+% If both conditions are true does, end with an error, since we cannot load
 % \LaTeX{} themes after the preamble. Otherwise, try loading a plain \TeX{}
 % theme instead.
 %
@@ -33217,7 +33308,7 @@ end
               { Load~Markdown~theme~#1~before~\begin{document} }
           }
           {
-            \@@_load_theme_plain_tex:nn
+            \@@_plain_tex_load_theme:nn
               { #1 }
               { #2 }
           }
@@ -33240,7 +33331,7 @@ end
               { markdown theme #2 }
           }
           {
-            \@@_load_theme_plain_tex:nn
+            \@@_plain_tex_load_theme:nn
               { #1 }
               { #2 }
           }
@@ -33267,66 +33358,6 @@ end
         }
     \fi
   }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Developers can use the \mref{markdownLoadPlainTeXTheme} macro to load a
-  % corresponding plain \TeX{} theme from within a \LaTeX{} theme.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\cs_new:Npn
-  \markdownLoadPlainTeXTheme
-  {
-%    \end{macrocode}
-% \begin{markdown}
-%
-% First, we extract the name of the current theme from the
-% \mref{g_@@_current_theme_tl} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-    \tl_set:NV
-      \l_tmpa_tl
-      \g_@@_current_theme_tl
-    \tl_reverse:N
-      \l_tmpa_tl
-    \tl_set:Ne
-      \l_tmpb_tl
-      {
-        \tl_tail:V
-          \l_tmpa_tl
-      }
-    \tl_reverse:N
-      \l_tmpb_tl
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Next, we munge the theme name.
-%
-% \end{markdown}
-%  \begin{macrocode}
-    \str_set:NV
-      \l_tmpa_str
-      \l_tmpb_tl
-    \str_replace_all:Nnn
-      \l_tmpa_str
-      { / }
-      { _ }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Finally, we load the plain \TeX{} theme.
-%
-% \end{markdown}
-%  \begin{macrocode}
-    \@@_load_theme_plain_tex:VV
-      \l_tmpb_tl
-      \l_tmpa_str
-  }
-\cs_generate_variant:Nn
-  \@@_load_theme_plain_tex:nn
-  { VV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}
@@ -34854,6 +34885,46 @@ end
 |endgroup
 %    \end{macrocode}
 % \par
+% \begin{markdown}
+%
+%### Themes
+%
+% This section overrides the plain \TeX{} implementation of the theme-loading
+% mechanism from Section <#sec:themes-implementation>.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset:Nn
+  \@@_load_theme:nn
+  {
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Determine whether a file named `t-markdowntheme`\meta{munged theme
+% name}`.tex` exists. If it does, load it. Otherwise, try loading a plain
+% \TeX{} theme instead.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \file_if_exist:nTF
+      { t - markdown theme #2.tex }
+      {
+        \markdownInfo
+          { Loading~ConTeXt~Markdown~theme~#1 }
+        \usemodule
+          [ t ]
+          [ markdown theme #2 ]
+      }
+      {
+        \@@_plain_tex_load_theme:nn
+          { #1 }
+          { #2 }
+      }
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
 % \begin{markdown}
 %
 %### Token Renderer Prototypes

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -787,7 +787,7 @@ abbr {
   doi       = {10.1109/ICPC.2010.41}}
 %</techdoc-bibliography>
 %<@@=markdown>
-%<*latex-themes-witiko-markdown-techdoc>
+%<*themes-witiko-markdown-techdoc>
 \ProvidesPackage{markdownthemewitiko_markdown_techdoc}[2022/12/13]
 \RequirePackage{etoolbox}
 \markdownSetup{
@@ -862,7 +862,7 @@ abbr {
     dlEnd = {\end{optionlist}},
   }
 }
-%</latex-themes-witiko-markdown-techdoc>
+%</themes-witiko-markdown-techdoc>
 %<*manual>
 
 ---
@@ -979,7 +979,7 @@ This should produce the following files:
 * `markdown.sty`, the \LaTeX{} package,
 * `markdownthemewitiko_dot.sty`, the `witiko/dot` \LaTeX{} theme,
 * `markdownthemewitiko_graphicx_http.sty`, the `witiko/graphicx/http` \LaTeX{} theme,
-* `markdownthemewitiko_tilde.sty`, the `witiko/tilde` \LaTeX{} theme, and
+* `markdownthemewitiko_tilde.tex`, the `witiko/tilde` \LaTeX{} theme, and
 * `t-markdown.tex`, the \Hologo{ConTeXt} module.
 
 ### Local Installation
@@ -995,7 +995,7 @@ placed:
 * `⟨TEXMF⟩/tex/latex/markdown/markdown.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_dot.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_graphicx_http.sty`
-* `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_tilde.sty`
+* `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_tilde.tex`
 * `⟨TEXMF⟩/tex/context/third/markdown/t-markdown.tex`
 
 where `⟨TEXMF⟩` corresponds to a root of your \TeX{} distribution, such as
@@ -1018,7 +1018,7 @@ This is where the individual files should be placed:
 * `./markdown.sty`
 * `./markdownthemewitiko_dot.sty`
 * `./markdownthemewitiko_graphicx_http.sty`
-* `./markdownthemewitiko_tilde.sty`
+* `./markdownthemewitiko_tilde.tex`
 * `./t-markdown.tex`
 
 %</manual>
@@ -1215,13 +1215,13 @@ local uni_algos = require("lua-uni-algos")
 % loaded,
 % \end{markdown}
 % \iffalse
-%<*latex-themes-witiko-dot,latex-themes-witiko-graphicx-http,latex-themes-witiko-tilde>
+%<*themes-witiko-dot,latex-themes-witiko-graphicx-http>
 % \fi
 %  \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}%
 %    \end{macrocode}
 % \iffalse
-%</latex-themes-witiko-dot,latex-themes-witiko-graphicx-http,latex-themes-witiko-tilde>
+%</themes-witiko-dot,latex-themes-witiko-graphicx-http>
 % \fi
 % \begin{markdown}
 % a \TeX{} engine that extends \Hologo{eTeX}, and all the plain \TeX{}
@@ -12072,9 +12072,63 @@ a specific look and other high-level goals without low-level programming.
 %    \end{macrocode}
 % \iffalse
 %</tex>
-%<*manual-tokens>
+%<*manual-options>
 % \fi
+% \par
 % \begin{markdown}
+
+Example themes provided with the Markdown package include:
+
+\pkg{witiko/tilde}
+
+:    A theme that makes tilde (`~`) always typeset the non-breaking space even
+     when the \Opt{hybrid} Lua option is disabled.
+%    ``` tex
+%    \input markdown
+%    \markdownSetup{import=witiko/tilde}
+%    \markdownBegin
+%    Bartel~Leendert van~der~Waerden
+%    \markdownEnd
+%    \bye
+%    ```````
+%    Typesetting the above document produces the following text:
+%    “Bartel~Leendert van~der~Waerden”.
+%
+% \end{markdown}
+% \iffalse
+
+##### Plain \TeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\input markdown
+\markdownSetup{import=witiko/tilde}
+\markdownBegin
+Bartel~Leendert van~der~Waerden
+\markdownEnd
+\bye
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+luatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text, where the middot (`·`) denotes a non-breaking space:
+
+> Bartel·Leendert van·der·Waerden
+
+% \fi
+% \par
+% \begin{markdown}
+%
+% Please, see Section <#sec:themes-implementation> for implementation
+% details of the example themes.
+%
+% \end{markdown}
+% \iffalse
+%</manual-options>
+%<*manual-tokens>
 
 ## Markdown Tokens
 
@@ -12082,6 +12136,9 @@ A key feature of the Markdown package is the support for manipulating markdown
 tokens, such as headings, emphasized text, links, and lists, in \TeX{}. Instead
 of reducing \TeX{} to a PDF document producer, the Markdown package allows the
 user to specify how every markdown token should be processed and rendered.
+
+% \fi
+% \begin{markdown}
 
 ### Token Renderers {#texrenderersuser}
 
@@ -20570,7 +20627,7 @@ exists and a \TeX{} document named `markdowntheme`\meta{munged theme
 name}`.tex` otherwise.
 
 Having the Markdown package automatically load either the generic `.tex`
-*theme file* or the \LaTeX-specific `.sty` theme file allows developers
+*theme file* or the \LaTeX{}-specific `.sty` theme file allows developers
 to have a single *theme file*, when the theme is small or the difference
 between \TeX{} formats is unimportant, and scale up to separate theme files
 native to different \TeX{} formats for large multi-format themes, where
@@ -20775,13 +20832,13 @@ conference article:
 > <http://ceur-ws.org/Vol-2696/paper_235.pdf>
 
 %</manual-options>
-%<*latex-themes-witiko-dot>
+%<*themes-witiko-dot>
 % \fi
 %  \begin{macrocode}
 \ProvidesPackage{markdownthemewitiko_dot}[2021/03/09]%
 %    \end{macrocode}
 % \iffalse
-%</latex-themes-witiko-dot>
+%</themes-witiko-dot>
 %<*manual-options>
 % \fi
 % \par
@@ -20837,67 +20894,13 @@ following image:
 > ![img](https://github.com/witiko/markdown/raw/main/markdown.png "The banner of the Markdown package")
 
 %</manual-options>
-%<*latex-themes-witiko-graphicx-http>
+%<*themes-witiko-graphicx-http>
 % \fi
 %  \begin{macrocode}
 \ProvidesPackage{markdownthemewitiko_graphicx_http}[2021/03/22]%
 %    \end{macrocode}
 % \iffalse
-%</latex-themes-witiko-graphicx-http>
-%<*manual-options>
-% \fi
-% \par
-% \markdownBegin
-
-\pkg{witiko/tilde}
-
-:    A theme that makes tilde (`~`) always typeset the non-breaking space even
-     when the \Opt{hybrid} Lua option is disabled.
-%    ``` tex
-%    \documentclass{article}
-%    \usepackage[import=witiko/tilde]{markdown}
-%    \begin{document}
-%    \begin{markdown}
-%    Bartel~Leendert van~der~Waerden
-%    \end{markdown}
-%    \end{document}
-%    ```````
-%    Typesetting the above document produces the following text:
-%    “Bartel~Leendert van~der~Waerden”.
-%
-% \markdownEnd
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[import=witiko/tilde]{markdown}
-\begin{document}
-\begin{markdown}
-Bartel~Leendert van~der~Waerden
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following text, where the middot (`·`) denotes a non-breaking space:
-
-> Bartel·Leendert van·der·Waerden
-
-%</manual-options>
-%<*latex-themes-witiko-tilde>
-% \fi
-%  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_tilde}[2021/03/22]%
-%    \end{macrocode}
-% \iffalse
-%</latex-themes-witiko-tilde>
+%</themes-witiko-graphicx-http>
 %<*manual-options>
 % \fi
 % \par
@@ -31949,6 +31952,28 @@ end
   { nV }
 \ExplSyntaxOff
 %    \end{macrocode}
+% \iffalse
+%</tex>
+%<*themes-witiko-tilde>
+% \fi
+% \par
+% \begin{markdown}
+%
+% The `witiko/tilde` theme redefines the tilde token renderer prototype,
+% so that it expands to a non-breaking space:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\markdownSetup {
+  rendererPrototypes = {
+    tilde = {~},
+  },
+}
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-tilde>
+%<*tex>
+% \fi
 % \begin{markdown}
 %
 %### Token Renderer Prototypes {#tex-token-renderer-prototypes}
@@ -33134,7 +33159,7 @@ end
 % \end{markdown}
 % \iffalse
 %</latex>
-%<*latex-themes-witiko-dot>
+%<*themes-witiko-dot>
 % \fi
 %  \begin{macrocode}
 \markdownSetup{fencedCode}%
@@ -33199,8 +33224,8 @@ end
   \next#2 \relax}%
 %    \end{macrocode}
 % \iffalse
-%</latex-themes-witiko-dot>
-%<*latex-themes-witiko-graphicx-http>
+%</themes-witiko-dot>
+%<*themes-witiko-graphicx-http>
 % \fi
 % \par
 % \begin{markdown}
@@ -33336,21 +33361,7 @@ end
 \endgroup
 %    \end{macrocode}
 % \iffalse
-%</latex-themes-witiko-graphicx-http>
-%<*latex-themes-witiko-tilde>
-% \fi
-% \par
-% \begin{markdown}
-%
-% The `witiko/tilde` theme redefines the tilde token renderer prototype,
-% so that it expands to a non-breaking space:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\renewcommand\markdownRendererTildePrototype{~}%
-%    \end{macrocode}
-% \iffalse
-%</latex-themes-witiko-tilde>
+%</themes-witiko-graphicx-http>
 %<*latex>
 % \fi
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -786,8 +786,9 @@ abbr {
   pages     = {196-205},
   doi       = {10.1109/ICPC.2010.41}}
 %</techdoc-bibliography>
+%<@@=markdown>
 %<*latex-themes-witiko-markdown-techdoc>
-\ProvidesPackage{markdownthemewitiko_markdown_techdoc}[2022/02/23]
+\ProvidesPackage{markdownthemewitiko_markdown_techdoc}[2022/12/13]
 \RequirePackage{etoolbox}
 \markdownSetup{
   renderers = {
@@ -802,24 +803,6 @@ abbr {
         {\def\addcontentsline##1##2##3{}\listoffigures}%
       }%
     },
-    headerAttributeContextBegin = {%
-      \begingroup
-      \markdownSetup{
-        rendererPrototypes = {
-          attributeIdentifier = {%
-            \markdownSetup{
-              rendererPrototypes = {
-                headerAttributeContextEnd = {%
-                  \label{sec:##1}%
-                  \endgroup
-                },
-              }
-            }%
-          },
-        },
-      }%
-    },
-    headerAttributeContextEnd = {\endgroup},
   },
   jekyllDataRenderers = {
     /authors/* = {%
@@ -837,6 +820,17 @@ abbr {
     url = {\gdef\ltd@title@url{#1}},
   }
 }
+\ExplSyntaxOn
+\markdownSetup{
+  rendererPrototypes = {
+    headerAttributeContextEnd = {
+      \seq_map_inline:Nn
+        \l_@@_header_identifiers_seq
+        { \label { sec:##1 } }
+    },
+  },
+}
+\ExplSyntaxOff
 \renewcommand\markdownLaTeXRendererDirectOrIndirectLink[4]{%
   #1\footnote{See \url{#3}.}}
 \RequirePackage{varioref}
@@ -1164,7 +1158,6 @@ local uni_algos = require("lua-uni-algos")
 %
 % \end{markdown}
 %  \begin{macrocode}
-%<@@=markdown>
 %</tex>
 %<*context,tex>
 \ifx\ExplSyntaxOn\undefined
@@ -33720,7 +33713,6 @@ end
 \markdownSetup{
   rendererPrototypes = {
     headerAttributeContextBegin = {
-      \group_begin:
       \seq_clear:N \l_@@_header_identifiers_seq
       \markdownSetup
         {
@@ -33737,7 +33729,6 @@ end
       \seq_map_inline:Nn
         \l_@@_header_identifiers_seq
         { \label { ##1 } }
-      \group_end:
     },
   },
 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -31978,7 +31978,7 @@ end
   \@@_load_theme:nn
   {
     \markdownInfo
-      { Loading~Markdown~theme~#1 }
+      { Loading~plain~TeX~Markdown~theme~#1 }
     \file_input:n
       { markdown theme #2 }
   }
@@ -33214,7 +33214,7 @@ end
           { markdown theme #2.sty }
           {
             \markdownInfo
-              { Loading~Markdown~theme~#1 }
+              { Loading~LaTeX~Markdown~theme~#1 }
             \RequirePackage
               { markdown theme #2 }
           }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21007,8 +21007,7 @@ package. Setting the option after loading the package will have no effect.
 
 % In Section~\ref{sec:themes}, we described the concept of themes.
 In \LaTeX{}, we expand on the concept of
-% themes
-% \iffalse
+% themes\iffalse
 [themes](#themes)
 % \fi
 by allowing a theme to be a full-blown \LaTeX{} package. Specifically, the
@@ -21073,6 +21072,7 @@ Due to limitations of \LaTeX{}, themes may not be loaded after the
 beginning of a \LaTeX{} document.
 
 % \end{markdown}
+% \par
 % \markdownBegin
 
 Example themes provided with the Markdown package include:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21024,7 +21024,7 @@ between \TeX{} formats is unimportant, and scale up to separate theme files
 native to different \TeX{} formats for large multi-format themes, where
 different code is needed for different \TeX{} formats. To enable code reuse,
 developers can load the `.tex` theme file from the `.sty` theme file using the
-\mdef{markdownSuper} macro.
+\mdef{markdownLoadPlainTeXTheme} macro.
 
 % If the \LaTeX{} option with keys `theme` or `import` is (repeatedly)
 % specified in the `\usepackage` macro, the loading of the theme(s) will be
@@ -33249,13 +33249,13 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Developers can use the \mref{markdownSuper} macro to load a corresponding
-% plain \TeX{} theme from within a \LaTeX{} theme.
+% Developers can use the \mref{markdownLoadPlainTeXTheme} macro to load a
+  % corresponding plain \TeX{} theme from within a \LaTeX{} theme.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \cs_new:Npn
-  \markdownSuper
+  \markdownLoadPlainTeXTheme
   {
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12074,6 +12074,7 @@ a specific look and other high-level goals without low-level programming.
 %</tex>
 %<*manual-tokens>
 % \fi
+% \begin{markdown}
 
 ## Markdown Tokens
 
@@ -12081,9 +12082,6 @@ A key feature of the Markdown package is the support for manipulating markdown
 tokens, such as headings, emphasized text, links, and lists, in \TeX{}. Instead
 of reducing \TeX{} to a PDF document producer, the Markdown package allows the
 user to specify how every markdown token should be processed and rendered.
-
-% \fi
-% \begin{markdown}
 
 ### Token Renderers {#texrenderersuser}
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12152,18 +12152,25 @@ options locally.
 \cs_new:Nn
   \@@_setup_snippet:nn
   {
+    \tl_if_empty:nT
+      { #1 }
+      {
+        \markdownError
+          { Empty~snippet~name }
+          { Pick~a~non-empty~name~for~your~snippet }
+      }
     \markdownIfSnippetExists
       { #1 }
       {
         \markdownWarning
           { Redefined~snippet~\markdownThemeName#1 }
-        \csname markdownLaTeXSetupSnippet%
+        \csname markdownSetupSnippet%
           \markdownThemeName#1\endcsname={#2}
       }
       {
         \newtoks\next
           \next={#2}
-        \expandafter\let\csname markdownLaTeXSetupSnippet%
+        \expandafter\let\csname markdownSetupSnippet%
           \markdownThemeName#1\endcsname=\next
       }
   }
@@ -12181,7 +12188,7 @@ options locally.
   #1 #2 #3
   {
     \@ifundefined
-      { markdownLaTeXSetupSnippet\markdownThemeName#1 }%
+      { markdownSetupSnippet\markdownThemeName#1 }%
       { #3 }
       { #2 }
   }
@@ -12199,7 +12206,7 @@ options locally.
       \markdownIfSnippetExists{#1}
         {
           \expandafter\markdownSetup\expandafter{
-            \the\csname markdownLaTeXSetupSnippet
+            \the\csname markdownSetupSnippet
             \markdownThemeName#1\endcsname}
         }{
           \markdownError
@@ -33134,12 +33141,8 @@ end
           { markdown theme #2.sty }
           {
             \markdownError
-              {
-                Cannot~load~file~markdown theme #2.sty~after~preamble.
-              }
-              {
-                Load~Markdown~theme~#1~before~\begin{document}.
-              }
+              { Cannot~load~file~markdown theme #2.sty~after~preamble }
+              { Load~Markdown~theme~#1~before~\begin{document} }
           }
           {
             \@@_load_theme_plain_tex:nn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11985,20 +11985,20 @@ a specific look and other high-level goals without low-level programming.
 % To keep track of the current theme when themes are nested, we will
 % maintain the \mdef{g_\@\@_themes_seq} stack of theme names.
 % For convenience, the name of the current theme is also available in the
-% \mdef{markdownThemeName} macro.
+% \mdef{g_@@_current_theme_tl} macro.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \seq_new:N
   \g_@@_themes_seq
 \tl_new:N
-  \markdownThemeName
+  \g_@@_current_theme_tl
 \tl_gset:Nn
-  \markdownThemeName
+  \g_@@_current_theme_tl
   { }
 \seq_gput_right:NV
   \g_@@_themes_seq
-  \markdownThemeName
+  \g_@@_current_theme_tl
 \cs_new:Nn
   \@@_set_theme:n
   {
@@ -12047,11 +12047,11 @@ a specific look and other high-level goals without low-level programming.
 % \end{markdown}
 %  \begin{macrocode}
     \tl_gset:Nn
-      \markdownThemeName
+      \g_@@_current_theme_tl
       { #1 / }
     \seq_gput_right:NV
       \g_@@_themes_seq
-      \markdownThemeName
+      \g_@@_current_theme_tl
     \@@_load_theme:nV
       { #1 }
       \l_tmpa_str
@@ -12062,7 +12062,7 @@ a specific look and other high-level goals without low-level programming.
       \g_@@_themes_seq
       \l_tmpa_tl
     \tl_gset:NV
-      \markdownThemeName
+      \g_@@_current_theme_tl
       \l_tmpa_tl
   }
 \cs_generate_variant:Nn
@@ -12149,6 +12149,8 @@ options locally.
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\prop_new:N
+  \g_@@_snippets_prop
 \cs_new:Nn
   \@@_setup_snippet:nn
   {
@@ -12159,22 +12161,26 @@ options locally.
           { Empty~snippet~name }
           { Pick~a~non-empty~name~for~your~snippet }
       }
-    \markdownIfSnippetExists
+    \@@_if_snippet_exists:nT
       { #1 }
       {
         \markdownWarning
-          { Redefined~snippet~\markdownThemeName#1 }
-        \csname markdownSetupSnippet%
-          \markdownThemeName#1\endcsname={#2}
+          { Redefined~snippet~\g_@@_current_theme_tl #1 }
       }
-      {
-        \newtoks\next
-          \next={#2}
-        \expandafter\let\csname markdownSetupSnippet%
-          \markdownThemeName#1\endcsname=\next
-      }
+    \tl_set:NV
+      \l_tmpa_tl
+      \g_@@_current_theme_tl
+    \tl_put_right:Nn
+      \l_tmpa_tl
+      { #1 }
+    \prop_gput:NVn
+      \g_@@_snippets_prop
+      \l_tmpa_tl
+      { #2 }
   }
-\let\markdownSetupSnippet=\@@_setup_snippet:nn
+\cs_gset_eq:NN
+  \markdownSetupSnippet
+  \@@_setup_snippet:nn
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -12183,15 +12189,26 @@ options locally.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\cs_new:Npn
-  \markdownIfSnippetExists
-  #1 #2 #3
+\prg_new_conditional:Nnn
+  \@@_if_snippet_exists:n
+  { TF, T, F }
   {
-    \@ifundefined
-      { markdownSetupSnippet\markdownThemeName#1 }%
-      { #3 }
-      { #2 }
+    \tl_set:NV
+      \l_tmpa_tl
+      \g_@@_current_theme_tl
+    \tl_put_right:Nn
+      \l_tmpa_tl
+      { #1 }
+    \prop_get:NVNTF
+      \g_@@_snippets_prop
+      \l_tmpa_tl
+      \l_tmpb_tl
+      { \prg_return_true: }
+      { \prg_return_false: }
   }
+\cs_gset_eq:NN
+  \markdownIfSnippetExists
+  \@@_if_snippet_exists:nTF
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -12203,18 +12220,32 @@ options locally.
   { markdown/options }
   {
     snippet .code:n = {
-      \markdownIfSnippetExists{#1}
+      \@@_if_snippet_exists:nTF
+        { #1 }
         {
-          \expandafter\markdownSetup\expandafter{
-            \the\csname markdownSetupSnippet
-            \markdownThemeName#1\endcsname}
-        }{
+          \tl_set:NV
+            \l_tmpa_tl
+            \g_@@_current_theme_tl
+          \tl_put_right:Nn
+            \l_tmpa_tl
+            { #1 }
+          \prop_get:NVN
+            \g_@@_snippets_prop
+            \l_tmpa_tl
+            \l_tmpb_tl
+          \@@_setup:V
+            \l_tmpb_tl
+        }
+        {
           \markdownError
-            { Can't~invoke~setup~snippet~#1 }
-            { The~setup~snippet~is~undefined }
+            { Can't~invoke~snippet~\g_@@_current_theme_tl #1 }
+            { The~snippet~is~undefined }
         }
     }
   }
+\cs_generate_variant:Nn
+  \@@_setup:n
+  { V }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
@@ -33068,9 +33099,6 @@ end
       }
   }
   { \markdownEnd }
-\cs_generate_variant:Nn
-  \@@_setup:n
-  { V }
 \ExplSyntaxOff
 \renewenvironment{markdown*}[1]{%
   \markdownWarning{%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12032,7 +12032,7 @@ a specific look and other high-level goals without low-level programming.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \tl_set:Nn
+    \str_set:Nn
       \l_tmpa_str
       { #1 }
     \str_replace_all:Nnn
@@ -21024,7 +21024,7 @@ between \TeX{} formats is unimportant, and scale up to separate theme files
 native to different \TeX{} formats for large multi-format themes, where
 different code is needed for different \TeX{} formats. To enable code reuse,
 developers can load the `.tex` theme file from the `.sty` theme file using the
-\mdef{markdownSuper} command.
+\mdef{markdownSuper} macro.
 
 % If the \LaTeX{} option with keys `theme` or `import` is (repeatedly)
 % specified in the `\usepackage` macro, the loading of the theme(s) will be
@@ -33246,6 +33246,66 @@ end
         }
     \fi
   }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Developers can use the \mref{markdownSuper} macro to load a corresponding
+% plain \TeX{} theme from within a \LaTeX{} theme.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\cs_new:Npn
+  \markdownSuper
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% First, we extract the name of the current theme from the
+% \mref{g_@@_current_theme_tl} macro.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \tl_set:NV
+      \l_tmpa_tl
+      \g_@@_current_theme_tl
+    \tl_reverse:N
+      \l_tmpa_tl
+    \tl_set:Ne
+      \l_tmpb_tl
+      {
+        \tl_tail:V
+          \l_tmpa_tl
+      }
+    \tl_reverse:N
+      \l_tmpb_tl
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Next, we munge the theme name.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \str_set:NV
+      \l_tmpa_str
+      \l_tmpb_tl
+    \str_replace_all:Nnn
+      \l_tmpa_str
+      { / }
+      { _ }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Finally, we load the plain \TeX{} theme.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \@@_load_theme_plain_tex:VV
+      \l_tmpb_tl
+      \l_tmpa_str
+  }
+\cs_generate_variant:Nn
+  \@@_load_theme_plain_tex:nn
+  { VV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.ins
+++ b/markdown.ins
@@ -9,10 +9,10 @@
     \file{markdown.tex}{\from{markdown.dtx}{tex}}
     \file{markdown.sty}{\from{markdown.dtx}{latex}}
     \file{t-markdown.tex}{\from{markdown.dtx}{context}}
-    \file{markdownthemewitiko_dot.sty}{\from{markdown.dtx}{latex-themes-witiko-dot}}
-    \file{markdownthemewitiko_graphicx_http.sty}{\from{markdown.dtx}{latex-themes-witiko-graphicx-http}}
-    \file{markdownthemewitiko_tilde.sty}{\from{markdown.dtx}{latex-themes-witiko-tilde}}
-    \file{markdownthemewitiko_markdown_techdoc.sty}{\from{markdown.dtx}{latex-themes-witiko-markdown-techdoc}}
+    \file{markdownthemewitiko_dot.sty}{\from{markdown.dtx}{themes-witiko-dot}}
+    \file{markdownthemewitiko_graphicx_http.sty}{\from{markdown.dtx}{themes-witiko-graphicx-http}}
+    \file{markdownthemewitiko_tilde.tex}{\from{markdown.dtx}{themes-witiko-tilde}}
+    \file{markdownthemewitiko_markdown_techdoc.sty}{\from{markdown.dtx}{themes-witiko-markdown-techdoc}}
   \usepreamble\empty
   \usepostamble\empty
     \file{markdown.md}{\from{markdown.dtx}{manual}}

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage
   {markdownthemewitiko_markdown_test}%
-  {2023/12/29 A LaTeX theme for the Markdown package that writes used renderers to the log for testing}
+  [2023/12/29 A LaTeX theme for the Markdown package that writes used renderers to the log for testing]
 \markdownLoadPlainTeXTheme

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -22,9 +22,9 @@
 
     % Expand `\markdownSetupSnippet{snippet}{<content of keyval-setup.tex>}`.
     \cs_generate_variant:Nn
-      \__markdown_latex_setup_snippet:nn
+      \__markdown_setup_snippet:nn
       { nV }
-    \__markdown_latex_setup_snippet:nV
+    \__markdown_setup_snippet:nV
       { snippet }
       \l_tmpa_tl
   }

--- a/tests/support/markdownthemewitiko_markdown_test.sty
+++ b/tests/support/markdownthemewitiko_markdown_test.sty
@@ -1,35 +1,5 @@
-\ProvidesExplPackage
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage
   {markdownthemewitiko_markdown_test}%
-  {2023-09-25}{1.0.0}%
-  {A LaTeX theme for the Markdown package that writes used renderers to the log for testing}
-
-\cs_gset:Npn
-  \next
-  {
-    % Read support file `keyval-setup.tex`.
-    \ior_open:Nn
-      \g_tmpa_ior
-      { keyval-setup }
-    \tl_clear:N
-      \l_tmpa_tl
-    \ior_map_inline:Nn
-      \g_tmpa_ior
-      {
-        \tl_put_right:Nn
-          \l_tmpa_tl
-          { ##1 }
-      }
-
-    % Expand `\markdownSetupSnippet{snippet}{<content of keyval-setup.tex>}`.
-    \cs_generate_variant:Nn
-      \__markdown_setup_snippet:nn
-      { nV }
-    \__markdown_setup_snippet:nV
-      { snippet }
-      \l_tmpa_tl
-  }
-
-% Ensure that the support file `keyval-setup.tex` is read
-% with ordinary category codes, not with expl3 category codes.
-\ExplSyntaxOff
-\next
+  {2023/12/29 A LaTeX theme for the Markdown package that writes used renderers to the log for testing}
+\markdownLoadPlainTeXTheme

--- a/tests/support/markdownthemewitiko_markdown_test.tex
+++ b/tests/support/markdownthemewitiko_markdown_test.tex
@@ -1,3 +1,6 @@
+% Load support file `setup.tex` with helper macros.
+\input setup
+
 \ExplSyntaxOn
 
 \cs_gset:Npn
@@ -17,11 +20,12 @@
           { ##1 }
       }
 
-    % Expand `\markdownSetup{<content of keyval-setup.tex>}`.
+    % Expand `\markdownSetupSnippet{snippet}{<content of keyval-setup.tex>}`.
     \cs_generate_variant:Nn
-      \__markdown_setup:n
-      { V }
-    \__markdown_setup:V
+      \__markdown_setup_snippet:nn
+      { nV }
+    \__markdown_setup_snippet:nV
+      { snippet }
       \l_tmpa_tl
   }
 

--- a/tests/support/t-markdownthemewitiko_markdown_test.tex
+++ b/tests/support/t-markdownthemewitiko_markdown_test.tex
@@ -1,10 +1,6 @@
-\module
-  [
-    file=t-markdownthemewitiko_markdown_test.tex,
-    title=A ConTeXt theme for the Markdown package that writes used renderers to the log for testing,
-    date=2023/12/29,
-  ]
+\startmodule[markdownthemewitiko_markdown_test]
 \unprotect
 \markdownLoadPlainTeXTheme
+\stopmodule
 \protect
 \endinput

--- a/tests/support/t-markdownthemewitiko_markdown_test.tex
+++ b/tests/support/t-markdownthemewitiko_markdown_test.tex
@@ -1,0 +1,10 @@
+\module
+  [
+    file=t-markdownthemewitiko_markdown_test.tex,
+    title=A ConTeXt theme for the Markdown package that writes used renderers to the log for testing,
+    date=2023/12/29,
+  ]
+\unprotect
+\markdownLoadPlainTeXTheme
+\protect
+\endinput

--- a/tests/templates/context-mkiv/input/body.tex.m4
+++ b/tests/templates/context-mkiv/input/body.tex.m4
@@ -11,6 +11,6 @@
 \catcode"7E=12%  Tildes (U+007E)
 
 % Perform the test.
-\inputmarkdown{TEST_INPUT_FILENAME}
+\inputmarkdown[snippet=testsnippet]{TEST_INPUT_FILENAME}
 
 \endgroup

--- a/tests/templates/context-mkiv/input/head.tex
+++ b/tests/templates/context-mkiv/input/head.tex
@@ -6,7 +6,10 @@ kpse.set_program_name("luatex")
 \usemodule[t][markdown]
 
 % Load the support files.
-\input setup
-\input plain-setup
+\setupmarkdown[
+  import = {
+    witiko/markdown/test = snippet as testsnippet,
+  }
+]
 
 \starttext

--- a/tests/templates/context-mkiv/verbatim/body.tex.m4
+++ b/tests/templates/context-mkiv/verbatim/body.tex.m4
@@ -11,8 +11,11 @@
 \catcode"7E=12%  Tildes (U+007E)
 
 % Perform the test.
+\begingroup
+\setupmarkdown[snippet=testsnippet]
 \startmarkdown
 undivert(TEST_INPUT_FILENAME)dnl
 \stopmarkdown
+\endgroup
 
 \endgroup

--- a/tests/templates/context-mkiv/verbatim/head.tex
+++ b/tests/templates/context-mkiv/verbatim/head.tex
@@ -6,7 +6,10 @@ kpse.set_program_name("luatex")
 \usemodule[t][markdown]
 
 % Load the support files.
-\input setup
-\input plain-setup
+\setupmarkdown[
+  import = {
+    witiko/markdown/test = snippet as testsnippet,
+  }
+]
 
 \starttext

--- a/tests/templates/latex/input/head.tex
+++ b/tests/templates/latex/input/head.tex
@@ -5,7 +5,6 @@
 \usepackage[plain]{markdown}
 
 % Load the support files.
-\input setup
 \markdownSetup{
   import = {
     witiko/markdown/test = snippet as testSnippet,

--- a/tests/templates/latex/verbatim/head.tex
+++ b/tests/templates/latex/verbatim/head.tex
@@ -5,7 +5,6 @@
 \usepackage[plain]{markdown}
 
 % Load the support files.
-\input setup
 \markdownSetup{
   import = {
     witiko/markdown/test = snippet as testSnippet,

--- a/tests/templates/plain/input/body.tex.m4
+++ b/tests/templates/plain/input/body.tex.m4
@@ -11,6 +11,9 @@
 \catcode"7E=12%  Tildes (U+007E)
 
 % Perform the test.
+\begingroup
+\markdownSetup{snippet=testSnippet}
 \markdownInput{TEST_INPUT_FILENAME}
+\endgroup
 
 \endgroup

--- a/tests/templates/plain/input/head.tex
+++ b/tests/templates/plain/input/head.tex
@@ -2,5 +2,8 @@
 \input markdown
 
 % Load the support files.
-\input setup
-\input plain-setup
+\markdownSetup{
+  import = {
+    witiko/markdown/test = snippet as testSnippet,
+  }
+}

--- a/tests/templates/plain/verbatim/body.tex.m4
+++ b/tests/templates/plain/verbatim/body.tex.m4
@@ -11,8 +11,11 @@
 \catcode"7E=12%  Tildes (U+007E)
 
 % Perform the test.
+\begingroup
+\markdownSetup{snippet=testSnippet}
 \markdownBegin
 undivert(TEST_INPUT_FILENAME)dnl
 \markdownEnd
+\endgroup
 
 \endgroup

--- a/tests/templates/plain/verbatim/head.tex
+++ b/tests/templates/plain/verbatim/head.tex
@@ -2,5 +2,8 @@
 \input markdown
 
 % Load the support files.
-\input setup
-\input plain-setup
+\markdownSetup{
+  import = {
+    witiko/markdown/test = snippet as testSnippet,
+  }
+}


### PR DESCRIPTION
Closes #276.

### Tasks

- [x] Move options `import`/`theme` from LaTeX (Section 2.3.2.3 of the technical documentation) to plain TeX (Section 2.2.2.5).
  - The documentation for options `import`/`theme` was moved in commit 3261f9f2 from this PR.
  - The options `import`/`theme` were moved to the plain TeX interface in commit 8253bb4 from this PR.
- [x] Define function `\@@_load_theme:nn` not only in LaTeX (Section 3.3.2.1 of the technical documentation), but also in plain TeX (new Section 3.2.2).
    - [x] Prevent repeated loading of plain TeX themes.
- [x] Move theme `witiko/tilde` from LaTeX (Section 2.3.2.3 of the technical documentation) to plain TeX (new Section 2.2.2.5).
- [x] Move options `snippet`/`import` from LaTeX (Section 2.3.2.4 of the technical documentation) to plain TeX (new Section 2.2.2.6).
- [x] Move option `code` from LaTeX (Section 3.3.3 of the technical documentation) to plain TeX (Section 2.2.6).
- [x] House-keeping of the technical documentation:
    - [x] Move sections 2.2.2.5 and 2.2.2.6 into higher-level sections 2.2.3 and 2.2.4.
    - [x] Move Section 2.3.2.3 of the technical documentation into a new higher-level Section 2.3.3.
    - [x] Move Section 3.3.2.1 of the technical documentation into a new higher-level Section 3.3.4.
- [x] Add macro `\markdownSuper`, which loads the plain TeX theme from the LaTeX theme.
    The macro `\markdownSuper` was documented in commit 3261f9f2 from this PR.
- [x] Rename `\markdownSuper`, which is a super confusing name, to `\markdownLoadPlainTeXTheme`.
- [x] Log whether a plain TeX or a LaTeX theme is being loaded.
- [x] Add support for ConTeXt themes by analogy with LaTeX themes at this point of the implementation.
- [ ] Move default LaTeX, ConTeXt renderer (prototype) definitions to a new theme `witiko/markdown/defaults`.
- [x] Merge files `plain-setup.tex` and the LaTeX theme `witiko/markdown/test` into plain TeX theme with the same name.
    Create stub ConTeXt and LaTeX themes that use `\markdownLoadPlainTeXTheme` to load the plain TeX theme.

Here are some further remarks:

- [x] After the beginning of a document, loading a theme in LaTeX should emit an error if an `*.sty` file exists and load a `*.tex` file if it exists or emit an error otherwise.