### PR TITLE
Add `\markinline` plain TeX command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 Development:
 
+- Add `\markinline` plain TeX command. (#300, #439)
 - Support incremental definitions of token renderers and renderer prototypes
   in the `\markdownSetup` command.
   (#232, #435, 540a83c0, [matrix.org][matrix-435], #437, #438,

--- a/examples/context-mkiv.tex
+++ b/examples/context-mkiv.tex
@@ -72,16 +72,15 @@ kpse.set_program_name("luatex")
 \catcode`\%=14\relax
 \catcode`\#=6\relax
 
-% Typeset some further examples with inline markdown text.
+% Besides inputting external files, Markdown text can we written directly
+% into a LaTeX document. Markdown text and LaTeX code can be freely combined.
 \startmarkdown
 
-Here are some non-ASCII characters: *ěščřžýáíé*
-and ConTeXt special characters: *|*.
+This is a paragraph of *Markdown text* with inline `\LaTeX`{=tex} code.
 
-Here is a hard line break that we inserted directly from the TeX source
-by typing two spaces at the end of a line.  
-This is stretching TeX's abilities and is only supported in ConTeXt MkIV
-and later.
+``` {=tex}
+This is a paragraph of \LaTeX{} code with inline \markinline{*Markdown text*}.
+```
 
 \stopmarkdown
 

--- a/examples/latex-luatex.tex
+++ b/examples/latex-luatex.tex
@@ -49,8 +49,33 @@ date:   \today
 \catcode`\%=14\relax
 \catcode`\#=6\relax
 
-% Typeset some further examples with inline markdown text.
+% Besides inputting external files, Markdown text can we written directly
+% into a LaTeX document. Markdown text and LaTeX code can be freely combined.
 \begin{markdown}
-Here are some non-ASCII characters: *ěščřžýáíé*.
+This is a paragraph of *Markdown text* with inline `\LaTeX`{=tex} code.
+
+``` {=tex}
+This is a paragraph of \LaTeX{} code with inline \markinline{*Markdown text*}.
+```
+\end{markdown}
+
+% Besides YAML, LaTeX, and Markdown, you can also type HTML in your documents.
+\begin{markdown}
+Here is some <b>HTML code</b> mixed *with Markdown*. In `\TeX`{=tex}, the HTML
+code will be silently ignored, whereas in `\TeX`{=tex}4ht, the HTML code will
+be passed through to the output:
+
+<table border="1">
+  <tr>
+    <td>Emil</td>
+    <td>Tobias</td>
+    <td>Linus</td>
+  </tr>
+  <tr>
+    <td>16</td>
+    <td>14</td>
+    <td>10</td>
+  </tr>
+</table>
 \end{markdown}
 \end{document}

--- a/examples/latex-pdftex.tex
+++ b/examples/latex-pdftex.tex
@@ -50,15 +50,21 @@ date:   \today
 \catcode`\%=14\relax
 \catcode`\#=6\relax
 
-% Typeset some further examples with inline markdown text.
+% Besides inputting external files, Markdown text can we written directly
+% into a LaTeX document. Markdown text and LaTeX code can be freely combined.
 \begin{markdown}
-Here are some non-ASCII characters: *ěščřžýáíé*.
+This is a paragraph of *Markdown text* with inline `\LaTeX`{=tex} code.
+
+``` {=tex}
+This is a paragraph of \LaTeX{} code with inline \markinline{*Markdown text*}.
+```
 \end{markdown}
 
-\begin{markdown}[hybrid]
-Here is some <b>HTML code</b> mixed *with Markdown*. In \TeX, the HTML code
-will be silently ignored, whereas in \TeX 4ht, the HTML code will be passed
-through to the output:
+% Besides YAML, LaTeX, and Markdown, you can also type HTML in your documents.
+\begin{markdown}
+Here is some <b>HTML code</b> mixed *with Markdown*. In `\TeX`{=tex}, the HTML
+code will be silently ignored, whereas in `\TeX`{=tex}4ht, the HTML code will
+be passed through to the output:
 
 <table border="1">
   <tr>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -33945,7 +33945,10 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \tl_new:N
-  \l_@@_after_markinline_tl
+  \g_@@_after_markinline_tl
+\tl_gset:Nn
+  \g_@@_after_markinline_tl
+  { \unskip }
 \cs_new:Npn
   \markinline
   {
@@ -34029,7 +34032,7 @@ end
           \cE }
         \c { group_end: }
         \c { tl_use:N }
-          \c { l_@@_after_markinline_tl }
+          \c { g_@@_after_markinline_tl }
       }
       {
         \msg_error:nn
@@ -34037,7 +34040,7 @@ end
           { markinline-peek-failure }
         \group_end:
         \tl_use:N
-          \l_@@_after_markinline_tl
+          \g_@@_after_markinline_tl
       }
   }
 \msg_new:nnn
