### PR TITLE
In `\begin{markdown}[options]`, allow a new line before `options`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 3.4.2
 
+Fixes:
+
+- In `\begin{markdown}[options]`, allow a new line before `options`.
+  (#414, #415)
+
 Contributed Software:
 
 - Add `contributions/istqb_product_base`. (8e727c9b)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -33732,7 +33732,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
     \peek_regex_replace_once:nnF
-      { \ *\[([^]]*)\][^\r]* }
+      { \ *\[\r*([^]]*)\][^\r]* }
       {
 %    \end{macrocode}
 % \begin{markdown}

--- a/tests/templates/latex/verbatim/body.tex.m4
+++ b/tests/templates/latex/verbatim/body.tex.m4
@@ -11,7 +11,9 @@
 \catcode"7E=12%  Tildes (U+007E)
 
 % Perform the test.
-\begin{markdown}[snippet=testSnippet]
+\begin{markdown}[
+  snippet=testSnippet,
+]
 undivert(TEST_INPUT_FILENAME)dnl
 \end{markdown}
 


### PR DESCRIPTION
Closes #414.