### PR TITLE
Include developer tools in development Docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
     - cron: '30 4 * * MON'
 env:
   DEBIAN_FRONTEND: noninteractive
-  NO_DOCUMENTATION: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == true }}
+  DOCKER_DEV_IMAGE: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == true }}
 jobs:
   shellcheck:
     name: Style check (Bash)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ Documentation:
 - In `README.md`, add a link to a GPT chatbot with background knowledge about
   the Markdown Package for TeX. (59eb04d)
 
+Docker:
+
+- Include developer tools in the development Docker image. (#374)
+
 ## 3.2.0 (2023-10-21)
 
 Development:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,18 @@ ARG DEPENDENCIES="\
     zip \
 "
 
+ARG DEV_DEPENDENCIES="\
+    less \
+    vim \
+"
+
 ARG BINARY_DIR=/usr/local/bin
 ARG BUILD_DIR=/git-repo
 ARG INSTALL_DIR=/usr/local/texlive/texmf-local
 
 ARG FROM_IMAGE=texlive/texlive
 ARG TEXLIVE_TAG=latest
-ARG NO_DOCUMENTATION=false
+ARG DEV_IMAGE=false
 
 FROM $FROM_IMAGE:$TEXLIVE_TAG as build
 
@@ -44,7 +49,7 @@ ARG DEPENDENCIES
 ARG BUILD_DIR
 ARG INSTALL_DIR
 
-ARG NO_DOCUMENTATION
+ARG DEV_IMAGE
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm
@@ -90,7 +95,7 @@ mtxrun --generate
 texhash
 
 # Produce the complete distribution archive of the Markdown package
-make -C ${BUILD_DIR} dist NO_DOCUMENTATION=${NO_DOCUMENTATION}
+make -C ${BUILD_DIR} dist NO_DOCUMENTATION=${DEV_IMAGE}
 mkdir ${BUILD_DIR}/dist
 unzip ${BUILD_DIR}/markdown.tds.zip -d ${BUILD_DIR}/dist
 
@@ -101,10 +106,13 @@ FROM $FROM_IMAGE:$TEXLIVE_TAG
 
 ARG AUXILIARY_FILES
 ARG DEPENDENCIES
+ARG DEV_DEPENDENCIES
 
 ARG BINARY_DIR
 ARG BUILD_DIR
 ARG INSTALL_DIR
+
+ARG DEV_IMAGE
 
 LABEL authors="Vít Starý Novotný <witiko@mail.muni.cz>"
 
@@ -133,6 +141,10 @@ chmod +x ${BINARY_DIR}/markdown-cli
 # Install dependencies, but this time we clean up after ourselves
 apt-get -qy update
 apt-get -qy install --no-install-recommends ${DEPENDENCIES}
+if [ ${DEV_IMAGE} = true ]
+then
+  apt-get -qy install --no-install-recommends ${DEV_DEPENDENCIES}
+fi
 apt-get -qy autoclean
 apt-get -qy clean
 apt-get -qy autoremove --purge

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ LASTMODIFIED=$(shell git log -1 --date=format:%Y-%m-%d --format=%ad)
 ifndef DOCKER_TEXLIVE_TAG
 	DOCKER_TEXLIVE_TAG=latest
 endif
-ifeq ($(NO_DOCUMENTATION), true)
+ifeq ($(DOCKER_DEV_IMAGE), true)
 	DOCKER_TAG_POSTFIX=-no_docs
 endif
 DOCKER_TEMPORARY_IMAGE=ghcr.io/witiko/markdown
@@ -88,7 +88,7 @@ base: $(INSTALLABLES) $(LIBRARIES)
 docker-image:
 	docker pull $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) || \
 	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(DOCKER_TEXLIVE_TAG) \
-	                               --build-arg NO_DOCUMENTATION=$(NO_DOCUMENTATION) \
+	                               --build-arg DEV_IMAGE=$(DOCKER_DEV_IMAGE) \
 	                               -t $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) .
 
 # This pseudo-targed pushes the built witiko/markdown Docker image to


### PR DESCRIPTION
Development is made easier by including developer tools such as `less` and `vim` directly in the development Docker image. This pull request separates the `NO_DOCUMENTATION` Make parameter to `DOCKER_DEV_IMAGE`, which is passed to the `docker build` command and the `NO_DOCUMENTATION` Make parameter, which is set internally by the `Dockerfile`.