### PR TITLE
Add support for TeX Live 2024 pretest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,9 +121,11 @@ jobs:
         texlive:
           - TL2022-historic
           - latest
+          - latest-pretest
     outputs:
       TL2022-historic: ${{ steps.temporary-tags.outputs.TL2022-historic }}
       latest: ${{ steps.temporary-tags.outputs.latest }}
+      latest-pretest: ${{ steps.temporary-tags.outputs.latest-pretest }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -162,6 +164,7 @@ jobs:
         texlive:
           - TL2022-historic
           - latest
+          - latest-pretest
     runs-on: self-hosted
     container:
       image: ghcr.io/witiko/markdown:${{ needs.build-docker-image.outputs[matrix.texlive] }}
@@ -196,6 +199,7 @@ jobs:
         texlive:
           - TL2022-historic
           - latest
+          - latest-pretest
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
     env:
@@ -223,6 +227,7 @@ jobs:
         texlive:
           - TL2022-historic
           - latest
+          - latest-pretest
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ Deprecation:
   `\markdownError` with l3msg functions and deprecate `\markdownInfo`,
   `\markdownWarning`, and `\markdownError`. (#383, #398, e3ca682c)
 
+Docker:
+
+- Add support for TeX Live 2024 pretest. (#404, #406)
+
 ## 3.4.0 (2024-01-31)
 
 Development:

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,13 @@ LASTMODIFIED=$(shell git log -1 --date=format:%Y-%m-%d --format=%ad)
 ifndef DOCKER_TEXLIVE_TAG
 	DOCKER_TEXLIVE_TAG=latest
 endif
+ifeq ($(DOCKER_TEXLIVE_TAG), latest-pretest)
+	DOCKER_FROM_IMAGE=witiko/texlive-pretest
+	DOCKER_FROM_TAG=latest
+else
+	DOCKER_FROM_IMAGE=texlive/texlive
+	DOCKER_FROM_TAG=$(DOCKER_TEXLIVE_TAG)
+endif
 ifeq ($(DOCKER_DEV_IMAGE), true)
 	DOCKER_TAG_POSTFIX=-no_docs
 endif
@@ -88,7 +95,8 @@ base: $(INSTALLABLES) $(LIBRARIES)
 # This pseudo-target builds a witiko/markdown Docker image.
 docker-image:
 	docker pull $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) || \
-	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(DOCKER_TEXLIVE_TAG) \
+	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(DOCKER_FROM_TAG) \
+	                               --build-arg FROM_IMAGE=$(DOCKER_FROM_IMAGE) \
 	                               --build-arg DEV_IMAGE=$(DOCKER_DEV_IMAGE) \
 	                               -t $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) .
 


### PR DESCRIPTION
This PR adds TeX Live 2024 pretest to the GitHub Actions configuration file. Closes #404.