### PR TITLE
Remove `<mroot>` from MathML in user manual

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Documentation:
 
 - Add slides from the defense of projects MUNI/33/1654/2022 and
   MUNI/33/1658/2022 to `README.md`. (49f01ccf)
+- Remove `<mroot>` from MathML in the user manual. (#420, #422,
+  contributed by @quark67)
 
 Contributed Software:
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1881,7 +1881,7 @@ following text:
 
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -1924,7 +1924,7 @@ following text:
 
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -1977,7 +1977,7 @@ following text:
 
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -7157,7 +7157,7 @@ following text:
 
 > \$\\sqrt {-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -7199,7 +7199,7 @@ following text:
 
 > \$\\sqrt {-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -7231,7 +7231,7 @@ following text:
 
 > \$\\sqrt {-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -7263,7 +7263,7 @@ following text:
 
 > \$\\sqrt {-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -7295,7 +7295,7 @@ following text:
 
 > \$\\sqrt {-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -11298,7 +11298,7 @@ following text:
 
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -14083,7 +14083,7 @@ following text:
 >
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -14124,7 +14124,7 @@ following text:
 >
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -14161,7 +14161,7 @@ following text:
 >
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -21053,7 +21053,7 @@ following text:
 
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 
@@ -21674,7 +21674,7 @@ following text:
 
 > \$\\sqrt{-1}\$ *equals* \$i\$.
 >
-> <math><mroot><msqrt><mo>−</mo><mn>1</mn></msqrt></mroot></math>
+> <math><msqrt><mo>−</mo><mn>1</mn></msqrt></math>
 > *equals*
 > <math><mi>i</mi></math>.
 


### PR DESCRIPTION
As discussed by @quark67 in <https://github.com/Witiko/markdown/issues/420#issue-2182548509>.