@@ -34209,7 +34212,7 @@ end
         \c { group_begin: }
         \c { @@_setup:n }
           \cB { \2 \cE }
-        \c { tl_set:Nn }
+        \c { tl_put_right:Nn }
           \c { l_@@_after_markinline_tl }
           \cB { \c { group_end: } \cE }
         \c { markinlinePlainTeX }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34019,11 +34019,15 @@ end
 % \end{markdown}
 %  \begin{macrocode}
         \c { group_end: }
+        \c { group_begin: }
+        \c { @@_setup:n }
+          \cB { contentLevel = inline \cE }
         \c { markdownInput }
           \cB {
             \c { markdownOptionOutputDir } /
             \c { markdownOptionInputTempFileName }
           \cE }
+        \c { group_end: }
         \c { tl_use:N }
           \c { l_@@_after_markinline_tl }
       }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34213,7 +34213,7 @@ end
         \c { @@_setup:n }
           \cB { \2 \cE }
         \c { tl_put_right:Nn }
-          \c { l_@@_after_markinline_tl }
+          \c { g_@@_after_markinline_tl }
           \cB { \c { group_end: } \cE }
         \c { markinlinePlainTeX }
       }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -21362,7 +21362,8 @@ pdflatex --shell-escape document.tex
 %
 %### Typesetting Markdown
 % The interface exposes the \envmdef{markdown} and \envmdef{markdown*}
-% \LaTeX{} environments, and redefines the \mref{markdownInput} command.
+% \LaTeX{} environments, and redefines the \mref{markinline} and
+% \mref{markdownInput} commands.
 %
 % The \envmref{markdown} and \envmref{markdown*} \LaTeX{} environments are used
 % to typeset markdown document fragments. Both \LaTeX{} environments accept
