### PR TITLE
Correctly produce paragraph separators inside block-level elements

### DIFF
--- a/tests/testfiles/CommonMark_0.30/block_quotes/017.test
+++ b/tests/testfiles/CommonMark_0.30/block_quotes/017.test
@@ -15,7 +15,7 @@
 BEGIN document
 blockQuoteBegin
 emphasis: foo
-interblockSeparator
+paragraphSeparator
 emphasis: bar
 blockQuoteEnd
 END document

--- a/tests/testfiles/CommonMark_0.30/indented_code_blocks/002.test
+++ b/tests/testfiles/CommonMark_0.30/indented_code_blocks/002.test
@@ -17,7 +17,7 @@
 BEGIN document
 ulBegin
 ulItem
-interblockSeparator
+paragraphSeparator
 ulItemEnd
 ulEnd
 END document

--- a/tests/testfiles/CommonMark_0.30/list_items/004.test
+++ b/tests/testfiles/CommonMark_0.30/list_items/004.test
@@ -18,7 +18,7 @@ BEGIN document
 ulBegin
 ulItem
 emphasis: one
-interblockSeparator
+paragraphSeparator
 emphasis: two
 ulItemEnd
 ulEnd

--- a/tests/testfiles/CommonMark_0.30/list_items/006.test
+++ b/tests/testfiles/CommonMark_0.30/list_items/006.test
@@ -18,7 +18,7 @@ BEGIN document
 ulBegin
 ulItem
 emphasis: one
-interblockSeparator
+paragraphSeparator
 emphasis: two
 ulItemEnd
 ulEnd

--- a/tests/testfiles/CommonMark_0.30/list_items/007.test
+++ b/tests/testfiles/CommonMark_0.30/list_items/007.test
@@ -24,7 +24,7 @@ blockQuoteBegin
 olBegin
 olItemWithNumber: 1
 emphasis: one
-interblockSeparator
+paragraphSeparator
 emphasis: two
 olItemEnd
 olEnd

--- a/tests/testfiles/CommonMark_0.30/list_items/010.test
+++ b/tests/testfiles/CommonMark_0.30/list_items/010.test
@@ -19,7 +19,7 @@ BEGIN document
 ulBegin
 ulItem
 emphasis: foo
-interblockSeparator
+paragraphSeparator
 emphasis: bar
 ulItemEnd
 ulEnd

--- a/tests/testfiles/CommonMark_0.30/list_items/025.test
+++ b/tests/testfiles/CommonMark_0.30/list_items/025.test
@@ -18,7 +18,7 @@ BEGIN document
 ulBegin
 ulItem
 emphasis: foo
-interblockSeparator
+paragraphSeparator
 emphasis: bar
 ulItemEnd
 ulEnd

--- a/tests/testfiles/CommonMark_0.30/lists/007.test
+++ b/tests/testfiles/CommonMark_0.30/lists/007.test
@@ -37,7 +37,7 @@ interblockSeparator
 ulBegin
 ulItem
 emphasis: baz
-interblockSeparator
+paragraphSeparator
 emphasis: bim
 ulItemEnd
 ulEnd

--- a/tests/testfiles/CommonMark_0.30/lists/009.test
+++ b/tests/testfiles/CommonMark_0.30/lists/009.test
@@ -30,7 +30,7 @@ BEGIN document
 ulBegin
 ulItem
 emphasis: foo
-interblockSeparator
+paragraphSeparator
 emphasis: notcode
 ulItemEnd
 ulItem

--- a/tests/testfiles/CommonMark_0.30/lists/016.test
+++ b/tests/testfiles/CommonMark_0.30/lists/016.test
@@ -29,7 +29,7 @@ emphasis: a
 ulItemEnd
 ulItem
 emphasis: b
-interblockSeparator
+paragraphSeparator
 emphasis: c
 ulItemEnd
 ulItem

--- a/tests/testfiles/CommonMark_0.30/lists/019.test
+++ b/tests/testfiles/CommonMark_0.30/lists/019.test
@@ -29,7 +29,7 @@ interblockSeparator
 ulBegin
 ulItem
 emphasis: b
-interblockSeparator
+paragraphSeparator
 emphasis: c
 ulItemEnd
 ulEnd

--- a/tests/testfiles/CommonMark_0.30/tabs/004.test
+++ b/tests/testfiles/CommonMark_0.30/tabs/004.test
@@ -17,7 +17,7 @@
 BEGIN document
 ulBegin
 ulItem
-interblockSeparator
+paragraphSeparator
 ulItemEnd
 ulEnd
 END document

