### PR TITLE
Deprecate `\markdownInfo`, `\markdownWarning`, and `\markdownError`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,11 @@ jobs:
           repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+      - name: Set safe Git directory
+        # This should have been done by the previous step.
+        # See also: <https://github.com/actions/checkout/issues/915>.
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Test Lua command-line interface
         run: |
           set -ex

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ Deprecation:
   `\markdownError` with l3msg functions and deprecate `\markdownInfo`,
   `\markdownWarning`, and `\markdownError`. (#383, #398)
 
+Docker:
+
+- Uninstall the distribution Markdown package. (258a73d4)
+
 ## 3.3.0 (2023-12-30)
 
 Development:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@ Default Renderer Prototypes:
 
 Unit Tests:
 
-- In pull requests, process added and modified testfiles first. (feafe9b9)
+- In pull requests, process added and modified testfiles first.
+  (feafe9b9, 9ff530da)
 
 Deprecation:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ Default Renderer Prototypes:
 Unit Tests:
 
 - In pull requests, process added and modified testfiles first.
-  (feafe9b9, 9ff530da)
+  (feafe9b9, 9ff530da, 18deae73)
 
 Deprecation:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,12 @@ Unit Tests:
 
 - In pull requests, process added and modified testfiles first. (feafe9b9)
 
+Deprecation:
+
+- Replace all instances of `\markdownInfo`, `\markdownWarning`, and
+  `\markdownError` with l3msg functions and deprecate `\markdownInfo`,
+  `\markdownWarning`, and `\markdownError`. (#383, #398)
+
 ## 3.3.0 (2023-12-30)
 
 Development:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ARG DEV_DEPENDENCIES="\
 ARG BINARY_DIR=/usr/local/bin
 ARG BUILD_DIR=/git-repo
 ARG INSTALL_DIR=/usr/local/texlive/texmf-local
+ARG PREINSTALLED_DIR=/usr/local/texlive/*/texmf-dist
 
 ARG FROM_IMAGE=texlive/texlive
 ARG TEXLIVE_TAG=latest
@@ -48,6 +49,7 @@ ARG DEPENDENCIES
 
 ARG BUILD_DIR
 ARG INSTALL_DIR
+ARG PREINSTALLED_DIR
 
 ARG DEV_IMAGE
 
@@ -70,7 +72,14 @@ apt-get -qy install --no-install-recommends ${DEPENDENCIES}
 # Generate the ConTeXt file database
 mtxrun --generate
 
-# Install the Markdown package
+# Uninstall the distribution Markdown package
+rm -rfv ${PREINSTALLED_DIR}/tex/luatex/markdown/
+rm -rfv ${PREINSTALLED_DIR}/scripts/markdown/
+rm -rfv ${PREINSTALLED_DIR}/tex/generic/markdown/
+rm -rfv ${PREINSTALLED_DIR}/tex/latex/markdown/
+rm -rfv ${PREINSTALLED_DIR}/tex/context/third/markdown/
+
+# Install the current Markdown package
 make -C ${BUILD_DIR} implode
 make -C ${BUILD_DIR} base
 mkdir -p                                                     ${INSTALL_DIR}/tex/luatex/markdown/
@@ -114,6 +123,7 @@ ARG DEV_DEPENDENCIES
 ARG BINARY_DIR
 ARG BUILD_DIR
 ARG INSTALL_DIR
+ARG PREINSTALLED_DIR
 
 ARG DEV_IMAGE
 
@@ -122,6 +132,21 @@ LABEL authors="Vít Starý Novotný <witiko@mail.muni.cz>"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm
 ENV TEXMFLOCAL=${INSTALL_DIR}
+
+RUN <<EOF
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+# Uninstall the distribution Markdown package
+rm -rfv ${PREINSTALLED_DIR}/tex/luatex/markdown/
+rm -rfv ${PREINSTALLED_DIR}/scripts/markdown/
+rm -rfv ${PREINSTALLED_DIR}/tex/generic/markdown/
+rm -rfv ${PREINSTALLED_DIR}/tex/latex/markdown/
+rm -rfv ${PREINSTALLED_DIR}/tex/context/third/markdown/
+
+EOF
 
 # Install the Markdown package
 COPY --from=build ${BUILD_DIR}/dist ${INSTALL_DIR}/
@@ -151,7 +176,7 @@ fi
 apt-get -qy autoclean
 apt-get -qy clean
 apt-get -qy autoremove --purge
-rm -rf ${AUXILIARY_FILES}
+rm -rfv ${AUXILIARY_FILES}
 
 # Generate the ConTeXt file database
 mtxrun --generate

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20729,6 +20729,10 @@ following text:
 % text. You may redefine these macros to redirect and process the info,
 % warning, and error messages.
 %
+% The \mref{markdownInfo}, \mref{markdownWarning}, and \mref{markdownError}
+% macros have been deprecated and will be removed in the next major version of
+% the Markdown package.
+%
 %### Miscellanea
 % The \mdef{markdownMakeOther} macro is used by the package, when a \TeX{}
 % engine that does not support direct Lua access is starting to buffer a text.

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12177,17 +12177,19 @@ a specific look and other high-level goals without low-level programming.
       { #1 }
       { / }
       {
-        \markdownError
-        { Won't~load~theme~with~unqualified~name~#1 }
-        { Theme~names~must~contain~at~least~one~forward~slash }
+        \msg_error:nnn
+          { markdown }
+          { unqualified-theme-name }
+          { #1 }
       }
     \str_if_in:nnT
       { #1 }
       { _ }
       {
-        \markdownError
-        { Won't~load~theme~with~an~underscore~in~its~name~#1 }
-        { Theme~names~must~not~contain~underscores~in~their~names }
+        \msg_error:nnn
+          { markdown }
+          { underscores-in-theme-name }
+          { #1 }
       }
 %    \end{macrocode}
 % \begin{markdown}
@@ -12229,6 +12231,16 @@ a specific look and other high-level goals without low-level programming.
       \g_@@_current_theme_tl
       \l_tmpa_tl
   }
+\msg_new:nnnn
+  { markdown }
+  { unqualified-theme-name }
+  { Won't~load~theme~with~unqualified~name~#1 }
+  { Theme~names~must~contain~at~least~one~forward~slash }
+\msg_new:nnnn
+  { markdown }
+  { underscores-in-theme-name }
+  { Won't~load~theme~with~an~underscore~in~its~name~#1 }
+  { Theme~names~must~not~contain~underscores~in~their~names }
 \cs_generate_variant:Nn
   \tl_replace_all:Nnn
   { NnV }
@@ -12327,15 +12339,10 @@ options locally.
     \tl_if_empty:nT
       { #1 }
       {
-        \markdownError
-          { Empty~snippet~name }
-          { Pick~a~non-empty~name~for~your~snippet }
-      }
-    \@@_if_snippet_exists:nT
-      { #1 }
-      {
-        \markdownWarning
-          { Redefined~snippet~\g_@@_current_theme_tl #1 }
+        \msg_error:nnn
+          { markdown }
+          { empty-snippet-name }
+          { #1 }
       }
     \tl_set:NV
       \l_tmpa_tl
@@ -12343,6 +12350,14 @@ options locally.
     \tl_put_right:Nn
       \l_tmpa_tl
       { #1 }
+    \@@_if_snippet_exists:nT
+      { #1 }
+      {
+        \msg_warning:nnV
+          { markdown }
+          { redefined-snippet }
+          \l_tmpa_tl
+      }
     \prop_gput:NVn
       \g_@@_snippets_prop
       \l_tmpa_tl
@@ -12351,6 +12366,15 @@ options locally.
 \cs_gset_eq:NN
   \markdownSetupSnippet
   \@@_setup_snippet:nn
+\msg_new:nnnn
+  { markdown }
+  { empty-snippet-name }
+  { Empty~snippet~name~#1 }
+  { Pick~a~non-empty~name~for~your~snippet }
+\msg_new:nnn
+  { markdown }
+  { redefined-snippet }
+  { Redefined~snippet~#1 }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -12390,15 +12414,15 @@ options locally.
   { markdown/options }
   {
     snippet .code:n = {
+      \tl_set:NV
+        \l_tmpa_tl
+        \g_@@_current_theme_tl
+      \tl_put_right:Nn
+        \l_tmpa_tl
+        { #1 }
       \@@_if_snippet_exists:nTF
         { #1 }
         {
-          \tl_set:NV
-            \l_tmpa_tl
-            \g_@@_current_theme_tl
-          \tl_put_right:Nn
-            \l_tmpa_tl
-            { #1 }
           \prop_get:NVN
             \g_@@_snippets_prop
             \l_tmpa_tl
@@ -12407,12 +12431,17 @@ options locally.
             \l_tmpb_tl
         }
         {
-          \markdownError
-            { Can't~invoke~snippet~\g_@@_current_theme_tl #1 }
-            { The~snippet~is~undefined }
+          \msg_error:nnV
+            { markdown }
+            { undefined-snippet }
+            \l_tmpa_tl
         }
     }
   }
+\msg_new:nnn
+  { markdown }
+  { undefined-snippet }
+  { Can't~invoke~undefined~snippet~#1 }
 \cs_generate_variant:Nn
   \@@_setup:n
   { V }
@@ -32195,15 +32224,17 @@ end
       { #1 }
       \l_tmpa_tl
       {
-        \markdownInfo
-          {
-            Plain~TeX~Markdown~theme~#1~was~previously~
-            loaded~on~line~\l_tmpa_tl,~not~loading~it~again
-          }
+        \msg_warning:nnnV
+          { markdown }
+          { repeatedly-loaded-plain-tex-theme }
+          { #1 }
+          \l_tmpa_tl
       }
       {
-        \markdownInfo
-          { Loading~plain~TeX~Markdown~theme~#1 }
+        \msg_info:nnn
+          { markdown }
+          { loading-plain-tex-theme }
+          { #1 }
         \prop_gput:Nnx
           \g_@@_plain_tex_loaded_themes_linenos_prop
           { #1 }
@@ -32211,6 +32242,17 @@ end
         \file_input:n
           { markdown theme #2 }
       }
+  }
+\msg_new:nnn
+  { markdown }
+  { loading-plain-tex-theme }
+  { Loading~plain~TeX~Markdown~theme~#1 }
+\msg_new:nnn
+  { markdown }
+  { repeatedly-loaded-plain-tex-theme }
+  {
+    Plain~TeX~Markdown~theme~#1~was~previously~
+    loaded~on~line~#2,~not~loading~it~again
   }
 \cs_generate_variant:Nn
   \prop_gput:Nnn
@@ -33396,14 +33438,27 @@ end
       }
   }
   { \markdownEnd }
+\renewenvironment
+  { markdown* }
+  [ 1 ]
+  {
+    \msg_warning:nnn
+      { markdown }
+      { latex-markdown-star-deprecated }
+      { #1 }
+    \@@_setup:n
+      { #1 }
+    \markdownReadAndConvert@markdown *
+  }
+  { \markdownEnd }
+\msg_new:nnn
+  { markdown }
+  { latex-markdown-star-deprecated }
+  {
+    The~markdown*~LaTeX~environment~has~been~deprecated~and~will~
+    be~removed~in~the~next~major~version~of~the~Markdown~package.
+  }
 \ExplSyntaxOff
-\renewenvironment{markdown*}[1]{%
-  \markdownWarning{%
-    The markdown* LaTeX environment has been deprecated and will
-    be removed in the next major version of the Markdown package.}%
-  \markdownSetup{#1}%
-  \markdownReadAndConvert@markdown*}{%
-  \markdownEnd}%
 \begingroup
 %    \end{macrocode}
 % \begin{markdown}
@@ -33471,9 +33526,10 @@ end
         \file_if_exist:nTF
           { markdown theme #2.sty }
           {
-            \markdownError
-              { Cannot~load~file~markdown theme #2.sty~after~preamble }
-              { Load~Markdown~theme~#1~before~\begin{document} }
+            \msg_error:nnn
+              { markdown }
+              { latex-theme-after-preamble }
+              { #1 }
           }
           {
             \@@_plain_tex_load_theme:nn
@@ -33493,8 +33549,10 @@ end
         \file_if_exist:nTF
           { markdown theme #2.sty }
           {
-            \markdownInfo
-              { Loading~LaTeX~Markdown~theme~#1 }
+            \msg_info:nnn
+              { markdown }
+              { loading-latex-theme }
+              { #1 }
             \RequirePackage
               { markdown theme #2 }
           }
@@ -33513,11 +33571,10 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-      \markdownInfo
-        {
-          Postponing~loading~Markdown~theme~#1~until~
-          Markdown~package~has~finished~loading
-        }
+      \msg_info:nnn
+        { markdown }
+        { theme-loading-postponed }
+        { #1 }
       \AtEndOfPackage
         {
           \@@_load_theme:nn
@@ -33526,6 +33583,43 @@ end
         }
     \fi
   }
+\msg_new:nnn
+  { markdown }
+  { theme-loading-postponed }
+  {
+    Postponing~loading~Markdown~theme~#1~until~
+    Markdown~package~has~finished~loading
+  }
+\msg_new:nnn
+  { markdown }
+  { loading-latex-theme }
+  { Loading~LaTeX~Markdown~theme~#1 }
+\cs_generate_variant:Nn
+  \msg_new:nnnn
+  { nnVV }
+\tl_set:Nn
+  \l_tmpa_tl
+  { Cannot~load~LaTeX~Markdown~theme~#1~after~ }
+\tl_put_right:NV
+  \l_tmpa_tl
+  \c_backslash_str
+\tl_put_right:Nn
+  \l_tmpa_tl
+  { begin{document} }
+\tl_set:Nn
+  \l_tmpb_tl
+  { Load~Markdown~theme~#1~before~ }
+\tl_put_right:NV
+  \l_tmpb_tl
+  \c_backslash_str
+\tl_put_right:Nn
+  \l_tmpb_tl
+  { begin{document} }
+\msg_new:nnVV
+  { markdown }
+  { latex-theme-after-preamble }
+  \l_tmpa_tl
+  \l_tmpb_tl
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}
@@ -35098,8 +35192,10 @@ end
     \file_if_exist:nTF
       { t - markdown theme #2.tex }
       {
-        \markdownInfo
-          { Loading~ConTeXt~Markdown~theme~#1 }
+        \msg_info:nnn
+          { markdown }
+          { loading-context-theme }
+          { #1 }
         \usemodule
           [ t ]
           [ markdown theme #2 ]
@@ -35110,6 +35206,10 @@ end
           { #2 }
       }
   }
+\msg_new:nnn
+  { markdown }
+  { loading-context-theme }
+  { Loading~ConTeXt~Markdown~theme~#1 }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,6 +11,7 @@ import logging
 from logging import getLogger
 from math import ceil
 from multiprocessing import Pool, cpu_count
+import os
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, List, NamedTuple, Optional, Set, Tuple, TypeVar
 from shutil import copyfile, rmtree
@@ -695,6 +696,7 @@ def format_testfile(testfile: TestFile) -> str:
 def get_added_and_modified_paths(repo_path=Path('..'), main_branch='origin/main'):
     added_paths, modified_paths = set(), set()
     try:
+        os.system('git config --global --add safe.directory /__w/markdown/markdown')  # XXX: Remove me
         repo = Repo(str(repo_path))
         main_commit = repo.commit(main_branch)
         diffs = main_commit.diff(repo.head.commit)

--- a/tests/test.py
+++ b/tests/test.py
@@ -692,11 +692,11 @@ def format_testfile(testfile: TestFile) -> str:
 
 
 @cache
-def get_added_and_modified_paths(repo_path=Path('..')):
+def get_added_and_modified_paths(repo_path=Path('..'), main_branch='origin/main'):
     added_paths, modified_paths = set(), set()
     try:
         repo = Repo(str(repo_path))
-        main_commit = repo.commit('main')
+        main_commit = repo.commit(main_branch)
         diffs = main_commit.diff(repo.head.commit)
 
         for diff in diffs:


### PR DESCRIPTION
Closes #383.

### Tasks
- [x] Replace all instances of `\markdownInfo`, `\markdownWarning`, and `\markdownError` with l3msg functions.
- [x] Deprecate `\markdownInfo`, `\markdownWarning`, and `\markdownError`