### PR TITLE
Produce more meaningful error message when KPathSea has failed to locate a file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 3.7.0
 
+Fixes:
+
+- Produce more meaningful error message when KPathSea has failed
+  to locate a file. (#458, #472, reported by @Yggdrasil128)
+
 ## 3.6.2 (2024-07-14)
 
 Fixes:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26291,7 +26291,7 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 %  \begin{macrocode}
 parsers.punctuation            = {}
 (function()
-  local pathname = assert(kpse.lookup("UnicodeData.txt"),
+  local pathname = assert(kpse.find_file("UnicodeData.txt"),
     [[Could not locate file "UnicodeData.txt"]])
   local file = assert(io.open(pathname, "r"),
     [[Could not open file "UnicodeData.txt"]])
@@ -33066,7 +33066,7 @@ function M.new(options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-      local pathname = assert(kpse.lookup(filename),
+      local pathname = assert(kpse.find_file(filename),
         [[Could not locate user-defined syntax extension "]]
         .. pathname .. [[" for reading]])
       local input_file = assert(io.open(pathname, "r"),

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26291,7 +26291,8 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 %  \begin{macrocode}
 parsers.punctuation            = {}
 (function()
-  local pathname = kpse.lookup("UnicodeData.txt")
+  local pathname = assert(kpse.lookup("UnicodeData.txt"),
+    [[Could not locate file "UnicodeData.txt"]])
   local file = assert(io.open(pathname, "r"),
     [[Could not open file "UnicodeData.txt"]])
   for line in file:lines() do
@@ -33065,7 +33066,9 @@ function M.new(options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-      local pathname = kpse.lookup(filename)
+      local pathname = assert(kpse.lookup(filename),
+        [[Could not locate user-defined syntax extension "]]
+        .. pathname .. [[" for reading]])
       local input_file = assert(io.open(pathname, "r"),
         [[Could not open user-defined syntax extension "]]
         .. pathname .. [[" for reading]])

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -33068,7 +33068,7 @@ function M.new(options)
 %  \begin{macrocode}
       local pathname = assert(kpse.find_file(filename),
         [[Could not locate user-defined syntax extension "]]
-        .. pathname .. [[" for reading]])
+        .. filename .. [[" for reading]])
       local input_file = assert(io.open(pathname, "r"),
         [[Could not open user-defined syntax extension "]]
         .. pathname .. [[" for reading]])


### PR DESCRIPTION
This PR produces more meaningful error message when KPathSea has failed to locate a file, as discussed in https://github.com/Witiko/markdown/issues/458#issuecomment-2256432061. Furthermore, this PR uses the faster function `kpse.find_file()` instead of `lookup()` when locating a single file.

This PR continues ticket #458.