### PR TITLE
Support incremental definitions of token renderers and renderer prototypes in the `\markdownSetup` command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## 3.5.0
 
+Development:
+
+- Support incremental definitions of token renderers and renderer prototypes
+  in the `\markdownSetup` command. (#232, #435, [matrix.org][matrix-435])
+
+ [matrix-435]: https://matrix.to/#/!UeAwznpYwwsinVTetR:matrix.org/$k4ky6I-uvxdp8ipVlHvef5JXfIfPQvFtXOAD_ogF2uU?via=matrix.org&via=im.f3l.de
+
 Default Renderer Prototypes:
 
 - Add default renderers for unnumbered sections in LaTeX.

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20259,7 +20259,36 @@ following text:
 % \par
 % \begin{markdown}
 %
-% <!-- TODO: Document appending to renderer prototypes. -->
+% Besides defining renderers at once, we can also define them incrementally
+% using the appending operator (`+=`). This can be especially useful in
+% defining rules for processing different \acro{HTML} class names and
+% identifiers:
+% ``` tex
+% \markdownSetup{
+%   renderers = {
+%     \% Start with empty renderer prototypes.
+%     headerAttributeContextBegin = {},
+%     attributeClassName = {},
+%     attributeIdentifier = {},
+%     \% Define the processing of a single specific HTML class name.
+%     headerAttributeContextBegin += {
+%       \markdownSetup{
+%         renderers = {
+%           attributeClassName += {...},
+%         },
+%       }
+%     },
+%     \% Define the processing of a single specific HTML attribute.
+%     headerAttributeContextBegin += {
+%       \markdownSetup{
+%         renderers = {
+%           attributeIdentifier += {...},
+%         },
+%       }
+%     },
+%   },
+% }
+% ```````
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -20292,13 +20321,13 @@ following text:
 % \par
 % \begin{markdown}
 %
-% In addition to exact token renderer names, we also support wildcards
-% and enumerations that match multiple token renderer names:
+% In addition to exact token renderer names, we also support wildcards (`*`)
+% and enumerations ('|') that match multiple token renderer names:
 % ``` tex
 % \markdownSetup{
 %   renderers = {
 %     heading* = {{\bf #1}},    \% Render headings using the bold face.
-%     jekyllData(String|Number) = {   \% Render YAML string and numbers
+%     jekyllData(String|Number) = {\%  \% Render YAML string and numbers
 %       {\it #2}\%                                     \% using italics.
 %     },
 %   }
@@ -20314,7 +20343,8 @@ following text:
 % }
 % ```````
 %
-% To determine the current token renderer, you can use the parameter `#0`:
+% To determine the current token renderer, you can use the
+% pseudo-parameter `#0`:
 % ``` tex
 % \markdownSetup{
 %   renderers = {
@@ -20916,7 +20946,36 @@ following text:
 % \par
 % \begin{markdown}
 %
-% <!-- TODO: Document appending to renderer prototypes. -->
+% Besides defining renderer prototypes at once, we can also define them
+% incrementally using the appending operator (`+=`). This can be especially
+% useful in defining rules for processing different \acro{HTML} class names
+% and identifiers:
+% ``` tex
+% \markdownSetup{
+%   rendererPrototypes = {
+%     \% Start with empty renderer prototypes.
+%     headerAttributeContextBegin = {},
+%     attributeClassName = {},
+%     attributeIdentifier = {},
+%     \% Define the processing of a single specific HTML class name.
+%     headerAttributeContextBegin += {
+%       \markdownSetup{
+%         rendererPrototypes = {
+%           attributeClassName += {...},
+%         },
+%       }
+%     },
+%     \% Define the processing of a single specific HTML attribute.
+%     headerAttributeContextBegin += {
+%       \markdownSetup{
+%         rendererPrototypes = {
+%           attributeIdentifier += {...},
+%         },
+%       }
+%     },
+%   },
+% }
+% ```````
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -20949,8 +21008,9 @@ following text:
 % \par
 % \begin{markdown}
 %
-% In addition to exact token renderer names, we also support wildcards
-% and enumerations that match multiple token renderer prototype names:
+% In addition to exact token renderer prototype names, we also support
+% wildcards (`*`) and enumerations ('|') that match multiple token renderer
+% prototype names:
 % ``` tex
 % \markdownSetup{
 %   rendererPrototypes = {
@@ -20972,7 +21032,7 @@ following text:
 % ```````
 %
 % To determine the current token renderer prototype, you can use the
-% parameter `#0`:
+% pseudo-parameter `#0`:
 % ``` tex
 % \markdownSetup{
 %   rendererPrototypes = {

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20266,6 +20266,8 @@ following text:
 %
 % \end{markdown}
 %  \begin{macrocode}
+\tl_new:N
+  \l_@@_renderer_glob_definition_tl
 \seq_new:N
   \l_@@_renderer_glob_results_seq
 \regex_const:Nn
@@ -20373,17 +20375,17 @@ following text:
             }
             {
               \tl_set:Nn
-                \l_@@_renderer_definition_tl
-                { #1 }
+                \l_@@_renderer_glob_definition_tl
+                { \exp_not:n { #1 } }
               \seq_map_inline:Nn
                 \l_@@_renderer_glob_results_seq
                 {
                   \tl_set:Nn
                     \l_tmpa_tl
                     { { ##1 } = }
-                  \tl_put_right:No
+                  \tl_put_right:Nx
                     \l_tmpa_tl
-                    { { \l_@@_renderer_definition_tl } }
+                    { { \l_@@_renderer_glob_definition_tl } }
                   \keys_set:nV
                     { markdown/options/renderers }
                     \l_tmpa_tl
@@ -21050,17 +21052,17 @@ following text:
             }
             {
               \tl_set:Nn
-                \l_@@_renderer_prototype_definition_tl
-                { #1 }
+                \l_@@_renderer_glob_definition_tl
+                { \exp_not:n { #1 } }
               \seq_map_inline:Nn
                 \l_@@_renderer_glob_results_seq
                 {
                   \tl_set:Nn
                     \l_tmpa_tl
                     { { ##1 } = }
-                  \tl_put_right:No
+                  \tl_put_right:Nx
                     \l_tmpa_tl
-                    { { \l_@@_renderer_prototype_definition_tl } }
+                    { { \l_@@_renderer_glob_definition_tl } }
                   \keys_set:nV
                     { markdown/options/renderer-prototypes }
                     \l_tmpa_tl

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20158,10 +20158,6 @@ following text:
         \tl_tail:n { #1 }
       }
   }
-\tl_new:N
-  \l_@@_renderer_definition_tl
-\prop_new:N
-  \g_@@_renderer_definitions_prop
 \bool_new:N
   \g_@@_appending_renderer_bool
 \cs_new:Nn \@@_define_renderer:nNn
@@ -20171,23 +20167,21 @@ following text:
       {
         #1 .code:n = {
           \tl_set:Nn
-            \l_@@_renderer_definition_tl
+            \l_tmpa_tl
             { ##1 }
           \regex_replace_all:nnN
             { \cP\#0 }
             { #1 }
-            \l_@@_renderer_definition_tl
+            \l_tmpa_tl
           \bool_if:NT
             \g_@@_appending_renderer_bool
             {
-              \prop_get:NnNTF
-                \g_@@_renderer_definitions_prop
-                { #1 }
-                \l_tmpa_tl
+              \tl_if_exist:cTF
+                { l_@@_renderers_ #1 }
                 {
-                  \tl_put_left:NV
-                    \l_@@_renderer_definition_tl
+                  \tl_put_left:Nv
                     \l_tmpa_tl
+                    { l_@@_renderers_ #1 }
                 }
                 {
                   \msg_error:nnn
@@ -20196,15 +20190,14 @@ following text:
                     { #1 }
                 }
             }
-          \prop_put:NnV
-            \g_@@_renderer_definitions_prop
-            { #1 }
-            \l_@@_renderer_definition_tl
+          \tl_set:cV
+            { l_@@_renderers_ #1 }
+            \l_tmpa_tl
           \cs_generate_from_arg_count:NNnV
             #2
             \cs_set:Npn
             { #3 }
-            \l_@@_renderer_definition_tl
+            \l_tmpa_tl
         },
       }
   }
@@ -20214,6 +20207,9 @@ following text:
 \cs_generate_variant:Nn
   \cs_generate_from_arg_count:NNnn
   { NNnV }
+\cs_generate_variant:Nn
+  \tl_put_left:Nn
+  { Nv }
 \msg_new:nnnn
   { markdown }
   { failed-to-append-renderer }
@@ -20847,10 +20843,6 @@ following text:
         Prototype
       }
   }
-\tl_new:N
-  \l_@@_renderer_prototype_definition_tl
-\prop_new:N
-  \g_@@_renderer_prototype_definitions_prop
 \bool_new:N
   \g_@@_appending_renderer_prototype_bool
 \cs_new:Nn \@@_define_renderer_prototype:nNn
@@ -20860,23 +20852,21 @@ following text:
       {
         #1 .code:n = {
           \tl_set:Nn
-            \l_@@_renderer_prototype_definition_tl
+            \l_tmpa_tl
             { ##1 }
           \regex_replace_all:nnN
             { \cP\#0 }
             { #1 }
-            \l_@@_renderer_prototype_definition_tl
+            \l_tmpa_tl
           \bool_if:NT
             \g_@@_appending_renderer_prototype_bool
             {
-              \prop_get:NnNTF
-                \g_@@_renderer_prototype_definitions_prop
-                { #1 }
-                \l_tmpa_tl
+              \tl_if_exist:cTF
+                { l_@@_renderer_prototypes_ #1 }
                 {
-                  \tl_put_left:NV
-                    \l_@@_renderer_prototype_definition_tl
+                  \tl_put_left:Nv
                     \l_tmpa_tl
+                    { l_@@_renderer_prototypes_ #1 }
                 }
                 {
                   \msg_error:nnn
@@ -20885,15 +20875,14 @@ following text:
                     { #1 }
                 }
             }
-          \prop_put:NnV
-            \g_@@_renderer_prototype_definitions_prop
-            { #1 }
-            \l_@@_renderer_prototype_definition_tl
+          \tl_set:cV
+            { l_@@_renderer_prototypes_ #1 }
+            \l_tmpa_tl
           \cs_generate_from_arg_count:NNnV
             #2
             \cs_set:Npn
             { #3 }
-            \l_@@_renderer_prototype_definition_tl
+            \l_tmpa_tl
         },
       }
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20290,28 +20290,15 @@ following text:
               \seq_map_inline:Nn
                 \l_@@_renderer_glob_results_seq
                 {
-                  \@@_renderer_tl_to_csname:nN
-                    { ##1 }
+                  \tl_set:Nn
                     \l_tmpa_tl
-                  \prop_get:NnN
-                    \g_@@_renderer_arities_prop
-                    { ##1 }
-                    \l_tmpb_tl
-                  \int_set:Nn
-                    \l_tmpa_int
-                    \l_tmpb_tl
-                  \tl_set:NV
-                    \l_tmpb_tl
-                    \l_@@_renderer_definition_tl
-                  \regex_replace_all:nnN
-                    { \cP\#0 }
-                    { ##1 }
-                    \l_tmpb_tl
-                  \cs_generate_from_arg_count:cNVV
-                    { \l_tmpa_tl }
-                    \cs_set:Npn
-                    \l_tmpa_int
-                    \l_tmpb_tl
+                    { { ##1 } = }
+                  \tl_put_right:No
+                    \l_tmpa_tl
+                    { { \l_@@_renderer_definition_tl } }
+                  \keys_set:nV
+                    { markdown/options/renderers }
+                    \l_tmpa_tl
                 }
             }
         }
@@ -20898,28 +20885,15 @@ following text:
               \seq_map_inline:Nn
                 \l_@@_renderer_glob_results_seq
                 {
-                  \@@_renderer_prototype_tl_to_csname:nN
-                    { ##1 }
+                  \tl_set:Nn
                     \l_tmpa_tl
-                  \prop_get:NnN
-                    \g_@@_renderer_arities_prop
-                    { ##1 }
-                    \l_tmpb_tl
-                  \int_set:Nn
-                    \l_tmpa_int
-                    \l_tmpb_tl
-                  \tl_set:NV
-                    \l_tmpb_tl
-                    \l_@@_renderer_prototype_definition_tl
-                  \regex_replace_all:nnN
-                    { \cP\#0 }
-                    { ##1 }
-                    \l_tmpb_tl
-                  \cs_generate_from_arg_count:cNVV
-                    { \l_tmpa_tl }
-                    \cs_set:Npn
-                    \l_tmpa_int
-                    \l_tmpb_tl
+                    { { ##1 } = }
+                  \tl_put_right:No
+                    \l_tmpa_tl
+                    { { \l_@@_renderer_prototype_definition_tl } }
+                  \keys_set:nV
+                    { markdown/options/renderer-prototypes }
+                    \l_tmpa_tl
                 }
             }
         }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34842,20 +34842,17 @@ end
 % \begin{markdown}
 %
 % If identifier attributes appear after a heading, we make them produce
-% `\label` macros. If the `.unnumbered` class name (or the `{-}` shorthand)
-% appears after a heading the heading and all its subheadings will be
-% unnumbered.
+% `\label` macros.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\seq_new:N \l_@@_header_identifiers_seq
-\bool_new:N \l_@@_header_unnumbered_bool
+\seq_new:N
+  \l_@@_header_identifiers_seq
 \markdownSetup
   {
     rendererPrototypes = {
       headerAttributeContextBegin = {
-        \seq_clear:N \l_@@_header_identifiers_seq
         \markdownSetup
           {
             rendererPrototypes = {
@@ -34864,7 +34861,35 @@ end
                   \l_@@_header_identifiers_seq
                   { ##1 }
               },
-              % TODO: Rewrite with appending syntax.
+            },
+          }
+      },
+      headerAttributeContextEnd = {
+        \seq_map_inline:Nn
+          \l_@@_header_identifiers_seq
+          { \label { ##1 } }
+        \seq_clear:N
+          \l_@@_header_identifiers_seq
+      },
+    },
+  }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the `.unnumbered` class name (or the `{-}` shorthand) appears after a
+% heading the heading and all its subheadings will be unnumbered.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\bool_new:N
+  \l_@@_header_unnumbered_bool
+\markdownSetup
+  {
+    rendererPrototypes = {
+      headerAttributeContextBegin += {
+        \markdownSetup
+          {
+            rendererPrototypes = {
               attributeClassName = {
                 \bool_if:nT
                   {
@@ -34878,14 +34903,6 @@ end
                     \bool_set_true:N
                       \l_@@_header_unnumbered_bool
                     \c@secnumdepth = 0
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Count the number of nested sections, so that we only start numbering sections
-% again when the top-level unnumbered section has ended.
-%
-% \end{markdown}
-%  \begin{macrocode}
                     \markdownSetup
                       {
                         rendererPrototypes = {
@@ -34901,11 +34918,6 @@ end
               },
             },
           }
-      },
-      headerAttributeContextEnd = {
-        \seq_map_inline:Nn
-          \l_@@_header_identifiers_seq
-          { \label { ##1 } }
       },
     },
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20276,7 +20276,7 @@ following text:
 %         },
 %       }
 %     },
-%     \% Define the processing of a single specific HTML attribute.
+%     \% Define the processing of a single specific HTML identifier.
 %     headerAttributeContextBegin += {
 %       \markdownSetup{
 %         renderers = {
@@ -20320,7 +20320,7 @@ following text:
 % \begin{markdown}
 %
 % In addition to exact token renderer names, we also support wildcards (`*`)
-% and enumerations ('|') that match multiple token renderer names:
+% and enumerations (`|`) that match multiple token renderer names:
 % ``` tex
 % \markdownSetup{
 %   renderers = {
@@ -20956,7 +20956,7 @@ following text:
 %         },
 %       }
 %     },
-%     \% Define the processing of a single specific HTML attribute.
+%     \% Define the processing of a single specific HTML identifier.
 %     headerAttributeContextBegin += {
 %       \markdownSetup{
 %         rendererPrototypes = {
@@ -21000,7 +21000,7 @@ following text:
 % \begin{markdown}
 %
 % In addition to exact token renderer prototype names, we also support
-% wildcards (`*`) and enumerations ('|') that match multiple token renderer
+% wildcards (`*`) and enumerations (`|`) that match multiple token renderer
 % prototype names:
 % ``` tex
 % \markdownSetup{
@@ -34892,8 +34892,8 @@ end
 % \par
 % \begin{markdown}
 %
-% If identifier attributes appear after a heading, we make them produce
-% `\label` macros.
+% If \acro{HTML} identifiers appear after a heading, we make them
+% produce `\label` macros.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -34927,8 +34927,8 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% If the `.unnumbered` class name (or the `{-}` shorthand) appears after a
-% heading the heading and all its subheadings will be unnumbered.
+% If the `unnumbered` \acro{HTML} class (or the `{-}` shorthand) appears after
+% a heading the heading and all its subheadings will be unnumbered.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20161,7 +20161,7 @@ following text:
 \tl_new:N
   \l_@@_renderer_definition_tl
 \bool_new:N
-  \g_@@_appending_bool
+  \g_@@_appending_renderer_bool
 \cs_new:Nn \@@_define_renderer:nNn
   {
     \keys_define:nn
@@ -20176,7 +20176,7 @@ following text:
             { #1 }
             \l_@@_renderer_definition_tl
           \bool_if:NTF
-            \g_@@_appending_bool
+            \g_@@_appending_renderer_bool
             {
               % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
               \exp_args:NnV
@@ -20264,7 +20264,7 @@ following text:
         \l_keys_key_str
         {
           \bool_gset_true:N
-            \g_@@_appending_bool
+            \g_@@_appending_renderer_bool
           \tl_set:NV
             \l_tmpa_tl
             \l_keys_key_str
@@ -20282,7 +20282,7 @@ following text:
             { markdown/options/renderers }
             \l_tmpb_tl
           \bool_gset_false:N
-            \g_@@_appending_bool
+            \g_@@_appending_renderer_bool
         }
 %    \end{macrocode}
 % \par
@@ -20813,6 +20813,8 @@ following text:
   }
 \tl_new:N
   \l_@@_renderer_prototype_definition_tl
+\bool_new:N
+  \g_@@_appending_renderer_prototype_bool
 \cs_new:Nn \@@_define_renderer_prototype:nNn
   {
     \keys_define:nn
@@ -20827,7 +20829,7 @@ following text:
             { #1 }
             \l_@@_renderer_prototype_definition_tl
           \bool_if:NTF
-            \g_@@_appending_bool
+            \g_@@_appending_renderer_prototype_bool
             {
               % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
               \exp_args:NnV
@@ -20913,7 +20915,7 @@ following text:
         \l_keys_key_str
         {
           \bool_gset_true:N
-            \g_@@_appending_bool
+            \g_@@_appending_renderer_prototype_bool
           \tl_set:NV
             \l_tmpa_tl
             \l_keys_key_str
@@ -20931,7 +20933,7 @@ following text:
             { markdown/options/renderer-prototypes }
             \l_tmpb_tl
           \bool_gset_false:N
-            \g_@@_appending_bool
+            \g_@@_appending_renderer_prototype_bool
         }
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20215,20 +20215,20 @@ following text:
 \seq_new:N
   \l_@@_renderer_glob_results_seq
 \regex_const:Nn
-  \c_@@_prepending_key
+  \c_@@_prepending_key_regex
   { \^\s*$ }
 \regex_const:Nn
-  \c_@@_appending_key
+  \c_@@_appending_key_regex
   { \$\s*$ }
 \regex_const:Nn
-  \c_@@_prepending_or_appending_key
+  \c_@@_prepending_or_appending_key_regex
   { [\^\$]\s*$ }
 \keys_define:nn
   { markdown/options/renderers }
   {
     unknown .code:n = {
       \regex_match:NVTF
-        \c_@@_prepending_or_appending_key
+        \c_@@_prepending_or_appending_key_regex
         \l_keys_key_str
         {
           % TODO
@@ -20822,7 +20822,7 @@ following text:
   {
     unknown .code:n = {
       \regex_match:NVTF
-        \c_@@_prepending_or_appending_key
+        \c_@@_prepending_or_appending_key_regex
         \l_keys_key_str
         {
           % TODO

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20194,7 +20194,6 @@ following text:
         { #1 }
     },
   }
-\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -20210,6 +20209,33 @@ following text:
 %   }
 % }
 % ```````
+%
+% \end{markdown}
+%  \begin{macrocode}
+\seq_new:N
+  \l_@@_renderer_glob_results_seq
+\regex_const:Nn
+  \c_@@_prepending_key
+  { \^\s*$ }
+\regex_const:Nn
+  \c_@@_appending_key
+  { \$\s*$ }
+\regex_const:Nn
+  \c_@@_prepending_or_appending_key
+  { [\^\$]\s*$ }
+\keys_define:nn
+  { markdown/options/renderers }
+  {
+    unknown .code:n = {
+      \regex_match:NVTF
+        \c_@@_prepending_or_appending_key
+        \l_keys_key_str
+        {
+          % TODO
+        }
+%    \end{macrocode}
+% \par
+% \begin{markdown}
 %
 % In addition to exact token renderer names, we also support wildcards
 % and enumerations that match multiple token renderer names:
@@ -20244,7 +20270,68 @@ following text:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\ExplSyntaxOn
+        {
+          \@@_glob_seq:VnN
+            \l_keys_key_str
+            { g_@@_renderers_seq }
+            \l_@@_renderer_glob_results_seq
+          \seq_if_empty:NTF
+            \l_@@_renderer_glob_results_seq
+            {
+              \msg_error:nnV
+                { markdown }
+                { undefined-renderer }
+                \l_keys_key_str
+            }
+            {
+              \tl_set:Nn
+                \l_@@_renderer_definition_tl
+                { #1 }
+              \seq_map_inline:Nn
+                \l_@@_renderer_glob_results_seq
+                {
+                  \@@_renderer_tl_to_csname:nN
+                    { ##1 }
+                    \l_tmpa_tl
+                  \prop_get:NnN
+                    \g_@@_renderer_arities_prop
+                    { ##1 }
+                    \l_tmpb_tl
+                  \int_set:Nn
+                    \l_tmpa_int
+                    \l_tmpb_tl
+                  \tl_set:NV
+                    \l_tmpb_tl
+                    \l_@@_renderer_definition_tl
+                  \regex_replace_all:nnN
+                    { \cP\#0 }
+                    { ##1 }
+                    \l_tmpb_tl
+                  \cs_generate_from_arg_count:cNVV
+                    { \l_tmpa_tl }
+                    \cs_set:Npn
+                    \l_tmpa_int
+                    \l_tmpb_tl
+                }
+            }
+        }
+    },
+  }
+\msg_new:nnn
+  { markdown }
+  { undefined-renderer }
+  {
+    Renderer~#1~is~undefined.
+  }
+\cs_generate_variant:Nn
+  \@@_glob_seq:nnN
+  { VnN }
+\cs_generate_variant:Nn
+  \cs_generate_from_arg_count:NNnn
+  { cNVV }
+\cs_generate_variant:Nn
+  \msg_error:nnn
+  { nnV }
 \prop_new:N
   \g_@@_glob_cache_prop
 \tl_new:N
@@ -20306,72 +20393,6 @@ following text:
 \cs_generate_variant:Nn
   \prop_gput:Nnn
   { NeV }
-\seq_new:N
-  \l_@@_renderer_glob_results_seq
-\keys_define:nn
-  { markdown/options/renderers }
-  {
-    unknown .code:n = {
-      \@@_glob_seq:VnN
-        \l_keys_key_str
-        { g_@@_renderers_seq }
-        \l_@@_renderer_glob_results_seq
-      \seq_if_empty:NTF
-        \l_@@_renderer_glob_results_seq
-        {
-          \msg_error:nnV
-            { markdown }
-            { undefined-renderer }
-            \l_keys_key_str
-        }
-        {
-          \tl_set:Nn
-            \l_@@_renderer_definition_tl
-            { #1 }
-          \seq_map_inline:Nn
-            \l_@@_renderer_glob_results_seq
-            {
-              \@@_renderer_tl_to_csname:nN
-                { ##1 }
-                \l_tmpa_tl
-              \prop_get:NnN
-                \g_@@_renderer_arities_prop
-                { ##1 }
-                \l_tmpb_tl
-              \int_set:Nn
-                \l_tmpa_int
-                \l_tmpb_tl
-              \tl_set:NV
-                \l_tmpb_tl
-                \l_@@_renderer_definition_tl
-              \regex_replace_all:nnN
-                { \cP\#0 }
-                { ##1 }
-                \l_tmpb_tl
-              \cs_generate_from_arg_count:cNVV
-                { \l_tmpa_tl }
-                \cs_set:Npn
-                \l_tmpa_int
-                \l_tmpb_tl
-            }
-        }
-    },
-  }
-\msg_new:nnn
-  { markdown }
-  { undefined-renderer }
-  {
-    Renderer~#1~is~undefined.
-  }
-\cs_generate_variant:Nn
-  \@@_glob_seq:nnN
-  { VnN }
-\cs_generate_variant:Nn
-  \cs_generate_from_arg_count:NNnn
-  { cNVV }
-\cs_generate_variant:Nn
-  \msg_error:nnn
-  { nnV }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -20791,7 +20812,6 @@ following text:
 \cs_generate_variant:Nn
   \@@_define_renderer_prototype:nNn
   { ncV }
-\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -20807,6 +20827,22 @@ following text:
 %   }
 % }
 % ```````
+%
+% \end{markdown}
+%  \begin{macrocode}
+\keys_define:nn
+  { markdown/options/renderer-prototypes }
+  {
+    unknown .code:n = {
+      \regex_match:NVTF
+        \c_@@_prepending_or_appending_key
+        \l_keys_key_str
+        {
+          % TODO
+        }
+%    \end{macrocode}
+% \par
+% \begin{markdown}
 %
 % In addition to exact token renderer names, we also support wildcards
 % and enumerations that match multiple token renderer prototype names:
@@ -20842,52 +20878,49 @@ following text:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\ExplSyntaxOn
-\keys_define:nn
-  { markdown/options/renderer-prototypes }
-  {
-    unknown .code:n = {
-      \@@_glob_seq:VnN
-        \l_keys_key_str
-        { g_@@_renderers_seq }
-        \l_@@_renderer_glob_results_seq
-      \seq_if_empty:NTF
-        \l_@@_renderer_glob_results_seq
         {
-          \msg_error:nnV
-            { markdown }
-            { undefined-renderer-prototype }
+          \@@_glob_seq:VnN
             \l_keys_key_str
-        }
-        {
-          \tl_set:Nn
-            \l_@@_renderer_prototype_definition_tl
-            { #1 }
-          \seq_map_inline:Nn
+            { g_@@_renderers_seq }
+            \l_@@_renderer_glob_results_seq
+          \seq_if_empty:NTF
             \l_@@_renderer_glob_results_seq
             {
-              \@@_renderer_prototype_tl_to_csname:nN
-                { ##1 }
-                \l_tmpa_tl
-              \prop_get:NnN
-                \g_@@_renderer_arities_prop
-                { ##1 }
-                \l_tmpb_tl
-              \int_set:Nn
-                \l_tmpa_int
-                \l_tmpb_tl
-              \tl_set:NV
-                \l_tmpb_tl
+              \msg_error:nnV
+                { markdown }
+                { undefined-renderer-prototype }
+                \l_keys_key_str
+            }
+            {
+              \tl_set:Nn
                 \l_@@_renderer_prototype_definition_tl
-              \regex_replace_all:nnN
-                { \cP\#0 }
-                { ##1 }
-                \l_tmpb_tl
-              \cs_generate_from_arg_count:cNVV
-                { \l_tmpa_tl }
-                \cs_set:Npn
-                \l_tmpa_int
-                \l_tmpb_tl
+                { #1 }
+              \seq_map_inline:Nn
+                \l_@@_renderer_glob_results_seq
+                {
+                  \@@_renderer_prototype_tl_to_csname:nN
+                    { ##1 }
+                    \l_tmpa_tl
+                  \prop_get:NnN
+                    \g_@@_renderer_arities_prop
+                    { ##1 }
+                    \l_tmpb_tl
+                  \int_set:Nn
+                    \l_tmpa_int
+                    \l_tmpb_tl
+                  \tl_set:NV
+                    \l_tmpb_tl
+                    \l_@@_renderer_prototype_definition_tl
+                  \regex_replace_all:nnN
+                    { \cP\#0 }
+                    { ##1 }
+                    \l_tmpb_tl
+                  \cs_generate_from_arg_count:cNVV
+                    { \l_tmpa_tl }
+                    \cs_set:Npn
+                    \l_tmpa_int
+                    \l_tmpb_tl
+                }
             }
         }
     },

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20212,21 +20212,21 @@ following text:
               }
             }
             {
-              \cs_generate_from_arg_count:nnnv
+              \cs_generate_from_arg_count:NNnV
                 #2
-                \cs_set:npn
+                \cs_set:Npn
                 { #3 }
                 \l_@@_renderer_definition_tl
             }
         },
       }
   }
-\cs_generate_variant:nn
-  \@@_define_renderer:nnn
-  { ncv }
-\cs_generate_variant:nn
-  \cs_generate_from_arg_count:nnnn
-  { nnnv }
+\cs_generate_variant:Nn
+  \@@_define_renderer:nNn
+  { ncV }
+\cs_generate_variant:Nn
+  \cs_generate_from_arg_count:NNnn
+  { NNnV }
 \msg_new:nnn
   { markdown }
   { failed-to-prepend-renderer }
@@ -20311,7 +20311,7 @@ following text:
             \c_@@_prepending_or_appending_key_regex
             { }
             \l_tmpa_tl
-          \tl_set:No
+          \tl_set:Nx
             \l_tmpb_tl
             { { \l_tmpa_tl } = }
           \tl_put_right:Nn
@@ -20409,6 +20409,10 @@ following text:
 \cs_generate_variant:Nn
   \msg_error:nnn
   { nnV }
+\prg_generate_conditional_variant:Nnn
+  \regex_match:Nn
+  { NV }
+  { TF }
 \prop_new:N
   \g_@@_glob_cache_prop
 \tl_new:N
@@ -20904,18 +20908,6 @@ following text:
             }
         },
       }
-\msg_new:nnn
-  { markdown }
-  { failed-to-prepend-renderer-prototype }
-  {
-    Failed~to~prepend~to~renderer~prototype~#1.
-  }
-\msg_new:nnn
-  { markdown }
-  { failed-to-append-renderer-prototype }
-  {
-    Failed~to~append~to~renderer~prototype~#1.
-  }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -20937,6 +20929,18 @@ following text:
 \cs_generate_variant:Nn
   \@@_define_renderer_prototype:nNn
   { ncV }
+\msg_new:nnn
+  { markdown }
+  { failed-to-prepend-renderer-prototype }
+  {
+    Failed~to~prepend~to~renderer~prototype~#1.
+  }
+\msg_new:nnn
+  { markdown }
+  { failed-to-append-renderer-prototype }
+  {
+    Failed~to~append~to~renderer~prototype~#1.
+  }
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -20987,7 +20991,7 @@ following text:
             \c_@@_prepending_or_appending_key_regex
             { }
             \l_tmpa_tl
-          \tl_set:No
+          \tl_set:Nx
             \l_tmpb_tl
             { { \l_tmpa_tl } = }
           \tl_put_right:Nn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -827,6 +827,8 @@ abbr {
       \seq_map_inline:Nn
         \l_@@_header_identifiers_seq
         { \label { sec:##1 } }
+      \seq_clear:N
+        \l_@@_header_identifiers_seq
     },
   },
 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20246,7 +20246,7 @@ following text:
   \l_@@_renderer_glob_results_seq
 \regex_const:Nn
   \c_@@_appending_key_regex
-  { \s*\+$ }
+  { \s*+$ }
 \keys_define:nn
   { markdown/options/renderers }
   {
@@ -20268,7 +20268,7 @@ following text:
           \tl_set:NV
             \l_tmpa_tl
             \l_keys_key_str
-          \regex_replace_once:NVN
+          \regex_replace_once:NnN
             \c_@@_appending_key_regex
             { }
             \l_tmpa_tl
@@ -20917,7 +20917,7 @@ following text:
           \tl_set:NV
             \l_tmpa_tl
             \l_keys_key_str
-          \regex_replace_once:NVN
+          \regex_replace_once:NnN
             \c_@@_appending_key_regex
             { }
             \l_tmpa_tl

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20864,7 +20864,7 @@ following text:
             { \cP\#0 }
             { #1 }
             \l_@@_renderer_prototype_definition_tl
-          \bool_if:NTF
+          \bool_if:NT
             \g_@@_appending_renderer_prototype_bool
             {
               \prop_get:NnNTF

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20843,8 +20843,6 @@ following text:
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\seq_new:N
-  \l_@@_renderer_prototype_glob_results_seq
 \keys_define:nn
   { markdown/options/renderer-prototypes }
   {
@@ -20852,9 +20850,9 @@ following text:
       \@@_glob_seq:VnN
         \l_keys_key_str
         { g_@@_renderers_seq }
-        \l_@@_renderer_prototype_glob_results_seq
+        \l_@@_renderer_glob_results_seq
       \seq_if_empty:NTF
-        \l_@@_renderer_prototype_glob_results_seq
+        \l_@@_renderer_glob_results_seq
         {
           \msg_error:nnV
             { markdown }
@@ -20866,7 +20864,7 @@ following text:
             \l_@@_renderer_prototype_definition_tl
             { #1 }
           \seq_map_inline:Nn
-            \l_@@_renderer_prototype_glob_results_seq
+            \l_@@_renderer_glob_results_seq
             {
               \@@_renderer_prototype_tl_to_csname:nN
                 { ##1 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1317,9 +1317,7 @@ local uni_algos = require("lua-uni-algos")
 %:    A package that is used to polyfill the general hook management system in
 %     the default renderer prototypes for \acro{yaml} metadata, see Section
 %     <#sec:latex-yaml-metadata>, and also in the default renderer prototype
-%     for identifier attributes. Furthermore, the package is used to implement
-%     partial redefinitions of renderers and renderer prototypes in \LaTeX.
-%     <!-- TODO: Redo this in pure expl3, so all \TeX{} formats are supported. -->
+%     for identifier attributes.
 %
 % \pkg{soulutf8}
 %
@@ -20160,6 +20158,8 @@ following text:
   }
 \tl_new:N
   \l_@@_renderer_definition_tl
+\prop_new:N
+  \g_@@_renderer_definitions_prop
 \bool_new:N
   \g_@@_appending_renderer_bool
 \cs_new:Nn \@@_define_renderer:nNn
@@ -20175,29 +20175,34 @@ following text:
             { \cP\#0 }
             { #1 }
             \l_@@_renderer_definition_tl
-          \bool_if:NTF
+          \bool_if:NT
             \g_@@_appending_renderer_bool
             {
-              % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
-              \exp_args:NnV
-                \apptocmd
-                  { #2 }
-                  \l_@@_renderer_definition_tl
-                  { }
-                  {
-                    \msg_error:nnn
-                      { markdown }
-                      { failed-to-append-renderer }
-                      { #1 }
-                  }
+              \prop_get:NnNTF
+                \g_@@_renderer_definitions_prop
+                { #1 }
+                \l_tmpa_tl
+                {
+                  \tl_put_left:NV
+                    \l_@@_renderer_definition_tl
+                    \l_tmpa_tl
+                }
+                {
+                  \msg_error:nnn
+                    { markdown }
+                    { failed-to-append-renderer }
+                    { #1 }
+                }
             }
-            {
-              \cs_generate_from_arg_count:NNnV
-                #2
-                \cs_set:Npn
-                { #3 }
-                \l_@@_renderer_definition_tl
-            }
+          \prop_put:NnV
+            \g_@@_renderer_definitions_prop
+            { #1 }
+            \l_@@_renderer_definition_tl
+          \cs_generate_from_arg_count:NNnV
+            #2
+            \cs_set:Npn
+            { #3 }
+            \l_@@_renderer_definition_tl
         },
       }
   }
@@ -20207,12 +20212,11 @@ following text:
 \cs_generate_variant:Nn
   \cs_generate_from_arg_count:NNnn
   { NNnV }
-\msg_new:nnn
+\msg_new:nnnn
   { markdown }
   { failed-to-append-renderer }
-  {
-    Failed~to~append~to~renderer~#1.
-  }
+  { Failed~to~append~(+=)~to~renderer~#1. }
+  { Have~you~assigned~(=)~to~renderer~#1~previously? }
 \keys_define:nn
   { markdown/options }
   {
@@ -20813,6 +20817,8 @@ following text:
   }
 \tl_new:N
   \l_@@_renderer_prototype_definition_tl
+\prop_new:N
+  \g_@@_renderer_prototype_definitions_prop
 \bool_new:N
   \g_@@_appending_renderer_prototype_bool
 \cs_new:Nn \@@_define_renderer_prototype:nNn
@@ -20831,26 +20837,31 @@ following text:
           \bool_if:NTF
             \g_@@_appending_renderer_prototype_bool
             {
-              % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
-              \exp_args:NnV
-                \apptocmd
-                  { #2 }
-                  \l_@@_renderer_prototype_definition_tl
-                  { }
-                  {
-                    \msg_error:nnn
-                      { markdown }
-                      { failed-to-append-renderer-prototype }
-                      { #1 }
-                  }
+              \prop_get:NnNTF
+                \g_@@_renderer_prototype_definitions_prop
+                { #1 }
+                \l_tmpa_tl
+                {
+                  \tl_put_left:NV
+                    \l_@@_renderer_prototype_definition_tl
+                    \l_tmpa_tl
+                }
+                {
+                  \msg_error:nnn
+                    { markdown }
+                    { failed-to-append-renderer-prototype }
+                    { #1 }
+                }
             }
-            {
-              \cs_generate_from_arg_count:NNnV
-                #2
-                \cs_set:Npn
-                { #3 }
-                \l_@@_renderer_prototype_definition_tl
-            }
+          \prop_put:NnV
+            \g_@@_renderer_prototype_definitions_prop
+            { #1 }
+            \l_@@_renderer_prototype_definition_tl
+          \cs_generate_from_arg_count:NNnV
+            #2
+            \cs_set:Npn
+            { #3 }
+            \l_@@_renderer_prototype_definition_tl
         },
       }
 %    \end{macrocode}
@@ -20874,12 +20885,11 @@ following text:
 \cs_generate_variant:Nn
   \@@_define_renderer_prototype:nNn
   { ncV }
-\msg_new:nnn
+\msg_new:nnnn
   { markdown }
   { failed-to-append-renderer-prototype }
-  {
-    Failed~to~append~to~renderer~prototype~#1.
-  }
+  { Failed~to~append~(+=)~to~renderer~prototype~#1. }
+  { Have~you~assigned~(=)~to~renderer~prototype~#1~previously? }
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20161,9 +20161,7 @@ following text:
 \tl_new:N
   \l_@@_renderer_definition_tl
 \bool_new:N
-  \g_@@_prepending_bool
-\bool_new:N
-  \g_@@_prepending_or_appending_bool
+  \g_@@_appending_bool
 \cs_new:Nn \@@_define_renderer:nNn
   {
     \keys_define:nn
@@ -20178,38 +20176,20 @@ following text:
             { #1 }
             \l_@@_renderer_definition_tl
           \bool_if:NTF
-            \g_@@_prepending_or_appending_bool
+            \g_@@_appending_bool
             {
-              \bool_if:NTF
-                \g_@@_prepending_bool
-              {
-                % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
-                \exp_args:NnV
-                  \pretocmd
-                    { #2 }
-                    \l_@@_renderer_definition_tl
-                    { }
-                    {
-                      \msg_error:nnn
-                        { markdown }
-                        { failed-to-prepend-renderer }
-                        { #1 }
-                    }
-              }
-              {
-                % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
-                \exp_args:NnV
-                  \apptocmd
-                    { #2 }
-                    \l_@@_renderer_definition_tl
-                    { }
-                    {
-                      \msg_error:nnn
-                        { markdown }
-                        { failed-to-append-renderer }
-                        { #1 }
-                    }
-              }
+              % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
+              \exp_args:NnV
+                \apptocmd
+                  { #2 }
+                  \l_@@_renderer_definition_tl
+                  { }
+                  {
+                    \msg_error:nnn
+                      { markdown }
+                      { failed-to-append-renderer }
+                      { #1 }
+                  }
             }
             {
               \cs_generate_from_arg_count:NNnV
@@ -20227,12 +20207,6 @@ following text:
 \cs_generate_variant:Nn
   \cs_generate_from_arg_count:NNnn
   { NNnV }
-\msg_new:nnn
-  { markdown }
-  { failed-to-prepend-renderer }
-  {
-    Failed~to~prepend~to~renderer~#1.
-  }
 \msg_new:nnn
   { markdown }
   { failed-to-append-renderer }
@@ -20271,14 +20245,8 @@ following text:
 \seq_new:N
   \l_@@_renderer_glob_results_seq
 \regex_const:Nn
-  \c_@@_prepending_key_regex
-  { \^\s*$ }
-\regex_const:Nn
   \c_@@_appending_key_regex
-  { \$\s*$ }
-\regex_const:Nn
-  \c_@@_prepending_or_appending_key_regex
-  { [\^\$]\s*$ }
+  { \s*\+$ }
 \keys_define:nn
   { markdown/options/renderers }
   {
@@ -20287,28 +20255,21 @@ following text:
 % \par
 % \begin{markdown}
 %
-% <!-- TODO: Document prepending and appending to renderer prototypes. -->
+% <!-- TODO: Document appending to renderer prototypes. -->
 %
 % \end{markdown}
 %  \begin{macrocode}
       \regex_match:NVTF
-        \c_@@_prepending_or_appending_key_regex
+        \c_@@_appending_key_regex
         \l_keys_key_str
         {
           \bool_gset_true:N
-            \g_@@_prepending_or_appending_bool
-          \regex_match:NVTF
-            \c_@@_prepending_key_regex
-            \l_keys_key_str
-            {
-              \bool_gset_true:N
-                \g_@@_prepending_bool
-            }
+            \g_@@_appending_bool
           \tl_set:NV
             \l_tmpa_tl
             \l_keys_key_str
           \regex_replace_once:NVN
-            \c_@@_prepending_or_appending_key_regex
+            \c_@@_appending_key_regex
             { }
             \l_tmpa_tl
           \tl_set:Nx
@@ -20321,7 +20282,7 @@ following text:
             { markdown/options/renderers }
             \l_tmpb_tl
           \bool_gset_false:N
-            \g_@@_prepending_or_appending_bool
+            \g_@@_appending_bool
         }
 %    \end{macrocode}
 % \par
@@ -20866,38 +20827,20 @@ following text:
             { #1 }
             \l_@@_renderer_prototype_definition_tl
           \bool_if:NTF
-            \g_@@_prepending_or_appending_bool
+            \g_@@_appending_bool
             {
-              \bool_if:NTF
-                \g_@@_prepending_bool
-              {
-                % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
-                \exp_args:NnV
-                  \pretocmd
-                    { #2 }
-                    \l_@@_renderer_prototype_definition_tl
-                    { }
-                    {
-                      \msg_error:nnn
-                        { markdown }
-                        { failed-to-prepend-renderer-prototype }
-                        { #1 }
-                    }
-              }
-              {
-                % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
-                \exp_args:NnV
-                  \apptocmd
-                    { #2 }
-                    \l_@@_renderer_prototype_definition_tl
-                    { }
-                    {
-                      \msg_error:nnn
-                        { markdown }
-                        { failed-to-append-renderer-prototype }
-                        { #1 }
-                    }
-              }
+              % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
+              \exp_args:NnV
+                \apptocmd
+                  { #2 }
+                  \l_@@_renderer_prototype_definition_tl
+                  { }
+                  {
+                    \msg_error:nnn
+                      { markdown }
+                      { failed-to-append-renderer-prototype }
+                      { #1 }
+                  }
             }
             {
               \cs_generate_from_arg_count:NNnV
@@ -20931,12 +20874,6 @@ following text:
   { ncV }
 \msg_new:nnn
   { markdown }
-  { failed-to-prepend-renderer-prototype }
-  {
-    Failed~to~prepend~to~renderer~prototype~#1.
-  }
-\msg_new:nnn
-  { markdown }
   { failed-to-append-renderer-prototype }
   {
     Failed~to~append~to~renderer~prototype~#1.
@@ -20967,28 +20904,21 @@ following text:
 % \par
 % \begin{markdown}
 %
-% <!-- TODO: Document prepending and appending to renderer prototypes. -->
+% <!-- TODO: Document appending to renderer prototypes. -->
 %
 % \end{markdown}
 %  \begin{macrocode}
       \regex_match:NVTF
-        \c_@@_prepending_or_appending_key_regex
+        \c_@@_appending_key_regex
         \l_keys_key_str
         {
           \bool_gset_true:N
-            \g_@@_prepending_or_appending_bool
-          \regex_match:NVTF
-            \c_@@_prepending_key_regex
-            \l_keys_key_str
-            {
-              \bool_gset_true:N
-                \g_@@_prepending_bool
-            }
+            \g_@@_appending_bool
           \tl_set:NV
             \l_tmpa_tl
             \l_keys_key_str
           \regex_replace_once:NVN
-            \c_@@_prepending_or_appending_key_regex
+            \c_@@_appending_key_regex
             { }
             \l_tmpa_tl
           \tl_set:Nx
@@ -21001,7 +20931,7 @@ following text:
             { markdown/options/renderer-prototypes }
             \l_tmpb_tl
           \bool_gset_false:N
-            \g_@@_prepending_or_appending_bool
+            \g_@@_appending_bool
         }
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1317,7 +1317,9 @@ local uni_algos = require("lua-uni-algos")
 %:    A package that is used to polyfill the general hook management system in
 %     the default renderer prototypes for \acro{yaml} metadata, see Section
 %     <#sec:latex-yaml-metadata>, and also in the default renderer prototype
-%     for identifier attributes.
+%     for identifier attributes. Furthermore, the package is used to implement
+%     partial redefinitions of renderers and renderer prototypes in \LaTeX.
+%     <!-- TODO: Redo this in pure expl3, so all \TeX{} formats are supported. -->
 %
 % \pkg{soulutf8}
 %
@@ -20158,6 +20160,10 @@ following text:
   }
 \tl_new:N
   \l_@@_renderer_definition_tl
+\bool_new:N
+  \g_@@_prepending_bool
+\bool_new:N
+  \g_@@_prepending_or_appending_bool
 \cs_new:Nn \@@_define_renderer:nNn
   {
     \keys_define:nn
@@ -20171,20 +20177,68 @@ following text:
             { \cP\#0 }
             { #1 }
             \l_@@_renderer_definition_tl
-          \cs_generate_from_arg_count:NNnV
-            #2
-            \cs_set:Npn
-            { #3 }
-            \l_@@_renderer_definition_tl
+          \bool_if:NTF
+            \g_@@_prepending_or_appending_bool
+            {
+              \bool_if:NTF
+                \g_@@_prepending_bool
+              {
+                % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
+                \exp_args:NnV
+                  \pretocmd
+                    { #2 }
+                    \l_@@_renderer_definition_tl
+                    { }
+                    {
+                      \msg_error:nnn
+                        { markdown }
+                        { failed-to-prepend-renderer }
+                        { #1 }
+                    }
+              }
+              {
+                % TODO: Redo this in pure expl3, so all \TeX{} formats are supported.
+                \exp_args:NnV
+                  \apptocmd
+                    { #2 }
+                    \l_@@_renderer_definition_tl
+                    { }
+                    {
+                      \msg_error:nnn
+                        { markdown }
+                        { failed-to-append-renderer }
+                        { #1 }
+                    }
+              }
+            }
+            {
+              \cs_generate_from_arg_count:nnnv
+                #2
+                \cs_set:npn
+                { #3 }
+                \l_@@_renderer_definition_tl
+            }
         },
       }
   }
-\cs_generate_variant:Nn
-  \@@_define_renderer:nNn
-  { ncV }
-\cs_generate_variant:Nn
-  \cs_generate_from_arg_count:NNnn
-  { NNnV }
+\cs_generate_variant:nn
+  \@@_define_renderer:nnn
+  { ncv }
+\cs_generate_variant:nn
+  \cs_generate_from_arg_count:nnnn
+  { nnnv }
+\msg_new:nnn
+  { markdown }
+  { failed-to-prepend-renderer }
+  {
+    Failed~to~prepend~to~renderer~#1.
+  }
+\msg_new:nnn
+  { markdown }
+  { failed-to-append-renderer }
+  {
+    Failed~to~append~to~renderer~#1.
+  }
 \keys_define:nn
   { markdown/options }
   {
@@ -20227,11 +20281,45 @@ following text:
   { markdown/options/renderers }
   {
     unknown .code:n = {
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% <!-- TODO: Document prepending and appending to renderer prototypes. -->
+%
+% \end{markdown}
+%  \begin{macrocode}
       \regex_match:NVTF
         \c_@@_prepending_or_appending_key_regex
         \l_keys_key_str
         {
-          % TODO
+          \bool_gset_true:N
+            \g_@@_prepending_or_appending_bool
+          \regex_match:NVTF
+            \c_@@_prepending_key_regex
+            \l_keys_key_str
+            {
+              \bool_gset_true:N
+                \g_@@_prepending_bool
+            }
+          \tl_set:NV
+            \l_tmpa_tl
+            \l_keys_key_str
+          \regex_replace_once:NVN
+            \c_@@_prepending_or_appending_key_regex
+            { }
+            \l_tmpa_tl
+          \tl_set:No
+            \l_tmpb_tl
+            { { \l_tmpa_tl } = }
+          \tl_put_right:Nn
+            \l_tmpb_tl
+            { { #1 } }
+          \keys_set:nV
+            { markdown/options/renderers }
+            \l_tmpb_tl
+          \bool_gset_false:N
+            \g_@@_prepending_or_appending_bool
         }
 %    \end{macrocode}
 % \par
@@ -20771,13 +20859,61 @@ following text:
             { \cP\#0 }
             { #1 }
             \l_@@_renderer_prototype_definition_tl
-          \cs_generate_from_arg_count:NNnV
-            #2
-            \cs_set:Npn
-            { #3 }
-            \l_@@_renderer_prototype_definition_tl
+          \bool_if:NTF
+            \g_@@_prepending_or_appending_bool
+            {
+              \bool_if:NTF
+                \g_@@_prepending_bool
+              {
+                % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
+                \exp_args:NnV
+                  \pretocmd
+                    { #2 }
+                    \l_@@_renderer_prototype_definition_tl
+                    { }
+                    {
+                      \msg_error:nnn
+                        { markdown }
+                        { failed-to-prepend-renderer-prototype }
+                        { #1 }
+                    }
+              }
+              {
+                % TODO: Redo this in pure expl3, so different \TeX{} formats are supported.
+                \exp_args:NnV
+                  \apptocmd
+                    { #2 }
+                    \l_@@_renderer_prototype_definition_tl
+                    { }
+                    {
+                      \msg_error:nnn
+                        { markdown }
+                        { failed-to-append-renderer-prototype }
+                        { #1 }
+                    }
+              }
+            }
+            {
+              \cs_generate_from_arg_count:NNnV
+                #2
+                \cs_set:Npn
+                { #3 }
+                \l_@@_renderer_prototype_definition_tl
+            }
         },
       }
+\msg_new:nnn
+  { markdown }
+  { failed-to-prepend-renderer-prototype }
+  {
+    Failed~to~prepend~to~renderer~prototype~#1.
+  }
+\msg_new:nnn
+  { markdown }
+  { failed-to-append-renderer-prototype }
+  {
+    Failed~to~append~to~renderer~prototype~#1.
+  }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -20821,11 +20957,45 @@ following text:
   { markdown/options/renderer-prototypes }
   {
     unknown .code:n = {
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% <!-- TODO: Document prepending and appending to renderer prototypes. -->
+%
+% \end{markdown}
+%  \begin{macrocode}
       \regex_match:NVTF
         \c_@@_prepending_or_appending_key_regex
         \l_keys_key_str
         {
-          % TODO
+          \bool_gset_true:N
+            \g_@@_prepending_or_appending_bool
+          \regex_match:NVTF
+            \c_@@_prepending_key_regex
+            \l_keys_key_str
+            {
+              \bool_gset_true:N
+                \g_@@_prepending_bool
+            }
+          \tl_set:NV
+            \l_tmpa_tl
+            \l_keys_key_str
+          \regex_replace_once:NVN
+            \c_@@_prepending_or_appending_key_regex
+            { }
+            \l_tmpa_tl
+          \tl_set:No
+            \l_tmpb_tl
+            { { \l_tmpa_tl } = }
+          \tl_put_right:Nn
+            \l_tmpb_tl
+            { { #1 } }
+          \keys_set:nV
+            { markdown/options/renderer-prototypes }
+            \l_tmpb_tl
+          \bool_gset_false:N
+            \g_@@_prepending_or_appending_bool
         }
 %    \end{macrocode}
 % \par
@@ -34746,6 +34916,7 @@ end
                   \l_@@_header_identifiers_seq
                   { ##1 }
               },
+              % TODO: Rewrite with appending syntax.
               attributeClassName = {
                 \bool_if:nT
                   {

--- a/tests/support/keyval-setup.tex
+++ b/tests/support/keyval-setup.tex
@@ -19,33 +19,41 @@ renderers = {%
   bracketedSpanAttributeContextBegin = {%
     \TYPE{BEGIN bracketedSpanAttributeContext}},
   bracketedSpanAttributeContextEnd = {%
-    \TYPE{END bracketedSpanAttributeContext}},
+    \TYPE{END bracketedSpanAttributeContext}%
+    \GOBBLE},
   linkAttributeContextBegin = {%
     \TYPE{BEGIN linkAttributeContext}},
   linkAttributeContextEnd = {%
-    \TYPE{END linkAttributeContext}},
+    \TYPE{END linkAttributeContext}%
+    \GOBBLE},
   imageAttributeContextBegin = {%
     \TYPE{BEGIN imageAttributeContext}},
   imageAttributeContextEnd = {%
-    \TYPE{END imageAttributeContext}},
+    \TYPE{END imageAttributeContext}%
+    \GOBBLE},
   codeSpanAttributeContextBegin = {%
     \TYPE{BEGIN codeSpanAttributeContext}},
   codeSpanAttributeContextEnd = {%
-    \TYPE{END codeSpanAttributeContext}},
+    \TYPE{END codeSpanAttributeContext}%
+    \GOBBLE},
   tableAttributeContextBegin = {%
     \TYPE{BEGIN tableAttributeContext}},
   tableAttributeContextEnd = {%
-    \TYPE{END tableAttributeContext}},
+    \TYPE{END tableAttributeContext}%
+    \GOBBLE},
   documentBegin = {%
     \TYPE{BEGIN document}},
   documentEnd = {%
     \TYPE{END document}},
   *Separator = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   *LineBreak = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   ellipsis = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   sectionBegin = {%
     \TYPE{BEGIN section}},
   sectionEnd = {%
@@ -55,29 +63,41 @@ renderers = {%
   headerAttributeContextEnd = {%
     \TYPE{END headerAttributeContext}},
   nbsp = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   leftBrace = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   rightBrace = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   dollarSign = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   percentSign = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   ampersand = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   underscore = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   hash = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   circumflex = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   backslash = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   tilde = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   pipe = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   codeSpan = {%
     \TYPE{#0: #1}},
   (link|image) = {%
@@ -146,7 +166,8 @@ renderers = {%
   inputBlockHtmlElement = {%
     \TYPE{#0: #1}},
   (ticked|halfTicked|unticked)Box = {%
-    \TYPE{#0}},
+    \TYPE{#0}%
+    \GOBBLE},
   jekyllData(Boolean|Number|String) = {%
     \TYPE{BEGIN #0}%
     \TYPE{- key:   #1}%
@@ -182,10 +203,6 @@ renderers = {%
     \TYPE{- raw attribute: #2}%
     \TYPE{END rawBlock}},
   replacementCharacter = {%
-    \TYPE{#0}},
-  % Some parameterless renderers are finished with a pair of curly braces that we should gobble.
-  *ContextEnd += {\GOBBLE},
-  *(Separator|LineBreak) += {\GOBBLE},
-  (ellipsis|nbsp|*Brace|*Sign|ampersand|underscore|hash|circumflex|backslash|tilde|pipe|replacementCharacter) += {\GOBBLE},
-  (ticked|halfTicked|unticked)Box += {\GOBBLE},
+    \TYPE{#0}%
+    \GOBBLE},
 }%

--- a/tests/support/keyval-setup.tex
+++ b/tests/support/keyval-setup.tex
@@ -19,41 +19,33 @@ renderers = {%
   bracketedSpanAttributeContextBegin = {%
     \TYPE{BEGIN bracketedSpanAttributeContext}},
   bracketedSpanAttributeContextEnd = {%
-    \TYPE{END bracketedSpanAttributeContext}%
-    \GOBBLE},
+    \TYPE{END bracketedSpanAttributeContext}},
   linkAttributeContextBegin = {%
     \TYPE{BEGIN linkAttributeContext}},
   linkAttributeContextEnd = {%
-    \TYPE{END linkAttributeContext}%
-    \GOBBLE},
+    \TYPE{END linkAttributeContext}},
   imageAttributeContextBegin = {%
     \TYPE{BEGIN imageAttributeContext}},
   imageAttributeContextEnd = {%
-    \TYPE{END imageAttributeContext}%
-    \GOBBLE},
+    \TYPE{END imageAttributeContext}},
   codeSpanAttributeContextBegin = {%
     \TYPE{BEGIN codeSpanAttributeContext}},
   codeSpanAttributeContextEnd = {%
-    \TYPE{END codeSpanAttributeContext}%
-    \GOBBLE},
+    \TYPE{END codeSpanAttributeContext}},
   tableAttributeContextBegin = {%
     \TYPE{BEGIN tableAttributeContext}},
   tableAttributeContextEnd = {%
-    \TYPE{END tableAttributeContext}%
-    \GOBBLE},
+    \TYPE{END tableAttributeContext}},
   documentBegin = {%
     \TYPE{BEGIN document}},
   documentEnd = {%
     \TYPE{END document}},
   *Separator = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   *LineBreak = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   ellipsis = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   sectionBegin = {%
     \TYPE{BEGIN section}},
   sectionEnd = {%
@@ -63,41 +55,29 @@ renderers = {%
   headerAttributeContextEnd = {%
     \TYPE{END headerAttributeContext}},
   nbsp = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   leftBrace = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   rightBrace = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   dollarSign = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   percentSign = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   ampersand = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   underscore = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   hash = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   circumflex = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   backslash = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   tilde = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   pipe = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   codeSpan = {%
     \TYPE{#0: #1}},
   (link|image) = {%
@@ -166,8 +146,7 @@ renderers = {%
   inputBlockHtmlElement = {%
     \TYPE{#0: #1}},
   (ticked|halfTicked|unticked)Box = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
   jekyllData(Boolean|Number|String) = {%
     \TYPE{BEGIN #0}%
     \TYPE{- key:   #1}%
@@ -203,6 +182,10 @@ renderers = {%
     \TYPE{- raw attribute: #2}%
     \TYPE{END rawBlock}},
   replacementCharacter = {%
-    \TYPE{#0}%
-    \GOBBLE},
+    \TYPE{#0}},
+  % Some parameterless renderers are finished with a pair of curly braces that we should gobble.
+  *ContextEnd += {\GOBBLE},
+  *(Separator|LineBreak) += {\GOBBLE},
+  (ellipsis|nbsp|*Brace|*Sign|ampersand|underscore|hash|circumflex|backslash|tilde|pipe|replacementCharacter) += {\GOBBLE},
+  (ticked|halfTicked|unticked)Box += {\GOBBLE},
 }%


### PR DESCRIPTION
This PR adds support to incremental definitions of token renderers and renderer prototypes in the `\markdownSetup` plain TeX command using the following syntax:

> ``` tex
> \markdownSetup {
>   renderers = {  % or rendererPrototypes
>     headingOne += { code },  % Appends `code` to the top-level heading.
>     % ...
>   }
> }
> ```
> *(Originally drafted in https://github.com/Witiko/markdown/issues/232#issuecomment-1366571332.)*

This PR continues https://github.com/Witiko/markdown/issues/232.

### Tasks
- [x] Implement prepending/appending.
- [x] Unimplement prepending and change the syntax of appending from `$=` to `+=`.
    It's unclear that prepending (`^=`) has useful uses.
    Furthermore, characters `^` and `$` in keys are difficult to parse due to their catcodes.
- [x] Change `\g_@@_appending_bool` to `\g_@@_appending_renderer_bool` and `renderer_prototype_bool`.
- [x] Reimplement appending without etoolbox, so that TeX formats other than LaTeX can easily be supported.
- [x] Redefine default `headerAttributeContextBegin` renderer prototype for LaTeX using appending, as discussed in [\#232][3].
- [x] Document appending in renderers and renderer prototypes.
- [x] Ensure no TODOs remain in [the Files changed tab][2].
- [x] Review the text of the technical documentation.
- [x] Update `CHANGES.md`.

 [2]: https://github.com/Witiko/markdown/pull/435/files
 [3]: https://github.com/Witiko/markdown/issues/232#issuecomment-2034214942