--- a/tests/testfiles/Markdown_1.0.3/ordered-and-unordered-lists.test
+++ b/tests/testfiles/Markdown_1.0.3/ordered-and-unordered-lists.test
@@ -248,7 +248,7 @@ interblockSeparator
 interblockSeparator
 olBegin
 olItemWithNumber: 1
-interblockSeparator
+paragraphSeparator
 softLineBreak
 olItemEnd
 olItemWithNumber: 2

--- a/tests/testfiles/lunamark-markdown/fenced-divs.test
+++ b/tests/testfiles/lunamark-markdown/fenced-divs.test
@@ -136,7 +136,7 @@ END fencedDivAttributeContext
 interblockSeparator
 BEGIN fencedDivAttributeContext
 attributeClassName: level2-fewer-colons
-interblockSeparator
+paragraphSeparator
 END fencedDivAttributeContext
 interblockSeparator
 BEGIN fencedDivAttributeContext

--- a/tests/testfiles/lunamark-markdown/no-slice.test
+++ b/tests/testfiles/lunamark-markdown/no-slice.test
@@ -1,6 +1,14 @@
-\markdownSetup{headerAttributes=true}
+\markdownSetup{
+  hashEnumerators=true,
+  definitionLists=true,
+  notes=true,
+  inlineNotes=true,
+  smartEllipses=true,
+  contentBlocks=true,
+  headerAttributes=true,
+}
 <<<
-This test ensures that the Lua `slice` option processes the entire document by
+This test ensures that omitting the Lua `slice` option processes the entire document by
 default.
 
 This is an H1
@@ -87,9 +95,9 @@ Term 1
 *Term 2*
 
 :   Definition 2
-
+    
         Some code, part of Definition 2
-
+    
     Third paragraph of Definition 2.
 
 :   Definition 3
@@ -117,14 +125,14 @@ Here is a note reference[^1] and another.[^longnote]
 Here is an inline note.^[Inlines notes are easier to
 write, since you don't have to pick an identifier and
 move down to type the note.]
-
+  
 [^1]: Here is the note.
 
 [^longnote]: Here's one with multiple blocks.
-
+  
     Subsequent paragraphs are indented to show that they
 belong to the previous note.
-
+  
         Some code
 
     The whole paragraph can be indented, or just the first
@@ -156,6 +164,7 @@ interblockSeparator
 BEGIN section
 headingSix: This is an H6
 interblockSeparator
+ellipsis
 interblockSeparator
 thematicBreak
 interblockSeparator
@@ -173,8 +182,13 @@ BEGIN image
 - URI: example-image.pdf
 - title: An example image from Martin Scharrer's mwe package
 END image
-paragraphSeparator
-paragraphSeparator
+interblockSeparator
+BEGIN contentBlock
+- suffix: csv
+- URI: scientists.csv
+- title: The great minds of the 19th century rendered via a content block
+END contentBlock
+interblockSeparator
 interblockSeparator
 BEGIN fencedCode
 - src: ./_markdown_test/4b6b6e5629f4aa0fcfcb9164fca2efa3.verbatim
@@ -195,7 +209,7 @@ interblockSeparator
 interblockSeparator
 ulBegin
 ulItem
-interblockSeparator
+paragraphSeparator
 ulItemEnd
 ulItem
 ulItemEnd
@@ -216,7 +230,7 @@ interblockSeparator
 interblockSeparator
 olBegin
 olItemWithNumber: 5
-interblockSeparator
+paragraphSeparator
 olItemEnd
 olItemWithNumber: 6
 olItemEnd
@@ -224,15 +238,17 @@ olItemWithNumber: 7
 olItemEnd
 olEnd
 interblockSeparator
-paragraphSeparator
-hash
 interblockSeparator
-inputVerbatim: ./_markdown_test/a0fd6fe345e26edf18c330d18cdf4d52.verbatim
-interblockSeparator
-hash
-softLineBreak
-hash
+olBegin
+olItemWithNumber: 1
 paragraphSeparator
+olItemEnd
+olItemWithNumber: 2
+olItemEnd
+olItemWithNumber: 3
+olItemEnd
+olEnd
+interblockSeparator
 interblockSeparator
 olBeginTight
 olItemWithNumber: 5
@@ -243,28 +259,46 @@ olItemWithNumber: 7
 olItemEnd
 olEndTight
 interblockSeparator
