### PR TITLE
Make ConTeXt command `\inputmarkdown` properly process extra options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 3.3.0
 
+Fixes:
+
+- Make ConTeXt command `\inputmarkdown` properly process extra options.
+  (#389, #390, contributed by @ibotty)
+
 Documentation:
 
 - Improve the discoverability of the `\markdownInput` macro.

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -58,8 +58,10 @@ kpse.set_program_name("luatex")
 \starttext
 
 % Typeset the document `example.md` by letting the Markdown package handle
-% the conversion internally.
-\inputmarkdown{./example.md}
+% the conversion internally. Optionally, we can specify additional options
+% between the square brackets similarly to the command `\setupmarkdown`.
+% Unlike `\setupmarkdown`, the options will only apply for this document.
+\inputmarkdown[smart_ellipses = yes]{./example.md}
 
 % Typeset the document `example.tex` that we prepared separately using the
 % Lua command-line interface and that contains a plain TeX representation

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34553,7 +34553,7 @@ end
 \long\def\doinputmarkdown[#1]#2{%
   \begingroup
     \iffirstargument
-      \setupmarkdown{#1}%
+      \setupmarkdown[#1]%
     \fi
     \markdownInput{#2}%
   \endgroup}%


### PR DESCRIPTION
As reported by @ibotty in #389, the command `\inputmarkdown` from the ConTeXt module for the Markdown package fails to properly process an optional argument with extra options. This pull request fixes the issue.