### PR TITLE
Revert Polyglossia fix

### DIFF
--- a/examples/latex-luatex.tex
+++ b/examples/latex-luatex.tex
@@ -1,15 +1,5 @@
 \documentclass{book}
 \usepackage{polyglossia}
-% work around a bug in polyglossia
-\makeatletter
-\ExplSyntaxOn
-\pretocmd\xpg@set@alias@values{%
-	\prop_if_exist:cF { xpg@alias@keyvals@#1@#4 }
-	{ \prop_new:c {xpg@alias@keyvals@#1@#4} }
-}{}{}
-\ExplSyntaxOff
-\makeatother
-% end of workaround
 \setmainlanguage{english}
 \usepackage{fontspec}
 \usepackage{booktabs}


### PR DESCRIPTION
This PR reverts commit a7cff81dfdb55857b64f2daa326bab6f52c112a9. The commit fixed a bug from https://github.com/reutenauer/polyglossia/issues/626, which has now been fixed on CTAN. This PR continues #411.