### PR TITLE
Do not unnecessarily override math renderer prototypes in LaTeX/ConTeXt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@ Development:
 - Add format-independent options `noDefaults` and `plain`, which control the
   loading of theme `witiko/markdown/defaults`. (#393, #394)
 
+Default Renderer Prototypes:
+
+- Do not unnecessarily override math renderer prototypes in LaTeX/ConTeXt.
+  (#387, #396, contributed by @zousiyu1995)
+
 ## 3.3.0 (2023-12-30)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34138,8 +34138,6 @@ end
 \markdownSetup{rendererPrototypes={
   superscript = {\textsuperscript{#1}},
   subscript = {\textsubscript{#1}},
-  displayMath = {\begin{displaymath}#1\end{displaymath}},
-  inlineMath = {\begin{math}#1\end{math}},
   blockQuoteBegin = {\begin{quotation}},
   blockQuoteEnd = {\end{quotation}},
   inputVerbatim = {\VerbatimInput{#1}},
@@ -35295,7 +35293,6 @@ end
 \def\markdownRendererSuperscriptPrototype#1{\high{#1}}
 \def\markdownRendererSubscriptPrototype#1{\low{#1}}
 \def\markdownRendererDisplayMathPrototype#1{\startformula#1\stopformula}%
-\def\markdownRendererInlineMathPrototype#1{$#1$}%
 %    \end{macrocode}
 % \par
 % \begin{markdown}


### PR DESCRIPTION
Fixes #387.