### PR TITLE
Use image `texlive/texlive:pretest` rather than `witiko/texlive-pretest` and update TeX Live packages in non-historic Docker images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Deprecation:
 
 Docker:
 
-- Add support for TeX Live 2024 pretest. (#404, #406, e51738ba)
+- Add support for TeX Live 2024 pretest. (#404, #406, e51738ba, #410)
 
 ## 3.4.0 (2024-01-31)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,12 @@ set -o nounset
 set -o xtrace
 
 # Update packages in non-historic TeX Live versions
-if echo ${TEXLIVE_TAG} | grep -qv historic
+if echo ${TEXLIVE_TAG} | grep -q latest
 then
   tlmgr update --self --all
+elif echo ${TEXLIVE_TAG} | grep -q pretest
+then
+  tlmgr update --self --all --repository ftp://ftp.cstug.cz/pub/tex/local/tlpretest/
 fi
 
 # Install dependencies
@@ -148,9 +151,12 @@ set -o nounset
 set -o xtrace
 
 # Update packages in non-historic TeX Live versions
-if echo ${TEXLIVE_TAG} | grep -qv historic
+if echo ${TEXLIVE_TAG} | grep -q latest
 then
   tlmgr update --self --all
+elif echo ${TEXLIVE_TAG} | grep -q pretest
+then
+  tlmgr update --self --all --repository ftp://ftp.cstug.cz/pub/tex/local/tlpretest/
 fi
 
 # Uninstall the distribution Markdown package

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ ARG BUILD_DIR
 ARG INSTALL_DIR
 ARG PREINSTALLED_DIR
 
+ARG TEXLIVE_TAG
 ARG DEV_IMAGE
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -64,6 +65,12 @@ RUN <<EOF
 set -o errexit
 set -o nounset
 set -o xtrace
+
+# Update packages in non-historic TeX Live versions
+if echo ${TEXLIVE_TAG} | grep -qv historic
+then
+  tlmgr update --self --all
+fi
 
 # Install dependencies
 apt-get -qy update
@@ -125,6 +132,7 @@ ARG BUILD_DIR
 ARG INSTALL_DIR
 ARG PREINSTALLED_DIR
 
+ARG TEXLIVE_TAG
 ARG DEV_IMAGE
 
 LABEL authors="Vít Starý Novotný <witiko@mail.muni.cz>"
@@ -138,6 +146,12 @@ RUN <<EOF
 set -o errexit
 set -o nounset
 set -o xtrace
+
+# Update packages in non-historic TeX Live versions
+if echo ${TEXLIVE_TAG} | grep -qv historic
+then
+  tlmgr update --self --all
+fi
 
 # Uninstall the distribution Markdown package
 rm -rfv ${PREINSTALLED_DIR}/tex/luatex/markdown/

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,6 @@ LASTMODIFIED=$(shell git log -1 --date=format:%Y-%m-%d --format=%ad)
 ifndef DOCKER_TEXLIVE_TAG
 	DOCKER_TEXLIVE_TAG=latest
 endif
-ifeq ($(DOCKER_TEXLIVE_TAG), pretest)
-	DOCKER_FROM_IMAGE=witiko/texlive-pretest
-	DOCKER_FROM_TAG=latest
-else
-	DOCKER_FROM_IMAGE=texlive/texlive
-	DOCKER_FROM_TAG=$(DOCKER_TEXLIVE_TAG)
-endif
 ifeq ($(DOCKER_DEV_IMAGE), true)
 	DOCKER_TAG_POSTFIX=-no_docs
 endif
@@ -95,8 +88,7 @@ base: $(INSTALLABLES) $(LIBRARIES)
 # This pseudo-target builds a witiko/markdown Docker image.
 docker-image:
 	docker pull $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) || \
-	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(DOCKER_FROM_TAG) \
-	                               --build-arg FROM_IMAGE=$(DOCKER_FROM_IMAGE) \
+	DOCKER_BUILDKIT=1 docker build --pull --build-arg TEXLIVE_TAG=$(DOCKER_TEXLIVE_TAG) \
 	                               --build-arg DEV_IMAGE=$(DOCKER_DEV_IMAGE) \
 	                               -t $(DOCKER_TEMPORARY_IMAGE):$(DOCKER_TEMPORARY_TAG) .
 


### PR DESCRIPTION
Continues #404.