@@ -21402,6 +21403,13 @@ pdflatex --shell-escape document.tex
 % \% ...                              \% ...
 % \end{document}                     \end{document}
 % ```````
+%
+% The \mref{markinline} macro accepts a single mandatory parameter containing
+% inline markdown content and expands to the result of the conversion of the
+% input markdown document to plain \TeX{}.  Unlike the \mref{markinline} macro
+% provided by the plain \TeX{} interface, this macro also accepts \LaTeX{}
+% interface options (see Section <#sec:latex-options>) as its optional
+% argument. These options will only influnce this markdown content.
 %
 % The \mref{markdownInput} macro accepts a single mandatory parameter containing
 % the filename of a markdown document and expands to the result of the
@@ -33936,6 +33944,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\tl_new:N
+  \l_@@_after_markinline_tl
 \cs_new:Npn
   \markinline
   {
@@ -34014,12 +34024,16 @@ end
             \c { markdownOptionOutputDir } /
             \c { markdownOptionInputTempFileName }
           \cE }
+        \c { tl_use:N }
+          \c { l_@@_after_markinline_tl }
       }
       {
         \msg_error:nn
           { markdown }
           { markinline-peek-failure }
         \group_end:
+        \tl_use:N
+          \l_@@_after_markinline_tl
       }
   }
 \msg_new:nnn
@@ -34162,21 +34176,59 @@ end
 % \par
 % \begin{markdown}
 %
-%### Logging Facilities
-% The \LaTeX{} implementation redefines the plain \TeX{} logging macros (see
-% Section <#sec:tex-interface-logging>) to use the \LaTeX{} `\PackageInfo`,
-% `\PackageWarning`, and `\PackageError` macros.
+%### Typesetting Markdown
+% The \mdef{markinlinePlainTeX} macro is used to store the original plain
+% \TeX{} implementation of the \mref{markinline} macro. The \mref{markinline}
+% macro is then redefined to accept an optional argument with options
+% recognized by the \LaTeX{} interface (see Section <#sec:latex-options>).
 %
 % \end{markdown}
 %  \begin{macrocode}
+\ExplSyntaxOn
+\cs_gset_eq:NN
+  \markinlinePlainTeX
+  \markinline
+\cs_gset:Npn
+  \markinline
+  {
+    \peek_regex_replace_once:nn
+      { ( \[ (.*?) \] ) ? }
+      {
 %    \end{macrocode}
 % \par
 % \begin{markdown}
 %
-%### Typesetting Markdown
+% Apply the options locally.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \c { group_begin: }
+        \c { @@_setup:n }
+          \cB { \2 \cE }
+        \c { tl_set:Nn }
+          \c { l_@@_after_markinline_tl }
+          \cB { \c { group_end: } \cE }
+        \c { markinlinePlainTeX }
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% Reintroduce the opening brace of \mref{markdownInput} that we removed
+% from the input stream by peeking.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \cO \{
+      }
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
 % The \mdef{markdownInputPlainTeX} macro is used to store the original plain
 % \TeX{} implementation of the \mref{markdownInput} macro. The \mref{markdownInput}
-% is then redefined to accept an optional argument with options recognized by
+% macro is then redefined to accept an optional argument with options recognized by
 % the \LaTeX{} interface (see Section <#sec:latex-options>).
 %
 % \end{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34216,16 +34216,6 @@ end
           \c { l_@@_after_markinline_tl }
           \cB { \c { group_end: } \cE }
         \c { markinlinePlainTeX }
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% Reintroduce the opening brace of \mref{markdownInput} that we removed
-% from the input stream by peeking.
-%
-% \end{markdown}
-%  \begin{macrocode}
-        \cO \{
       }
   }
 \ExplSyntaxOff

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11350,7 +11350,7 @@ pdftex --shell-escape document.tex
 %### Typesetting Markdown {#tex-typesetting}
 %
 % The interface exposes the \mdef{markdownBegin}, \mdef{markdownEnd},
-% \mdef{markdownInput}, and \mdef{markdownEscape} macros.
+% \mdef{markinline}, \mdef{markdownInput}, and \mdef{markdownEscape} macros.
 %
 % The \mref{markdownBegin} macro marks the beginning of a markdown document
 % fragment and the \mref{markdownEnd} macro marks its end.
@@ -11408,6 +11408,38 @@ pdftex --shell-escape document.tex
 % \bye
 % ```````
 %
+% You can use the \mref{markinline} macro to input inline markdown content.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\let\markinline\relax
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The following example plain \TeX{} code showcases the usage of the
+% \mref{markinline} macro:
+%
+% ``` tex
+% \input markdown
+% \markinline{_Hello_ **world**}
+% \bye
+% ```````
+%
+% The above code has the same effect as the below code:
+%
+% ``` tex
+% \input markdown
+% \markdownSetup{contentLevel=inline}
+% \markdownBegin
+% _Hello_ **world** ...
+% \markdownEnd
+% \bye
+% ```````
+%
+% The \mref{markinline} macro is subject to the same limitations as the
+% \mref{markdownBegin} and \mref{markdownEnd} macros.
+%
 % You can use the \mref{markdownInput} macro to include markdown documents,
 % similarly to how you might use the \mref{input} \TeX{} primitive to include
 % \TeX{} documents. The \mref{markdownInput} macro accepts a single parameter
@@ -11421,7 +11453,7 @@ pdftex --shell-escape document.tex
 % \par
 % \begin{markdown}
 %
-% This macro is not subject to the abovelisted limitations of the
+% This macro is not subject to the limitations of the
 % \mref{markdownBegin} and \mref{markdownEnd} macros.
 %
 % The following example plain \TeX{} code showcases the usage of the
@@ -11914,11 +11946,11 @@ macro after loading the package has no effect.
 %
 % The \mdef{markdownOptionStripPercentSigns} macro controls whether a percent
 % sign (`\%`) at the beginning of a line will be discarded when buffering
