### PR TITLE
Add file `DEPENDS.txt`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Fixes:
 Documentation:
 
 - Fix various typos. (#454, contributed by @mbertucci47)
+- Add file `DEPENDS.txt`. (#462, #463)
 
 Continuous Integration:
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ INSTALLABLES=markdown.lua markdown-cli.lua markdown.tex markdown.sty t-markdown.
   markdownthemewitiko_markdown_defaults.sty t-markdownthemewitiko_markdown_defaults.tex
 EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES) \
   $(DEPENDENCIES)
-MAKEABLES=$(TECHNICAL_DOCUMENTATION) $(USER_MANUAL) $(INSTALLABLES) $(EXAMPLES)
+MAKEABLES=$(TECHNICAL_DOCUMENTATION) $(USER_MANUAL) $(INSTALLABLES) $(EXAMPLES) $(DEPENDENCIES)
 RESOURCES=$(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(EXAMPLES) \
   $(MAKES) $(READMES) $(INSTALLER) $(DTXARCHIVE) $(TESTS) $(DEPENDENCIES)
 EVERYTHING=$(RESOURCES) $(INSTALLABLES) $(LIBRARIES)
@@ -70,6 +70,9 @@ ifndef DOCKER_TEXLIVE_TAG
 endif
 ifeq ($(DOCKER_DEV_IMAGE), true)
 	DOCKER_TAG_POSTFIX=-no_docs
+ifeq ($(DOCKER_TEXLIVE_TAG), latest)
+	DOCKER_TEXLIVE_TAG=latest-minimal
+endif
 endif
 DOCKER_TEMPORARY_IMAGE=ghcr.io/witiko/markdown
 DOCKER_TEMPORARY_TAG=$(VERSION)-$(DOCKER_TEXLIVE_TAG)$(DOCKER_TAG_POSTFIX)
@@ -131,9 +134,11 @@ $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	    -e 's#(((LASTMODIFIED)))#$(LASTMODIFIED)#g' \
 	    $(INSTALLABLES)
 	sed -i \
-	    -e '/\\ExplSyntaxOff/{N;/\\ExplSyntaxOn/d;}' \
+	    -e '/\\ExplSyntaxOff/ { N; /\\ExplSyntaxOn/d; }' \
 	    $(INSTALLABLES)
-	grep -v '^#' $(DEPENDENCIES) | sort -u -o $(DEPENDENCIES)
+	( \
+	  sed -n '/^#/ ! { s/\s*#.*//; p }' $(DEPENDENCIES); \
+	) | sort -u -o $(DEPENDENCIES)
 
 # This target produces the version file.
 $(VERSION_FILE): force

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ DTXARCHIVE=markdown.dtx
 INSTALLER=markdown.ins docstrip.cfg
 TECHNICAL_DOCUMENTATION_RESOURCES=markdown.bib markdown-figure-block-diagram.tex \
   markdownthemewitiko_markdown_techdoc.sty
+DEPENDENCIES=DEPENDS.txt
 TECHNICAL_DOCUMENTATION=markdown.pdf
 MARKDOWN_USER_MANUAL=markdown.md markdown.css
 HTML_USER_MANUAL=markdown.html markdown.css
@@ -47,10 +48,11 @@ INSTALLABLES=markdown.lua markdown-cli.lua markdown.tex markdown.sty t-markdown.
   markdownthemewitiko_dot.sty markdownthemewitiko_graphicx_http.sty \
   markdownthemewitiko_tilde.tex markdownthemewitiko_markdown_defaults.tex \
   markdownthemewitiko_markdown_defaults.sty t-markdownthemewitiko_markdown_defaults.tex
-EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES)
+EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES) \
+  $(DEPENDENCIES)
 MAKEABLES=$(TECHNICAL_DOCUMENTATION) $(USER_MANUAL) $(INSTALLABLES) $(EXAMPLES)
 RESOURCES=$(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(EXAMPLES) \
-  $(MAKES) $(READMES) $(INSTALLER) $(DTXARCHIVE) $(TESTS)
+  $(MAKES) $(READMES) $(INSTALLER) $(DTXARCHIVE) $(TESTS) $(DEPENDENCIES)
 EVERYTHING=$(RESOURCES) $(INSTALLABLES) $(LIBRARIES)
 GITHUB_PAGES=gh-pages
 
@@ -131,6 +133,7 @@ $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	sed -i \
 	    -e '/\\ExplSyntaxOff/{N;/\\ExplSyntaxOn/d;}' \
 	    $(INSTALLABLES)
+	grep -v '^#' $(DEPENDENCIES) | sort -u -o $(DEPENDENCIES)
 
 # This target produces the version file.
 $(VERSION_FILE): force
@@ -247,9 +250,9 @@ $(DISTARCHIVE): $(EVERYTHING) $(TDSARCHIVE)
 	rm -f markdown
 
 # This target produces the CTAN archive.
-$(CTANARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(LIBRARIES) $(TDSARCHIVE)
+$(CTANARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(LIBRARIES) $(TDSARCHIVE) $(DEPENDENCIES)
 	-ln -s . markdown
-	zip -MM -r -v -nw --symlinks $@ $(addprefix markdown/,$(DTXARCHIVE) $(INSTALLER) $(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(LIBRARIES)) $(TDSARCHIVE)
+	zip -MM -r -v -nw --symlinks $@ $(addprefix markdown/,$(DTXARCHIVE) $(INSTALLER) $(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(LIBRARIES)) $(TDSARCHIVE) $(DEPENDENCIES)
 	rm -f markdown
 
 # This pseudo-target removes any existing auxiliary files and directories.

--- a/examples/DEPENDS.txt
+++ b/examples/DEPENDS.txt
@@ -1,0 +1,10 @@
+soft babel-english
+soft collection-context
+soft collection-latex
+soft collection-latexrecommended
+soft collection-luatex
+soft dvipng
+soft latex-bin
+soft make4ht
+soft optex
+soft xetex

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1148,6 +1148,17 @@ end)()
 %:    A package that implements Unicode case-folding in \TeX{} Live${}\geq{}2020$.
 %
 % \end{markdown}
+% \iffalse
+%</lua>
+%<*depends>
+% \fi
+%  \begin{macrocode}
+hard lua-uni-algos
+%    \end{macrocode}
+% \iffalse
+%</depends>
+%<*lua>
+% \fi
 %  \begin{macrocode}
 local uni_algos = require("lua-uni-algos")
 %    \end{macrocode}
@@ -1166,6 +1177,13 @@ local uni_algos = require("lua-uni-algos")
 % \end{markdown}
 % \iffalse
 %</lua>
+%<*depends>
+% \fi
+%  \begin{macrocode}
+# hard lua-tinyyaml  # TODO: Uncomment after TeX Live 2022 has been deprecated.
+%    \end{macrocode}
+% \iffalse
+%</depends>
 %<*tex>
 % \fi
 % \par
@@ -1185,18 +1203,33 @@ local uni_algos = require("lua-uni-algos")
 %     such as options, renderers, and renderer prototypes.
 %
 % \end{markdown}
-%  \begin{macrocode}
+% \iffalse
 %</tex>
+%<*depends>
+% \fi
+%  \begin{macrocode}
+hard l3kernel
+%    \end{macrocode}
+% \iffalse
+%</depends>
 %<*context>
+% \fi
+%  \begin{macrocode}
 \unprotect
+%    \end{macrocode}
+% \iffalse
 %</context>
 %<*context,tex>
+% \fi
+%  \begin{macrocode}
 \ifx\ExplSyntaxOn\undefined
   \input expl3-generic
 \fi
+%    \end{macrocode}
+% \iffalse
 %</context,tex>
 %<*tex>
-%    \end{macrocode}
+% \fi
 % \begin{markdown}
 %
 % \pkg{lt3luabridge}
@@ -1204,6 +1237,20 @@ local uni_algos = require("lua-uni-algos")
 %:    A package that allows us to execute Lua code with LuaTeX as well as
 %     with other TeX engines that provide the *shell escape* capability,
 %     which allows them to execute code with the system's shell.
+%
+% \end{markdown}
+% \iffalse
+%</tex>
+%<*depends>
+% \fi
+%  \begin{macrocode}
+hard lt3luabridge
+%    \end{macrocode}
+% \iffalse
+%</depends>
+%<*tex>
+% \fi
+% \begin{markdown}
 %
 % The plain \TeX{} part of the package also requires the following Lua module:
 %
@@ -1249,10 +1296,13 @@ local uni_algos = require("lua-uni-algos")
 %<*themes-witiko-dot,latex-themes-witiko-graphicx-http>
 % \fi
 %  \begin{macrocode}
-\NeedsTeXFormat{LaTeX2e}%
+\NeedsTeXFormat{LaTeX2e}
+\RequirePackage{expl3}
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-dot,latex-themes-witiko-graphicx-http>
+%</latex>
+%<*depends>
 % \fi
 % \begin{markdown}
 % a \TeX{} engine that extends \Hologo{eTeX}, and all the plain \TeX{}
@@ -1269,10 +1319,23 @@ local uni_algos = require("lua-uni-algos")
 %
 %:    A package that provides the `\url` macro for the typesetting of links.
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft url
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{graphicx}
 %
 %:    A package that provides the `\includegraphics` macro for the typesetting
-%     of images.
+%     of images.Furthermore, it also provides a key-value interface that is
+%     used in the default renderer prototypes for image attribute contexts.
+%
+% \end{markdown}
+%  \begin{macrocode}
+soft graphics
+%    \end{macrocode}
+% \begin{markdown}
 %
 % \pkg{paralist}
 %
@@ -1281,16 +1344,34 @@ local uni_algos = require("lua-uni-algos")
 %     ordered lists, and definition lists as well as the rendering of
 %     fancy lists.
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft paralist
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{ifthen}
 %
 %:    A package that provides a concise syntax for the inspection of macro
 %     values. It is used in the `witiko/dot` \LaTeX{} theme (see Section
 %     <#sec:latexthemes>).
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft latex
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{fancyvrb}
 %
 %:    A package that provides the `\VerbatimInput` macros for the verbatim
 %     inclusion of files containing code.
+%
+% \end{markdown}
+%  \begin{macrocode}
+soft fancyvrb
+%    \end{macrocode}
+% \begin{markdown}
 %
 % \pkg{csvsimple}
 %
@@ -1298,16 +1379,35 @@ local uni_algos = require("lua-uni-algos")
 %     \acro{csv} files in the default renderer prototypes for iA\\,Writer
 %     content blocks.
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft csvsimple
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{gobble}
 %
 %:    A package that provides the `\@gobblethree` \TeX{} command that
 %     is used in the default renderer prototype for citations. The package
 %     is included in \TeX Live${}\geq{}2016$.
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft gobble
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{amsmath} and \pkg{amssymb}
 %
 %:    Packages that provide symbols used for drawing ticked and unticked
 %     boxes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+soft amsmath
+soft amsfonts
+%    \end{macrocode}
+% \begin{markdown}
 %
 % \pkg{catchfile}
 %
@@ -1315,11 +1415,11 @@ local uni_algos = require("lua-uni-algos")
 %     is used in the `witiko/graphicx/http` \LaTeX{} theme, see Section
 %     <#sec:latexthemes>.
 %
-% \pkg{graphicx}
-%
-%:    A package that builds upon the \pkg{graphics} package, which is part of
-%     the \LaTeXe{} kernel. It provides a key-value interface that is used in
-%     the default renderer prototypes for image attribute contexts.
+% \end{markdown}
+%  \begin{macrocode}
+soft catchfile
+%    \end{macrocode}
+% \begin{markdown}
 %
 % \pkg{grffile}
 %
@@ -1330,6 +1430,12 @@ local uni_algos = require("lua-uni-algos")
 %     the `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes, see Section
 %     <#sec:latexthemes>.
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft grffile
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{etoolbox}
 %
 %:    A package that is used to polyfill the general hook management system in
@@ -1337,17 +1443,35 @@ local uni_algos = require("lua-uni-algos")
 %     <#sec:latex-yaml-metadata>, and also in the default renderer prototype
 %     for identifier attributes.
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft etoolbox
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{soulutf8}
 %
 %:    A package that is used in the default renderer prototype for
 %     strike-throughs and marked text.
 %     <!-- TODO: 1,$s/soulutf8/soul/g in TeX Live 2023. -->
 %
+% \end{markdown}
+%  \begin{macrocode}
+soft soul
+%    \end{macrocode}
+% \begin{markdown}
+%
 % \pkg{ltxcmds}
 %
 %:    A package that is used to detect whether the \pkg{minted} and
 %     \pkg{listings} packages are loaded in the default renderer prototype
 %     for fenced code blocks.
+%
+% \end{markdown}
+%  \begin{macrocode}
+soft ltxcmds
+%    \end{macrocode}
+% \begin{markdown}
 %
 % \pkg{verse}
 %
@@ -1356,10 +1480,13 @@ local uni_algos = require("lua-uni-algos")
 %
 % \end{markdown}
 %  \begin{macrocode}
-\RequirePackage{expl3}
+soft verse
 %    \end{macrocode}
+% \begin{markdown}
+%
+% \end{markdown}
 % \iffalse
-%</latex>
+%</depends>
 %<*context>
 % \fi
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1359,6 +1359,7 @@ soft paralist
 % \end{markdown}
 %  \begin{macrocode}
 soft latex
+soft epstopdf-pkg  # required by `latex`
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -1382,6 +1383,8 @@ soft fancyvrb
 % \end{markdown}
 %  \begin{macrocode}
 soft csvsimple
+soft pgf  # required by `csvsimple`, which loads `pgfkeys.sty`
+soft tools  # required by `csvsimple`, which loads `shellesc.sty`
 %    \end{macrocode}
 % \begin{markdown}
 %

--- a/markdown.ins
+++ b/markdown.ins
@@ -25,5 +25,6 @@
     \file{markdown.css}{\from{markdown.dtx}{manual-css}}
     \file{markdown-figure-block-diagram.tex}{\from{markdown.dtx}{techdoc-block-diagram}}
     \file{markdown.bib}{\from{markdown.dtx}{techdoc-bibliography}}
+    \file{DEPENDS.txt}{\from{markdown.dtx}{depends}}
 }
 \endbatchfile

--- a/tests/DEPENDS.txt
+++ b/tests/DEPENDS.txt
@@ -1,0 +1,3 @@
+soft context
+soft latex-bin
+soft xetex


### PR DESCRIPTION
### Tasks

- [x] Add [file `DEPENDS.txt`][1] to `markdown.dtx`, `markdown.ins`, and `Makefile`.
      This file should be based on technical documentation and [the file of the same name][2] in [witiko/expltools#3](https://github.com/Witiko/expltools/pull/3).
- [x] Use file `DEPENDS.txt` to produce a minimal image in the CI for pull requests.
- [x] Update `CHANGES.md`

Closes #462.

 [1]: https://tex.stackexchange.com/a/598696/70941
 [2]: https://github.com/Witiko/expltools/blob/0b1111f/texmf/tex/latex/markdown/DEPENDS.txt