-paragraphSeparator
-hash
-softLineBreak
-hash
-softLineBreak
-hash
-paragraphSeparator
-paragraphSeparator
-paragraphSeparator
-paragraphSeparator
-emphasis: Term 2
-paragraphSeparator
 interblockSeparator
-inputVerbatim: ./_markdown_test/c268833f99a7a4a12803144b445357da.verbatim
+olBeginTight
+olItemWithNumber: 1
+olItemEnd
+olItemWithNumber: 2
+olItemEnd
+olItemWithNumber: 3
+olItemEnd
+olEndTight
 interblockSeparator
-paragraphSeparator
-paragraphSeparator
-softLineBreak
-softLineBreak
-emphasis: Term 2
-softLineBreak
-softLineBreak
+interblockSeparator
+dlBegin
+dlItem: Term 1
+dlDefinitionBegin
+dlDefinitionEnd
+dlItemEnd
+dlItem: (emphasis: Term 2)
+dlDefinitionBegin
+interblockSeparator
+inputVerbatim: ./_markdown_test/990a3431517de9eac439b71b42999658.verbatim
+interblockSeparator
+dlDefinitionEnd
+dlDefinitionBegin
+dlDefinitionEnd
+dlItemEnd
+dlEnd
+interblockSeparator
+interblockSeparator
+dlBeginTight
+dlItem: Term 1
+dlDefinitionBegin
+dlDefinitionEnd
+dlItemEnd
+dlItem: (emphasis: Term 2)
+dlDefinitionBegin
+dlDefinitionEnd
+dlDefinitionBegin
+dlDefinitionEnd
+dlItemEnd
+dlEndTight
 interblockSeparator
 END section
 BEGIN section
@@ -278,21 +312,10 @@ blockQuoteEnd
 interblockSeparator
 blockQuoteEnd
 interblockSeparator
-circumflex
-circumflex
+note: Here is the note.
+note: Here's one with multiple blocks.(paragraphSeparator)Subsequent paragraphs are indented to show that they(softLineBreak)belong to the previous note.(interblockSeparator)(inputVerbatim: ./_markdown_test/c92b3efa18315dd3d2ff8cccfb5a26a0.verbatim)(interblockSeparator)The whole paragraph can be indented, or just the first(softLineBreak)line.  In this way, multi-paragraph notes work like(softLineBreak)multi-paragraph list items.
 softLineBreak
-circumflex
-softLineBreak
-softLineBreak
-paragraphSeparator
-circumflex
-paragraphSeparator
-circumflex
-interblockSeparator
-inputVerbatim: ./_markdown_test/abbf8dcafba2274ed2400ea0c2d432ff.verbatim
-interblockSeparator
-interblockSeparator
-inputVerbatim: ./_markdown_test/3372369b5571c25af4e3298ee616142e.verbatim
+note: Inlines notes are easier to write, since you don't have to pick an identifier and move down to type the note.
 END section
 END section
 END document

--- a/tests/testfiles/lunamark-markdown/paragraph-separators.test
+++ b/tests/testfiles/lunamark-markdown/paragraph-separators.test
@@ -1,21 +1,218 @@
+\markdownSetup{fencedDivs=true}
 <<<
 This test ensures that paragraph separators and interblock separators
 are produced where appropriate.
 
-Two markdown *paragraphs* are
+Two markdown paragraphs are
 
-*always separated by a paragraph separator*
+always separated by a paragraph separator
 
 
-*no matter how many blank lines* in between.
+no matter how many blank lines in between.
 
+Here is a list surrounded by interblock separators:
+
+- first item
+- second item
+
+Here is a list with a paragraph separator above it:
+
+
+- first item
+- second item
+
+Here is a list with a paragraph separator below it:
+
+- first item
+- second item
+
+
+Here is a list with a paragraph separator from both sides:
+
+
+- first item
+- second item
+
+
+Paragraph separators should work the same way inside block-level elements such
+as blockquotes and lists:
+
+> first paragraph
+>
+> second paragraph
+>
+>
+> third paragraph
+>
+> - list item
+> - list item
+>
+>
+> 1. list item
+> 2. list item
+
+::: fenced-div
+first paragraph
+
+second paragraph
+
+
+third paragraph
+
+- list item
+- list item
+
+
+1. list item
+2. list item
+:::
+
+- first paragraph
+
+  second paragraph
+
+
+  third paragraph
+
+  - list item
+  - list item
+
+
+  1. list item
+  2. list item
+
+1. first paragraph
+
+   second paragraph
+
+
+   third paragraph
+
+   - list item
+   - list item
+
+
+   1. list item
+   2. list item
 >>>
 BEGIN document
 softLineBreak
 paragraphSeparator