-% Markdown input (see Section <#sec:buffering>) or not. Notably, this
-% enables the use of markdown when writing \TeX{} package documentation using
-% the \pkg{Doc} \LaTeX{}~package~[@mittelbach17] or similar. The recognized
-% values of the macro are `true` (discard) and `false` (retain). It defaults
-% to `false`.
+% Markdown input (see sections <#sec:buffering-block> and
+% <#sec:buffering-inline>) or not. Notably, this enables the use of markdown
+% when writing \TeX{} package documentation using the \pkg{Doc}
+% \LaTeX{}~package~[@mittelbach17] or similar. The recognized values of the
+% macro are `true` (discard) and `false` (retain). It defaults to `false`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -33655,7 +33687,7 @@ end
 % \par
 % \begin{markdown}
 %
-%### Buffering Markdown Input {#buffering}
+%### Buffering Block-Level Markdown Input {#buffering-block}
 %
 % The macros \mdef{markdownInputFileStream} and \mdef{markdownOutputFileStream}
 % contain the number of the input and output file streams that will be used for
@@ -33714,7 +33746,8 @@ end
     |markdownIfOption{frozenCache}{}{@
       |immediate|openout|markdownOutputFileStream@
         |markdownOptionInputTempFileName|relax@
-      |markdownInfo{Buffering markdown input into the temporary @
+      |markdownInfo{@
+        Buffering block-level markdown input into the temporary @
         input file "|markdownOptionInputTempFileName" and scanning @
         for the closing token sequence "#1"}@
     }@
@@ -33892,6 +33925,112 @@ end
   { disabled-shell-access }
   { Shell~escape~is~disabled }
   \l_tmpa_tl
+\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+%
+%### Buffering Inline Markdown Input {#buffering-inline}
+%
+% This section describes the implementation of the macro \mref{markinline}.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_new:Npn
+  \markinline
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Locally change the category of the special plain \TeX{} characters
+% to *other* in order to prevent unwanted interpretation of the input
+% markdown text as \TeX{} code.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \group_begin:
+    \cctab_select:N
+      \c_other_cctab
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Unless we are reading markdown documents from the frozen cache,
+% open the file \Opt{inputTempFileName} for writing.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \@@_if_option:nF
+      { frozenCache }
+      {
+        \immediate
+          \openout
+          \markdownOutputFileStream
+          \markdownOptionInputTempFileName
+          \relax
+        \msg_info:nne
+          { markdown }
+          { buffering-markinline }
+          { \markdownOptionInputTempFileName }
+      }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Peek ahead and extract the inline markdown text.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \peek_regex_replace_once:nnF
+      { { (.*?) } }
+      {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Unless we are reading markdown documents from the frozen cache,
+% store the text in the file \Opt{inputTempFileName} and close it.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \c { @@_if_option:nF }
+          \cB { frozenCache \cE }
+          \cB {
+            \c { immediate }
+              \c { write }
+              \c { markdownOutputFileStream }
+              \cB { \1 \cE }
+            \c { immediate }
+              \c { closeout }
+              \c { markdownOutputFileStream }
+          \cE }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Reset the category codes and `\input` the result of the conversion.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \c { group_end: }
+        \c { markdownInput }
+          \cB {
+            \c { markdownOptionOutputDir } /
+            \c { markdownOptionInputTempFileName }
+          \cE }
+      }
+      {
+        \msg_error:nn
+          { markdown }
+          { markinline-peek-failure }
+        \group_end:
+      }
+  }
+\msg_new:nnn
+  { markdown }
+  { buffering-markinline }
+  { Buffering~inline~markdown~input~into~the~temporary~input~file~"#1". }
+\msg_new:nnnn
+  { markdown }
+  { markinline-peek-failure }
+  { Use~of~\iow_char:N \\ markinline~doesn't~match~its~definition }
+  { The~macro~should~be~followed~by~inline~markdown~text~in~curly~braces }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}


### PR DESCRIPTION
Closes #300.

![image](https://github.com/Witiko/markdown/assets/603082/06cc9070-3f8c-440c-8777-c3819ccbb16a)

### Tasks

- [x] Add plain TeX command `\markinline`.
- [x] Add optional parameters to `\markinline` in LaTeX.
- [x] Use `\markinline` in example documents.
- [x] Update `CHANGES.md`.