### PR TITLE
Separate default token renderer prototype definitions to a universal theme `witiko/markdown/defaults`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 3.4.0
+
+Development:
+
+- Separate default token renderer prototype definitions to a universal theme
+  `witiko/markdown/defaults`. (#391, #392)
+
 ## 3.3.0 (2023-12-30)
 
 Development:

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,20 +73,23 @@ mtxrun --generate
 # Install the Markdown package
 make -C ${BUILD_DIR} implode
 make -C ${BUILD_DIR} base
-mkdir -p                                               ${INSTALL_DIR}/tex/luatex/markdown/
-cp ${BUILD_DIR}/markdown.lua                           ${INSTALL_DIR}/tex/luatex/markdown/
-cp ${BUILD_DIR}/libraries/markdown-tinyyaml.lua        ${INSTALL_DIR}/tex/luatex/markdown/
-mkdir -p                                               ${INSTALL_DIR}/scripts/markdown/
-cp ${BUILD_DIR}/markdown-cli.lua                       ${INSTALL_DIR}/scripts/markdown/
-mkdir -p                                               ${INSTALL_DIR}/tex/generic/markdown/
-cp ${BUILD_DIR}/markdown.tex                           ${INSTALL_DIR}/tex/generic/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_tilde.tex          ${INSTALL_DIR}/tex/generic/markdown/
-mkdir -p                                               ${INSTALL_DIR}/tex/latex/markdown/
-cp ${BUILD_DIR}/markdown.sty                           ${INSTALL_DIR}/tex/latex/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_dot.sty            ${INSTALL_DIR}/tex/latex/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_graphicx_http.sty  ${INSTALL_DIR}/tex/latex/markdown/
-mkdir -p                                               ${INSTALL_DIR}/tex/context/third/markdown/
-cp ${BUILD_DIR}/t-markdown.tex                         ${INSTALL_DIR}/tex/context/third/markdown/
+mkdir -p                                                     ${INSTALL_DIR}/tex/luatex/markdown/
+cp ${BUILD_DIR}/markdown.lua                                 ${INSTALL_DIR}/tex/luatex/markdown/
+cp ${BUILD_DIR}/libraries/markdown-tinyyaml.lua              ${INSTALL_DIR}/tex/luatex/markdown/
+mkdir -p                                                     ${INSTALL_DIR}/scripts/markdown/
+cp ${BUILD_DIR}/markdown-cli.lua                             ${INSTALL_DIR}/scripts/markdown/
+mkdir -p                                                     ${INSTALL_DIR}/tex/generic/markdown/
+cp ${BUILD_DIR}/markdown.tex                                 ${INSTALL_DIR}/tex/generic/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_tilde.tex                ${INSTALL_DIR}/tex/generic/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_markdown_defaults.tex    ${INSTALL_DIR}/tex/generic/markdown/
+mkdir -p                                                     ${INSTALL_DIR}/tex/latex/markdown/
+cp ${BUILD_DIR}/markdown.sty                                 ${INSTALL_DIR}/tex/latex/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_dot.sty                  ${INSTALL_DIR}/tex/latex/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_graphicx_http.sty        ${INSTALL_DIR}/tex/latex/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_markdown_defaults.sty    ${INSTALL_DIR}/tex/latex/markdown/
+mkdir -p                                                     ${INSTALL_DIR}/tex/context/third/markdown/
+cp ${BUILD_DIR}/t-markdown.tex                               ${INSTALL_DIR}/tex/context/third/markdown/
+cp ${BUILD_DIR}/t-markdownthemewitiko_markdown_defaults.tex  ${INSTALL_DIR}/tex/context/third/markdown/
 
 # Generate the ConTeXt file database
 mtxrun --generate

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ DOCUMENTATION=$(TECHNICAL_DOCUMENTATION) $(HTML_USER_MANUAL) $(ROOT_README) $(VE
 LIBRARIES=libraries/markdown-tinyyaml.lua
 INSTALLABLES=markdown.lua markdown-cli.lua markdown.tex markdown.sty t-markdown.tex \
   markdownthemewitiko_dot.sty markdownthemewitiko_graphicx_http.sty \
-  markdownthemewitiko_tilde.tex
+  markdownthemewitiko_tilde.tex markdownthemewitiko_markdown_defaults.tex \
+	markdownthemewitiko_markdown_defaults.sty t-markdownthemewitiko_markdown_defaults.tex
 EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES)
 MAKEABLES=$(TECHNICAL_DOCUMENTATION) $(USER_MANUAL) $(INSTALLABLES) $(EXAMPLES)
 RESOURCES=$(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(EXAMPLES) \
@@ -214,10 +215,12 @@ $(TDSARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(INSTALLABLES) $(DOCUMENTATION) $(EXA
 	  tex/context/third/markdown scripts/markdown
 	cp markdown.lua $(LIBRARIES) tex/luatex/markdown/
 	cp markdown-cli.lua scripts/markdown/
+	cp markdown.tex markdownthemewitiko_tilde.tex \
+	  markdownthemewitiko_markdown_defaults.tex tex/generic/markdown/
 	cp markdown.sty markdownthemewitiko_graphicx_http.sty markdownthemewitiko_dot.sty \
-	  tex/latex/markdown/
-	cp markdown.tex markdownthemewitiko_tilde.tex tex/generic/markdown/
-	cp t-markdown.tex tex/context/third/markdown/
+	  markdownthemewitiko_markdown_defaults.sty tex/latex/markdown/
+	cp t-markdown.tex t-markdownthemewitiko_markdown_defaults.tex \
+	  tex/context/third/markdown/
 	@# Installing the documentation.
 	mkdir -p doc/generic/markdown doc/latex/markdown/examples \
 	  doc/context/third/markdown/examples doc/optex/markdown/examples

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1240,7 +1240,7 @@ local uni_algos = require("lua-uni-algos")
 % The following packages are soft prerequisites. They are only used to provide
 % default token renderer prototypes (see sections
 % <#sec:texrendererprototypes> and
-% <#sec:latex-default-renderer-prototypes>) or \LaTeX{} themes (see Section
+% <#sec:latex-token-renderer-prototypes>) or \LaTeX{} themes (see Section
 % <#sec:latexthemes>) and will not be loaded if the `plain` package option
 % has been enabled (see Section <#sec:latexplain>):
 %
@@ -12139,7 +12139,7 @@ following text, where the middot (`·`) denotes a non-breaking space:
      with the package and explicitly loading it has no effect.
 
 % Please, see Section <#sec:themes-implementation> for implementation
-% details of the built-in themes.
+% details of the built-in plain \TeX{} themes.
 
 ### Snippets {#snippets}
 
@@ -21314,7 +21314,7 @@ following image:
 % \begin{markdown}
 %
 % Please, see Section <#sec:latex-themes-implementation> for implementation
-% details of the built-in themes.
+% details of the built-in \LaTeX{} themes.
 %
 % \Hologo{ConTeXt} Interface {#contextinterface}
 %----------------------------
@@ -21606,6 +21606,9 @@ Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
 %<*manual-options>
 % \fi
 % \begin{markdown}
+%
+% Please, see Section <#sec:context-themes-implementation> for implementation
+% details of the built-in \Hologo{ConTeXt} themes.
 %
 % Implementation {#implementation}
 %================
@@ -32053,7 +32056,8 @@ end
 %### Themes {#themes-implementation}
 %
 % This section implements the theme-loading mechanism and the built-in themes
-% provided with the Markdown package.
+% provided with the Markdown package. Futhermore, this section also implements
+% the built-in plain \TeX{} themes provided with the Markdown package.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -33334,7 +33338,7 @@ end
 %
 % This section overrides the plain \TeX{} implementation of the theme-loading
 % mechanism from Section <#sec:themes-implementation>. Futhermore, this section
-% also implements the built-in themes provided with the Markdown package.
+% also implements the built-in \LaTeX{} themes provided with the Markdown package.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -33639,8 +33643,8 @@ end
 % \begin{markdown}
 %
 % The `witiko/markdown/defaults` \LaTeX{} theme provides default definitions
-% for token renderer prototypes. First, the theme loads the plain \TeX{}
-% theme with the default definitions for plain \TeX{}:
+% for token renderer prototypes. First, the \LaTeX{} theme loads the plain
+% \TeX{} theme with the default definitions for plain \TeX{}:
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -33650,10 +33654,10 @@ end
 % \begin{markdown}
 %
 % Next, the \LaTeX{} theme overrides some of the plain \TeX{} definitions.
-% See Section <#sec:latex-default-renderer-prototypes> for the actual
+% See Section <#sec:latex-token-renderer-prototypes> for the actual
 % definitions.
 %
-%### Token Renderer Prototypes {#latex-default-renderer-prototypes}
+%### Token Renderer Prototypes {#latex-token-renderer-prototypes}
 %
 % The following configuration should be considered placeholder. If the `plain`
 % package option has been enabled (see Section <#sec:latexplain>), none of
@@ -34969,10 +34973,12 @@ end
 % \par
 % \begin{markdown}
 %
-%### Themes
+%### Themes {#context-themes-implementation}
 %
 % This section overrides the plain \TeX{} implementation of the theme-loading
-% mechanism from Section <#sec:themes-implementation>.
+% mechanism from Section <#sec:themes-implementation>. Futhermore, this section
+% also implements the built-in \Hologo{ConTeXt} themes provided with the
+% Markdown package.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -35006,10 +35012,33 @@ end
       }
   }
 \ExplSyntaxOff
+\stopmodule
+\protect
 %    \end{macrocode}
+% \iffalse
+%</context>
+%<*themes-witiko-markdown-defaults-context>
+% \fi
+% \par
 % \begin{markdown}
 %
-%### Token Renderer Prototypes
+% The `witiko/markdown/defaults` \Hologo{ConTeXt} theme provides default
+% definitions for token renderer prototypes. First, the \Hologo{ConTeXt} theme
+% loads the plain \TeX{} theme with the default definitions for plain \TeX{}:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\markdownLoadPlainTeXTheme
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Next, the \Hologo{ConTeXt} theme overrides some of the plain \TeX{} definitions.
+% See Section <#sec:context-token-renderer-prototypes> for the actual
+% definitions.
+%
+%### Token Renderer Prototypes {#context-token-renderer-prototypes}
+%
 % The following configuration should be considered placeholder.
 %
 % \end{markdown}
@@ -35301,5 +35330,5 @@ end
 \protect
 %    \end{macrocode}
 % \iffalse
-%</context>
+%</themes-witiko-markdown-defaults-context>
 % \fi

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -972,15 +972,19 @@ make base
 ``````
 This should produce the following files:
 
-* `markdown.lua`, the Lua module,
-* `libraries/markdown-tinyyaml.lua`, an external library for reading \acro{yaml},
-* `markdown-cli.lua`, the Lua command-line interface,
-* `markdown.tex`, the plain \TeX{} macro package,
-* `markdown.sty`, the \LaTeX{} package,
-* `markdownthemewitiko_dot.sty`, the `witiko/dot` \LaTeX{} theme,
-* `markdownthemewitiko_graphicx_http.sty`, the `witiko/graphicx/http` \LaTeX{} theme,
-* `markdownthemewitiko_tilde.tex`, the `witiko/tilde` \LaTeX{} theme, and
-* `t-markdown.tex`, the \Hologo{ConTeXt} module.
+* `markdown.lua`: The Lua module
+* `libraries/markdown-tinyyaml.lua`: An external library for reading \acro{yaml}
+* `markdown-cli.lua`: The Lua command-line interface
+* `markdown.tex`: The plain \TeX{} macro package
+* `markdown.sty`: The \LaTeX{} package
+* `markdownthemewitiko_dot.sty`: The `witiko/dot` \LaTeX{} theme
+* `markdownthemewitiko_graphicx_http.sty`: The `witiko/graphicx/http` \LaTeX{} theme
+* `markdownthemewitiko_tilde.tex`: The `witiko/tilde` theme
+* `markdownthemewitiko_markdown_defaults.tex`,
+  `markdownthemewitiko_markdown_defaults.sty`, and
+  `t-markdownthemewitiko_markdown_defaults.tex`: The `witiko/markdown/defaults`
+  theme
+* `t-markdown.tex`: The \Hologo{ConTeXt} module
 
 ### Local Installation
 
@@ -992,11 +996,14 @@ placed:
 * `⟨TEXMF⟩/tex/luatex/markdown/markdown-tinyyaml.lua`
 * `⟨TEXMF⟩/scripts/markdown/markdown-cli.lua`
 * `⟨TEXMF⟩/tex/generic/markdown/markdown.tex`
+* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_tilde.tex`
+* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_markdown_defaults.tex`
 * `⟨TEXMF⟩/tex/latex/markdown/markdown.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_dot.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_graphicx_http.sty`
-* `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_tilde.tex`
+* `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_markdown_defaults.sty`
 * `⟨TEXMF⟩/tex/context/third/markdown/t-markdown.tex`
+* `⟨TEXMF⟩/tex/context/third/markdown/t-markdownthemewitiko_markdown_defaults.tex`
 
 where `⟨TEXMF⟩` corresponds to a root of your \TeX{} distribution, such as
 `/usr/share/texmf` and `~/texmf` on UN\*X systems or
@@ -1016,10 +1023,13 @@ This is where the individual files should be placed:
 * `./markdown-cli.lua`
 * `./markdown/markdown.tex`
 * `./markdown.sty`
+* `./t-markdown.tex`
 * `./markdownthemewitiko_dot.sty`
 * `./markdownthemewitiko_graphicx_http.sty`
 * `./markdownthemewitiko_tilde.tex`
-* `./t-markdown.tex`
+* `./markdownthemewitiko_markdown_defaults.tex`
+* `./markdownthemewitiko_markdown_defaults.sty`
+* `./t-markdownthemewitiko_markdown_defaults.tex`
 
 %</manual>
 %<*lua>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21291,6 +21291,23 @@ following image:
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-graphicx-http>
+%<*themes-witiko-markdown-defaults-latex>
+% \fi
+% \par
+% \begin{markdown}
+
+\pkg{witiko/markdown/defaults}
+
+:    A theme with the default definitions of token renderer prototypes for
+     plain \TeX{}. This theme is loaded automatically together with the package
+     and explicitly loading it has no effect.
+
+% \end{markdown}
+%  \begin{macrocode}
+\ProvidesPackage{markdownthemewitiko_markdown_defaults}[2024/01/03]%
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-markdown-defaults-latex>
 %<*context>
 % \fi
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21075,7 +21075,6 @@ would use the following code in the preamble of your document:
 %  \begin{macrocode}
 \newif\ifmarkdownLaTeXLoaded
   \markdownLaTeXLoadedfalse
-\AtEndOfPackage{\markdownLaTeXLoadedtrue}
 %    \end{macrocode}
 % \iffalse
 %</latex>
@@ -21291,7 +21290,7 @@ following image:
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-graphicx-http>
-%<*themes-witiko-markdown-defaults-latex>
+%<*manual-options>
 % \fi
 % \par
 % \begin{markdown}
@@ -21303,6 +21302,20 @@ following image:
      package and explicitly loading it has no effect.
 
 % \end{markdown}
+% \iffalse
+%</manual-options>
+%<*latex>
+% \fi
+%  \begin{macrocode}
+\AtEndOfPackage{
+  \markdownLaTeXLoadedtrue
+  \markdownSetup{theme=witiko/markdown/defaults}
+}
+%    \end{macrocode}
+% \iffalse
+%</latex>
+%<*themes-witiko-markdown-defaults-latex>
+% \fi
 %  \begin{macrocode}
 \ProvidesPackage{markdownthemewitiko_markdown_defaults}[2024/01/03]%
 %    \end{macrocode}
@@ -21555,7 +21568,7 @@ following text:
 %    \end{macrocode}
 % \iffalse
 %</context>
-%<*themes-witiko-markdown-defaults-context>
+%<*manual-options>
 % \fi
 % \begin{markdown}
 
@@ -21597,6 +21610,10 @@ Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
      with the package and explicitly loading it has no effect.
 
 % \end{markdown}
+% \iffalse
+%</manual-options>
+%<*themes-witiko-markdown-defaults-context>
+% \fi
 %  \begin{macrocode}
 \startmodule[markdownthemewitiko_markdown_defaults]
 \unprotect
@@ -32610,6 +32627,26 @@ end
 % \fi
 % \begin{markdown}
 %
+% If plain \TeX{} is the top layer, we load the `witiko/markdown/defaults`
+% plain \TeX{} theme with the default definitions for token renderer
+% prototypes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\str_if_eq:VVT
+  \c_@@_top_layer_tl
+  \c_@@_option_layer_plain_tex_tl
+  {
+    \ExplSyntaxOff
+    \@@_setup:n
+      {theme = witiko/markdown/defaults}
+    \ExplSyntaxOn
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+%
 %### Lua Snippets
 % After the \mdef{markdownPrepareLuaOptions} macro has been fully expanded,
 % the \mdef{markdownLuaOptions} macro will expands to a Lua table that
@@ -35012,8 +35049,6 @@ end
       }
   }
 \ExplSyntaxOff
-\stopmodule
-\protect
 %    \end{macrocode}
 % \iffalse
 %</context>
@@ -35331,4 +35366,21 @@ end
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-markdown-defaults-context>
+%<*context>
+% \fi
+% \par
+% \begin{markdown}
+%
+% At the end of the \Hologo{ConTeXt} implementation, we load the
+% The `witiko/markdown/defaults` \Hologo{ConTeXt} theme with the default
+% definitions for token renderer prototypes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\setupmarkdown[theme=witiko/markdown/defaults]
+\stopmodule
+\protect
+%    \end{macrocode}
+% \iffalse
+%</context>
 % \fi

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12087,7 +12087,7 @@ a specific look and other high-level goals without low-level programming.
 % \par
 % \begin{markdown}
 
-Example themes provided with the Markdown package include:
+Built-in plain \TeX{} themes provided with the Markdown package include:
 
 \pkg{witiko/tilde}
 
@@ -21091,7 +21091,7 @@ beginning of a \LaTeX{} document.
 % \par
 % \markdownBegin
 
-Example themes provided with the Markdown package include:
+Built-in \LaTeX{} themes provided with the Markdown package include:
 
 \pkg{witiko/dot}
 
@@ -21555,7 +21555,7 @@ following text:
 %    \end{macrocode}
 % \iffalse
 %</context>
-%<*manual-options>
+%<*themes-witiko-markdown-defaults-context>
 % \fi
 % \begin{markdown}
 
@@ -21588,6 +21588,25 @@ For example, to load a theme named `witiko/tilde` in your document:
 \setupmarkdown[import=witiko/tilde]
 ```````
 
+Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
+
+\pkg{witiko/markdown/defaults}
+
+:    A \Hologo{ConTeXt} theme with the default definitions of token renderer
+     prototypes for plain \TeX{}. This theme is loaded automatically together
+     with the package and explicitly loading it has no effect.
+
+% \end{markdown}
+%  \begin{macrocode}
+\startmodule[markdownthemewitiko_markdown_defaults]
+\unprotect
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-markdown-defaults-context>
+%<*manual-options>
+% \fi
+% \begin{markdown}
+%
 % Implementation {#implementation}
 %================
 %
@@ -35278,7 +35297,8 @@ end
   \markdownRendererInputRawBlockPrototype
   \markdownRendererInputRawInlinePrototype
 \ExplSyntaxOff
-\stopmodule\protect
+\stopmodule
+\protect
 %    \end{macrocode}
 % \iffalse
 %</context>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12134,9 +12134,9 @@ following text, where the middot (`·`) denotes a non-breaking space:
 
 \pkg{witiko/markdown/defaults}
 
-:    A theme with the default definitions of token renderer prototypes for
-     plain \TeX{}. This theme is loaded automatically together with the package
-     and explicitly loading it has no effect.
+:    A plain \TeX{} theme with the default definitions of token renderer
+     prototypes for plain \TeX{}. This theme is loaded automatically together
+     with the package and explicitly loading it has no effect.
 
 % Please, see Section <#sec:themes-implementation> for implementation
 % details of the built-in themes.
@@ -21298,9 +21298,9 @@ following image:
 
 \pkg{witiko/markdown/defaults}
 
-:    A theme with the default definitions of token renderer prototypes for
-     plain \TeX{}. This theme is loaded automatically together with the package
-     and explicitly loading it has no effect.
+:    A \LaTeX{} theme with the default definitions of token renderer prototypes
+     for plain \TeX{}. This theme is loaded automatically together with the
+     package and explicitly loading it has no effect.
 
 % \end{markdown}
 %  \begin{macrocode}
@@ -32164,8 +32164,8 @@ end
 % \fi
 % \begin{markdown}
 %
-% The `witiko/markdown/defaults` theme provides default definitions
-% for token renderer prototypes. See Section
+% The `witiko/markdown/defaults` plain \TeX{} theme provides default
+% definitions for token renderer prototypes. See Section
 % <#sec:tex-token-renderer-prototypes> for the actual definitions.
 %
 %### Token Renderer Prototypes {#tex-token-renderer-prototypes}
@@ -33614,10 +33614,25 @@ end
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-graphicx-http>
-%<*latex>
+%<*themes-witiko-markdown-defaults-latex>
 % \fi
 % \par
 % \begin{markdown}
+%
+% The `witiko/markdown/defaults` \LaTeX{} theme provides default definitions
+% for token renderer prototypes. First, the theme loads the plain \TeX{}
+% theme with the default definitions for plain \TeX{}:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\markdownLoadPlainTeXTheme
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Next, the \LaTeX{} theme overrides some of the plain \TeX{} definitions.
+% See Section <#sec:latex-default-renderer-prototypes> for the actual
+% definitions.
 %
 %### Token Renderer Prototypes {#latex-default-renderer-prototypes}
 %
@@ -34806,8 +34821,12 @@ end
       }
   }
 \ExplSyntaxOff
-\fi % Closes `\markdownIfOption{Plain}{\iffalse}{iftrue}`
+\fi % Closes `\markdownIfOption{Plain}{\iffalse}{\iftrue}`
 %    \end{macrocode}
+% \iffalse
+%</themes-witiko-markdown-defaults-latex>
+%<*latex>
+% \fi
 % \par
 % \begin{markdown}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12131,7 +12131,13 @@ following text, where the middot (`·`) denotes a non-breaking space:
 % \fi
 % \par
 % \begin{markdown}
-%
+
+\pkg{witiko/markdown/defaults}
+
+:    A theme with the default definitions of token renderer prototypes for
+     plain \TeX{}. This theme is loaded automatically together with the package
+     and explicitly loading it has no effect.
+
 % Please, see Section <#sec:themes-implementation> for implementation
 % details of the example themes.
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12139,7 +12139,7 @@ following text, where the middot (`·`) denotes a non-breaking space:
      and explicitly loading it has no effect.
 
 % Please, see Section <#sec:themes-implementation> for implementation
-% details of the example themes.
+% details of the built-in themes.
 
 ### Snippets {#snippets}
 
@@ -20952,7 +20952,7 @@ other packages used in a document.  Additionally, if we redefine token
 renderers and renderer prototypes ourselves, the default definitions will bring
 no benefit to us. Using the `plain` package option, we can keep the default
 definitions from the plain \TeX{} implementation
-% (see Section <#sec:tex-token-renderer-prototypes>)
+% (see Section <#sec:themes-implementation>)
 and prevent the soft \LaTeX{} prerequisites
 % in Section <#sec:latex-prerequisites>
 from being loaded: The plain option must be set before or when loading the
@@ -21314,7 +21314,7 @@ following image:
 % \begin{markdown}
 %
 % Please, see Section <#sec:latex-themes-implementation> for implementation
-% details of the example themes.
+% details of the built-in themes.
 %
 % \Hologo{ConTeXt} Interface {#contextinterface}
 %----------------------------
@@ -32033,7 +32033,7 @@ end
 %
 %### Themes {#themes-implementation}
 %
-% This section implements the theme-loading mechanism and the example themes
+% This section implements the theme-loading mechanism and the built-in themes
 % provided with the Markdown package.
 %
 % \end{markdown}
@@ -32160,9 +32160,13 @@ end
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-tilde>
-%<*tex>
+%<*themes-witiko-markdown-defaults-tex>
 % \fi
 % \begin{markdown}
+%
+% The `witiko/markdown/defaults` theme provides default definitions
+% for token renderer prototypes. See Section
+% <#sec:tex-token-renderer-prototypes> for the actual definitions.
 %
 %### Token Renderer Prototypes {#tex-token-renderer-prototypes}
 %
@@ -32342,7 +32346,7 @@ end
 % \par
 % \begin{markdown}
 %
-%#### YAML Metadata Renderer Prototypes {#expl3-yaml-metadata-implementation}
+%#### YAML Metadata Renderer Prototypes
 %
 % To keep track of the current type of structure we inhabit when we are
 % traversing a \acro{yaml} document, we will maintain the
@@ -32577,6 +32581,10 @@ end
 }
 \ExplSyntaxOff
 %    \end{macrocode}
+% \iffalse
+%</themes-witiko-markdown-defaults-tex>
+%<*tex>
+% \fi
 % \begin{markdown}
 %
 %### Lua Snippets
@@ -33307,7 +33315,7 @@ end
 %
 % This section overrides the plain \TeX{} implementation of the theme-loading
 % mechanism from Section <#sec:themes-implementation>. Futhermore, this section
-% also implements the example themes provided with the Markdown package.
+% also implements the built-in themes provided with the Markdown package.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.ins
+++ b/markdown.ins
@@ -12,6 +12,9 @@
     \file{markdownthemewitiko_dot.sty}{\from{markdown.dtx}{themes-witiko-dot}}
     \file{markdownthemewitiko_graphicx_http.sty}{\from{markdown.dtx}{themes-witiko-graphicx-http}}
     \file{markdownthemewitiko_tilde.tex}{\from{markdown.dtx}{themes-witiko-tilde}}
+    \file{markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-tex}}
+    \file{markdownthemewitiko_markdown_defaults.sty}{\from{markdown.dtx}{themes-witiko-markdown-defaults-latex}}
+    \file{t-markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-context}}
     \file{markdownthemewitiko_markdown_techdoc.sty}{\from{markdown.dtx}{themes-witiko-markdown-techdoc}}
   \usepreamble\empty
   \usepostamble\empty

--- a/tests/support/t-markdownthemewitiko_markdown_test.tex
+++ b/tests/support/t-markdownthemewitiko_markdown_test.tex
@@ -3,4 +3,3 @@
 \markdownLoadPlainTeXTheme
 \stopmodule
 \protect
-\endinput


### PR DESCRIPTION
Closes #391.

### Tasks

- [x] Add new tags for the plain TeX, LaTeX, ConTeXt, and OpTeX theme `witiko/markdown/defaults` to `markdown.ins`.
- [x] Document and implement the theme in subsections *Themes* of sections *Interface* and *Implementation*.
- [x] Update `Makefile`, `Dockerfile`, and `markdown.dtx` with instructions for packaging and installing the files of the theme.
- [x] Update `CHANGES.md`