-emphasis: paragraphs
 paragraphSeparator
-emphasis: always separated by a paragraph separator
 paragraphSeparator
-emphasis: no matter how many blank lines
+paragraphSeparator
+interblockSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+interblockSeparator
+paragraphSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+interblockSeparator
+interblockSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+paragraphSeparator
+paragraphSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+paragraphSeparator
+softLineBreak
+interblockSeparator
+blockQuoteBegin
+paragraphSeparator
+paragraphSeparator
+interblockSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+paragraphSeparator
+olBeginTight
+olItemWithNumber: 1
+olItemEnd
+olItemWithNumber: 2
+olItemEnd
+olEndTight
+blockQuoteEnd
+interblockSeparator
+BEGIN fencedDivAttributeContext
+attributeClassName: fenced-div
+paragraphSeparator
+paragraphSeparator
+interblockSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+paragraphSeparator
+olBeginTight
+olItemWithNumber: 1
+olItemEnd
+olItemWithNumber: 2
+olItemEnd
+olEndTight
+END fencedDivAttributeContext
+interblockSeparator
+ulBegin
+ulItem
+paragraphSeparator
+paragraphSeparator
+interblockSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+paragraphSeparator
+olBeginTight
+olItemWithNumber: 1
+olItemEnd
+olItemWithNumber: 2
+olItemEnd
+olEndTight
+ulItemEnd
+ulEnd
+interblockSeparator
+olBegin
+olItemWithNumber: 1
+paragraphSeparator
+paragraphSeparator
+interblockSeparator
+ulBeginTight
+ulItem
+ulItemEnd
+ulItem
+ulItemEnd
+ulEndTight
+paragraphSeparator
+olBeginTight
+olItemWithNumber: 1
+olItemEnd
+olItemWithNumber: 2
+olItemEnd
+olEndTight
+olItemEnd
+olEnd
 END document

--- a/tests/testfiles/lunamark-markdown/slice-two-sections.test
+++ b/tests/testfiles/lunamark-markdown/slice-two-sections.test
@@ -205,7 +205,7 @@ interblockSeparator
 interblockSeparator
 ulBegin
 ulItem
-interblockSeparator
+paragraphSeparator
 ulItemEnd
 ulItem
 ulItemEnd
@@ -226,7 +226,7 @@ interblockSeparator
 interblockSeparator
 olBegin
 olItemWithNumber: 5
-interblockSeparator
+paragraphSeparator
 olItemEnd
 olItemWithNumber: 6
 olItemEnd
@@ -237,7 +237,7 @@ interblockSeparator
 interblockSeparator
 olBegin
 olItemWithNumber: 1
-interblockSeparator
+paragraphSeparator
 olItemEnd
 olItemWithNumber: 2
 olItemEnd

--- a/tests/testfiles/lunamark-markdown/task-lists.test
+++ b/tests/testfiles/lunamark-markdown/task-lists.test
@@ -7,13 +7,13 @@ the plain TeX interface.
 - [] *another item without a tickbox*
 - [      ] *an item with an unticked box*
 
-    1. [x]     *a loose nested item with a ticked box*
+    1. [x]     *a nested item with a ticked box*
 
-    2. *a loose nested item without a tickbox*
+    2. *a nested item without a tickbox*
 
        [x] *here is a new paragraph, but still no tickbox*
 
-    3. [X] *here is loose nested item with a ticked box*
+    3. [X] *here is nested item with a ticked box*
 
     4. *some item with a Unicode unticked box ☐*
     5. *some item with a Unicode half-ticked box ⌛*
@@ -54,16 +54,16 @@ interblockSeparator
 olBegin
 olItemWithNumber: 1
 tickedBox
-emphasis: a loose nested item with a ticked box
+emphasis: a nested item with a ticked box
 olItemEnd
 olItemWithNumber: 2
-emphasis: a loose nested item without a tickbox
-interblockSeparator
+emphasis: a nested item without a tickbox
+paragraphSeparator
 emphasis: here is a new paragraph, but still no tickbox
 olItemEnd
 olItemWithNumber: 3
 tickedBox
-emphasis: here is loose nested item with a ticked box
+emphasis: here is nested item with a ticked box
 olItemEnd
 olItemWithNumber: 4
 emphasis: some item with a Unicode unticked box (untickedBox)


### PR DESCRIPTION
This PR adds regression tests for the issue reported in #376.

@lostenderman's bugfix should be based on the code from this PR.