### PR TITLE
Ensure that all code lines are shorter than 72 characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,19 @@ jobs:
       - name: Check for tabs and trailing spaces
         run: |
           ! grep -n -P '\t|\s+$' markdown.dtx
+  linelength:
+    name: Style check (Line length)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+      - name: Extract scripts
+        run: make base
+      - name: Check the line length
+        run: make check-line-length
   shellcheck:
     name: Style check (Bash)
     runs-on: ubuntu-latest
@@ -130,6 +143,7 @@ jobs:
     name: Build Docker image
     needs:
       - spacecheck
+      - linelength
       - shellcheck
       - luacheck
       - markdownlint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,7 @@ jobs:
           repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - name: Check for tabs and trailing spaces
-        run: |
-          ! grep -n -P '\t|\s+$' markdown.dtx
+        run: make check-tabs-and-spaces
   linelength:
     name: Style check (Line length)
     runs-on: ubuntu-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ Deprecation:
   Users should use `jekyllDataTypographicString` instead.
   (istqborg/istqb_product_base#46, #440, #451, sponsored by @istqborg)
 
+Continuous Integration:
+
+- Ensure that all code lines are shorter than 72 characters. (#478)
+
 Experiments:
 
 - Measure the speed of the Markdown package across recent versions.

--- a/Makefile
+++ b/Makefile
@@ -279,4 +279,8 @@ implode: clean
 
 # This pseudo-target checks that the length of lines in the source files.
 check-line-length: $(INSTALLABLES)
-	! grep -En '^.{73,}$$' $^
+	! grep -n -E '^.{73,}$$' $^
+
+# This pseudo-target checks for tabs and trailing spaces in the source files.
+check-tabs-and-spaces: $(DTXARCHIVE)
+	! grep -n -P '\t|\s+$$' $<

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all base clean implode dist test force \
   docker-image docker-push-temporary-tag docker-print-temporary-tag \
-  docker-push-release-tag preview
+  docker-push-release-tag preview check-line-length
 
 SHELL=/bin/bash
 
@@ -276,3 +276,7 @@ implode: clean
 	rm -f $(MAKEABLES) $(ARCHIVES)
 	$(MAKE) -C examples implode
 	$(MAKE) -C libraries implode
+
+# This pseudo-target checks that the length of lines in the source files.
+check-line-length: $(INSTALLABLES)
+	! grep -En '^.{73,}$$' $^

--- a/docstrip.cfg
+++ b/docstrip.cfg
@@ -11,12 +11,12 @@
 -- permit persons to whom the Software is furnished to do so, subject to^^J%
 -- the following conditions:^^J%
 --^^J%
--- The above copyright notice and this permission notice shall be included^^J%
--- in all copies or substantial portions of the Software.^^J%
+-- The above copyright notice and this permission notice shall be^^J%
+-- included in all copies or substantial portions of the Software.^^J%
 --^^J%
 -- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,^^J%
 -- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF^^J%
--- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.^^J%
+-- MERCHANTABILITY, FITNESS FOR PARTICULAR PURPOSE AND NONINFRINGEMENT.^^J%
 -- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY^^J%
 -- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,^^J%
 -- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE^^J%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -814,7 +814,9 @@ abbr {
   },
   jekyllDataRenderers = {
     /authors/* = {%
-      \expandafter\gdef\expandafter\ltd@title@author\expandafter{\ltd@title@author, #1}%
+      \expandafter\gdef
+        \expandafter\ltd@title@author
+          \expandafter{\ltd@title@author, #1}%
     },
     title = {%
       \gdef\ltd@title@title{#1}%
@@ -928,8 +930,10 @@ documentation][techdoc].
 %  \begin{macrocode}
 local metadata = {
     version   = "(((VERSION)))",
-    comment   = "A module for the conversion from markdown to plain TeX",
-    author    = "John MacFarlane, Hans Hagen, Vít Starý Novotný, Andrej Genčur",
+    comment   = "A module for the conversion from markdown "
+             .. "to plain TeX",
+    author    = "John MacFarlane, Hans Hagen, Vít Starý Novotný, "
+             .. "Andrej Genčur",
     copyright = {"2009-2016 John MacFarlane, Hans Hagen",
                  "2016-2024 Vít Starý Novotný, Andrej Genčur"},
     license   = "LPPL 1.3c"
@@ -1181,7 +1185,7 @@ local uni_algos = require("lua-uni-algos")
 %<*depends>
 % \fi
 %  \begin{macrocode}
-# hard lua-tinyyaml  # TODO: Uncomment after TeX Live 2022 has been deprecated.
+# hard lua-tinyyaml  # TODO: Uncomment after TeX Live 2022 deprecation.
 %    \end{macrocode}
 % \iffalse
 %</depends>
@@ -2205,7 +2209,9 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 \prop_new:N \g_@@_default_lua_options_prop
 \seq_new:N \g_@@_option_layers_seq
 \tl_const:Nn \c_@@_option_layer_lua_tl { lua }
-\seq_gput_right:NV \g_@@_option_layers_seq \c_@@_option_layer_lua_tl
+\seq_gput_right:NV
+  \g_@@_option_layers_seq
+  \c_@@_option_layer_lua_tl
 \cs_new:Nn
   \@@_add_lua_option:nnn
   {
@@ -2282,21 +2288,50 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 \cs_generate_variant:Nn
   \msg_error:nnnn
   { nnnV }
-\seq_new:N \g_@@_option_types_seq
-\tl_const:Nn \c_@@_option_type_clist_tl { clist }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_clist_tl
-\tl_const:Nn \c_@@_option_type_counter_tl { counter }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_counter_tl
-\tl_const:Nn \c_@@_option_type_boolean_tl { boolean }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_boolean_tl
-\tl_const:Nn \c_@@_option_type_number_tl  { number  }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_number_tl
-\tl_const:Nn \c_@@_option_type_path_tl    { path    }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_path_tl
-\tl_const:Nn \c_@@_option_type_slice_tl   { slice   }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_slice_tl
-\tl_const:Nn \c_@@_option_type_string_tl  { string  }
-\seq_gput_right:NV \g_@@_option_types_seq \c_@@_option_type_string_tl
+\seq_new:N
+  \g_@@_option_types_seq
+\tl_const:Nn
+  \c_@@_option_type_clist_tl
+  { clist }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_clist_tl
+\tl_const:Nn
+  \c_@@_option_type_counter_tl
+  { counter }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_counter_tl
+\tl_const:Nn
+  \c_@@_option_type_boolean_tl
+  { boolean }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_boolean_tl
+\tl_const:Nn
+  \c_@@_option_type_number_tl
+  { number }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_number_tl
+\tl_const:Nn
+  \c_@@_option_type_path_tl
+  { path }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_path_tl
+\tl_const:Nn
+  \c_@@_option_type_slice_tl
+  { slice }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_slice_tl
+\tl_const:Nn
+  \c_@@_option_type_string_tl
+  { string }
+\seq_gput_right:NV
+  \g_@@_option_types_seq
+  \c_@@_option_type_string_tl
 \cs_new:Nn
   \@@_get_option_type:nN
   {
@@ -11467,8 +11502,8 @@ for i = 1, #arg do
           if default_type == "nil" then
             warn('Option "' .. key .. '" not recognized.')
           else
-            warn('Option "' .. key .. '" type not recognized, please file ' ..
-                 'a report to the package maintainer.')
+            warn('Option "' .. key .. '" type not recognized, ' ..
+                 'file a report to the package maintainer.')
           end
           warn('Parsing the ' .. 'value "' .. value ..'" of option "' ..
                key .. '" as a string.')
@@ -11803,7 +11838,9 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \prop_new:N \g_@@_plain_tex_option_types_prop
 \prop_new:N \g_@@_default_plain_tex_options_prop
-\seq_gput_right:NV \g_@@_option_layers_seq \c_@@_option_layer_plain_tex_tl
+\seq_gput_right:NV
+  \g_@@_option_layers_seq
+  \c_@@_option_layer_plain_tex_tl
 \cs_new:Nn
   \@@_add_plain_tex_option:nnn
   {
@@ -20410,7 +20447,8 @@ removed in Markdown 4.0.0.
           {
             \markdownWarning
               {
-                The~jekyllDataString~renderer~prototype~has~been~deprecated,~
+                The~jekyllDataString~renderer~prototype~
+                has~been~deprecated,~
                 to~be~removed~in~Markdown~4.0.0
               }
             \markdownRendererJekyllDataStringPrototype
@@ -22602,14 +22640,14 @@ Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
 % \end{markdown}
 % \iffalse
 %</manual-options>
-%<*themes-witiko-markdown-defaults-context>
+%<*themes-witiko-markdown-defaults-ctx>
 % \fi
 %  \begin{macrocode}
 \startmodule[markdownthemewitiko_markdown_defaults]
 \unprotect
 %    \end{macrocode}
 % \iffalse
-%</themes-witiko-markdown-defaults-context>
+%</themes-witiko-markdown-defaults-ctx>
 %<*manual-options>
 % \fi
 % \begin{markdown}
@@ -22701,7 +22739,7 @@ function util.cache(dir, string, salt, transform, suffix)
   local digest = md5.sumhexa(string .. (salt or ""))
   local name = util.pathname(dir, digest .. suffix)
   local file = io.open(name, "r")
-  if file == nil then -- If no cache entry exists, then create a new one.
+  if file == nil then -- If no cache entry exists, create a new one.
     file = assert(io.open(name, "w"),
       [[Could not open file "]] .. name .. [[" for writing]])
     local result = string
@@ -25480,11 +25518,13 @@ function M.writer.new(options)
     ["\n"] = " ",
   }
   self.escaped_minimal_strings = {
-    ["^^"] = "\\markdownRendererCircumflex\\markdownRendererCircumflex ",
+    ["^^"] = "\\markdownRendererCircumflex"
+          .. "\\markdownRendererCircumflex ",
     ["☒"] = "\\markdownRendererTickedBox{}",
     ["⌛"] = "\\markdownRendererHalfTickedBox{}",
     ["☐"] = "\\markdownRendererUntickedBox{}",
-    [entities.hex_entity('FFFD')] = "\\markdownRendererReplacementCharacter{}",
+    [entities.hex_entity('FFFD')] =
+      "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
 % \par
@@ -25519,7 +25559,8 @@ function M.writer.new(options)
     ["^"] = "\\markdownRendererCircumflex{}",
     ["~"] = "\\markdownRendererTilde{}",
     ["|"] = "\\markdownRendererPipe{}",
-    [entities.hex_entity('0000')] = "\\markdownRendererReplacementCharacter{}",
+    [entities.hex_entity('0000')] =
+      "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
 % \par
@@ -25804,7 +25845,8 @@ function M.writer.new(options)
 %  \begin{macrocode}
   function self.inline_html_tag(contents)
     if self.flatten_inlines then return contents end
-    return {"\\markdownRendererInlineHtmlTag{",self.string(contents),"}"}
+    return {"\\markdownRendererInlineHtmlTag{",
+            self.string(contents),"}"}
   end
 %    \end{macrocode}
 % \par
@@ -26095,8 +26137,10 @@ function M.writer.new(options)
 %  \begin{macrocode}
   function self.push_attributes(attribute_type, attributes,
                                 start_output, end_output)
-    local attribute_type_level = self.attribute_type_levels[attribute_type]
-    self.attribute_type_levels[attribute_type] = attribute_type_level + 1
+    local attribute_type_level =
+      self.attribute_type_levels[attribute_type]
+    self.attribute_type_levels[attribute_type] =
+      attribute_type_level + 1
 
     -- index attributes in a hash table for easy lookup
     attributes = attributes or {}
@@ -26151,8 +26195,10 @@ function M.writer.new(options)
       local attributes, _, end_output
       current_attribute_type, attributes, _, end_output = table.unpack(
         self.active_attributes[#self.active_attributes])
-      local attribute_type_level = self.attribute_type_levels[current_attribute_type]
-      self.attribute_type_levels[current_attribute_type] = attribute_type_level - 1
+      local attribute_type_level =
+        self.attribute_type_levels[current_attribute_type]
+      self.attribute_type_levels[current_attribute_type] =
+        attribute_type_level - 1
       if self.is_writing and end_output ~= nil then
         table.insert(buf, end_output)
       end
@@ -26186,7 +26232,8 @@ function M.writer.new(options)
     local prev_space = false
     local letter_found = false
     local normalized_s = s
-    if not options.unicodeNormalization or options.unicodeNormalizationForm ~= "nfc" then
+    if not options.unicodeNormalization
+        or options.unicodeNormalizationForm ~= "nfc" then
       normalized_s = uni_algos.normalize.NFC(normalized_s)
     end
 
@@ -26203,7 +26250,8 @@ function M.writer.new(options)
         end
       end
 
-      -- Remove all non-alphanumeric characters, except underscores, hyphens, and periods.
+      -- Remove all non-alphanumeric characters, except underscores,
+      -- hyphens, and periods.
       if not unicode.utf8.match(char, "[%w_%-%.%s]") then
         goto continue
       end
@@ -26231,7 +26279,8 @@ function M.writer.new(options)
       table.remove(buffer)
     end
 
-    local identifier = #buffer == 0 and "section" or table.concat(buffer, "")
+    local identifier = #buffer == 0 and "section"
+                    or table.concat(buffer, "")
     return identifier
   end
 %    \end{macrocode}
@@ -26246,7 +26295,8 @@ function M.writer.new(options)
     local prev_space = false
     local letter_found = false
     local normalized_s = s
-    if not options.unicodeNormalization or options.unicodeNormalizationForm ~= "nfc" then
+    if not options.unicodeNormalization
+        or options.unicodeNormalizationForm ~= "nfc" then
       normalized_s = uni_algos.normalize.NFC(normalized_s)
     end
 
@@ -26263,7 +26313,8 @@ function M.writer.new(options)
         end
       end
 
-      -- Remove all non-alphanumeric characters, except underscores and hyphens.
+      -- Remove all non-alphanumeric characters, except underscores
+      -- and hyphens.
       if not unicode.utf8.match(char, "[%w_%-%s]") then
         prev_space = false
         goto continue
@@ -26292,7 +26343,8 @@ function M.writer.new(options)
       table.remove(buffer)
     end
 
-    local identifier = #buffer == 0 and "section" or table.concat(buffer, "")
+    local identifier = #buffer == 0 and "section"
+                    or table.concat(buffer, "")
     return identifier
   end
 %    \end{macrocode}
@@ -26331,9 +26383,11 @@ function M.writer.new(options)
       table.insert(auto_identifiers, create_auto_identifier(flat_text))
     end
     if self.options.gfmAutoIdentifiers then
-      table.insert(auto_identifiers, create_gfm_auto_identifier(flat_text))
+      table.insert(auto_identifiers,
+                   create_gfm_auto_identifier(flat_text))
     end
-    local normalized_attributes = normalize_attributes(attributes, auto_identifiers)
+    local normalized_attributes = normalize_attributes(attributes,
+                                                       auto_identifiers)
 
     -- push attributes for the new section
     local start_output = {}
@@ -26349,7 +26403,8 @@ function M.writer.new(options)
 
     -- render the heading and its attributes
     if self.is_writing and #normalized_attributes > 0 then
-      table.insert(buf, "\\markdownRendererHeaderAttributeContextBegin\n")
+      table.insert(buf,
+                   "\\markdownRendererHeaderAttributeContextBegin\n")
       table.insert(buf, self.attributes(normalized_attributes, false))
     end
 
@@ -26550,7 +26605,8 @@ parsers.punctuation            = {}
 end)()
 
 parsers.escapable              = parsers.ascii_punctuation
-parsers.anyescaped             = parsers.backslash / "" * parsers.escapable
+parsers.anyescaped             = parsers.backslash / ""
+                               * parsers.escapable
                                + parsers.any
 
 parsers.spacechar              = S("\t ")
@@ -26569,14 +26625,18 @@ parsers.linechar               = P(1 - parsers.newline)
 parsers.blankline              = parsers.optionalspace
                                * parsers.newline / "\n"
 parsers.blanklines             = parsers.blankline^0
-parsers.skipblanklines         = (parsers.optionalspace * parsers.newline)^0
+parsers.skipblanklines         = ( parsers.optionalspace
+                                 * parsers.newline)^0
 parsers.indentedline           = parsers.indent    /""
-                               * C(parsers.linechar^1 * parsers.newline^-1)
+                               * C( parsers.linechar^1
+                                  * parsers.newline^-1)
 parsers.optionallyindentedline = parsers.indent^-1 /""
-                               * C(parsers.linechar^1 * parsers.newline^-1)
+                               * C( parsers.linechar^1
+                                  * parsers.newline^-1)
 parsers.sp                     = parsers.spacing^0
 parsers.spnl                   = parsers.optionalspace
-                               * (parsers.newline * parsers.optionalspace)^-1
+                               * ( parsers.newline
+                                 * parsers.optionalspace)^-1
 parsers.line                   = parsers.linechar^0 * parsers.newline
 parsers.nonemptyline           = parsers.line - parsers.blankline
 %    \end{macrocode}
@@ -26659,7 +26719,8 @@ local function update_indent_table(indent_table, new_indent, add)
   if add then
     indent_table.indents[#indent_table.indents + 1] = new_indent
   else
-    if indent_table.indents[#indent_table.indents].name == new_indent.name then
+    if indent_table.indents[#indent_table.indents].name
+        == new_indent.name then
       indent_table.indents[#indent_table.indents] = nil
     end
   end
@@ -26675,10 +26736,12 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 local function remove_indent(name)
-  local function remove_indent_level(s, i, indent_table) -- luacheck: ignore s i
-    indent_table = update_indent_table(indent_table, {name=name}, false)
-    return true, indent_table
-  end
+  local remove_indent_level =
+    function(s, i, indent_table) -- luacheck: ignore s i
+      indent_table = update_indent_table(indent_table, {name=name},
+                                         false)
+      return true, indent_table
+    end
 
   return Cg(Cmt(Cb("indent_info"), remove_indent_level), "indent_info")
 end
@@ -26694,7 +26757,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function process_starter_spacing(indent, spacing, minimum, left_strip_length)
+local function process_starter_spacing(indent, spacing,
+                                       minimum, left_strip_length)
   left_strip_length = left_strip_length or 0
 
   local count = 0
@@ -26731,14 +26795,16 @@ local function process_starter_spacing(indent, spacing, minimum, left_strip_leng
         minimum_remainder = minimum_remainder .. character
       elseif (count >= minimum) then
         minimum_found = true
-        minimum_remainder = minimum_remainder .. string.rep(" ", count - minimum)
+        minimum_remainder = minimum_remainder
+                         .. string.rep(" ", count - minimum)
       end
 
       if (code_started) then
         code_start = code_start .. character
       elseif (count >= minimum + 4) then
         code_started = true
-        code_start = code_start .. string.rep(" ", count - (minimum + 4))
+        code_start = code_start
+                  .. string.rep(" ", count - (minimum + 4))
       end
     end
   end
@@ -26805,7 +26871,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function process_starter_indent(_, _, indent_table, starter, is_blank, indent_type, breakable)
+local function process_starter_indent(_, _, indent_table, starter,
+                                      is_blank, indent_type, breakable)
   local last_trail = starter[1]
   local delimiter = starter[2]
   local raw_new_trail = starter[3]
@@ -26833,11 +26900,13 @@ local function process_starter_indent(_, _, indent_table, starter, is_blank, ind
   local last_trail_length = #last_trail
   local delimiter_length = total_delimiter_length(delimiter)
 
-  local total_indent_level = preceding_indentation + last_trail_length + delimiter_length
+  local total_indent_level = preceding_indentation + last_trail_length
+                           + delimiter_length
 
   local sp = {}
   if not is_blank then
-    sp = process_starter_spacing(total_indent_level, raw_new_trail, 0, 1)
+    sp = process_starter_spacing(total_indent_level, raw_new_trail,
+                                 0, 1)
   end
 
   local del_trail_length = sp.left_total_stripped
@@ -26847,12 +26916,17 @@ local function process_starter_indent(_, _, indent_table, starter, is_blank, ind
     del_trail_length = del_trail_length + #sp.remainder
   end
 
-  local indent_length = last_trail_length + delimiter_length + del_trail_length
+  local indent_length = last_trail_length + delimiter_length
+                      + del_trail_length
   local new_indent_info = {name=indent_type, length=indent_length}
 
-  indent_table = update_indent_table(indent_table, new_indent_info, true)
-  indent_table = add_trail(indent_table, {is_code=sp.is_code, remainder=sp.remainder, total_length=sp.total_length,
-                                          full_remainder=sp.full_remainder})
+  indent_table = update_indent_table(indent_table, new_indent_info,
+                                     true)
+  indent_table = add_trail(indent_table,
+                           {is_code=sp.is_code,
+                            remainder=sp.remainder,
+                            total_length=sp.total_length,
+                            full_remainder=sp.full_remainder})
 
   return true, indent_table
 end
@@ -26870,7 +26944,8 @@ local function decode_pattern(name)
     delimeter = parsers.more
   end
 
-  return C(parsers.optionalspace) * C(delimeter) * C(parsers.optionalspace) * Cp()
+  return C(parsers.optionalspace) * C(delimeter)
+       * C(parsers.optionalspace) * Cp()
 end
 
 %    \end{macrocode}
@@ -26911,7 +26986,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function traverse_indent(s, i, indent_table, is_optional, is_blank, current_line_indents)
+local function traverse_indent(s, i, indent_table, is_optional,
+                               is_blank, current_line_indents)
   local new_index = i
 
   local preceding_indentation = 0
@@ -26930,12 +27006,17 @@ local function traverse_indent(s, i, indent_table, is_optional, is_blank, curren
     -- match decoded pattern
     local new_indent_info = lpeg.match(Ct(pattern), s, new_index)
     if new_indent_info == nil then
-      local blankline_end = lpeg.match(Ct(parsers.blankline * Cg(Cp(), "pos")), s, new_index)
-      if is_optional or not indent_table.ignore_blockquote_blank or not blankline_end then
-        return is_optional, new_index, current_trail, current_line_indents
+      local blankline_end = lpeg.match(
+        Ct(parsers.blankline * Cg(Cp(), "pos")), s, new_index)
+      if is_optional or not indent_table.ignore_blockquote_blank
+          or not blankline_end then
+        return is_optional, new_index, current_trail,
+               current_line_indents
       end
 
-      return traverse_indent(s, tonumber(blankline_end.pos), indent_table, is_optional, is_blank, current_line_indents)
+      return traverse_indent(s, tonumber(blankline_end.pos),
+                             indent_table, is_optional, is_blank,
+                             current_line_indents)
     end
 
     local raw_last_trail = new_indent_info[1]
@@ -26948,13 +27029,15 @@ local function traverse_indent(s, i, indent_table, is_optional, is_blank, curren
     -- check previous trail
     if not space_only and next(current_trail) == nil then
       local sp = process_starter_spacing(0, raw_last_trail, 0, 0)
-      current_trail = {is_code=sp.is_code, remainder=sp.remainder, total_length=sp.total_length,
+      current_trail = {is_code=sp.is_code, remainder=sp.remainder,
+                       total_length=sp.total_length,
                        full_remainder=sp.full_remainder}
     end
 
     if next(current_trail) ~= nil then
       if not space_only and current_trail.is_code then
-        return is_optional, new_index, current_trail, current_line_indents
+        return is_optional, new_index, current_trail,
+               current_line_indents
       end
       if current_trail.internal_remainder ~= nil then
         raw_last_trail = current_trail.internal_remainder
@@ -26969,7 +27052,8 @@ local function traverse_indent(s, i, indent_table, is_optional, is_blank, curren
       raw_last_trail_length = #raw_last_trail
     end
 
-    local total_indent_level = preceding_indentation + raw_last_trail_length + delimiter_length
+    local total_indent_level = preceding_indentation
+                             + raw_last_trail_length + delimiter_length
 
     local spacing_to_process
     local minimum = 0
@@ -26983,13 +27067,17 @@ local function traverse_indent(s, i, indent_table, is_optional, is_blank, curren
       minimum = value.length
     end
 
-    local sp = process_starter_spacing(total_indent_level, spacing_to_process, minimum, left_strip_length)
+    local sp = process_starter_spacing(total_indent_level,
+                                       spacing_to_process, minimum,
+                                       left_strip_length)
 
     if space_only and not sp.is_minimum then
-      return is_optional or (is_blank and blank_starter <= index), new_index, current_trail, current_line_indents
+      return is_optional or (is_blank and blank_starter <= index),
+             new_index, current_trail, current_line_indents
     end
 
-    local indent_length = raw_last_trail_length + delimiter_length + sp.left_total_stripped
+    local indent_length = raw_last_trail_length + delimiter_length
+                        + sp.left_total_stripped
 
     -- update info for the next pattern
     if not space_only then
@@ -26998,8 +27086,10 @@ local function traverse_indent(s, i, indent_table, is_optional, is_blank, curren
       preceding_indentation = preceding_indentation + value.length
     end
 
-    current_trail = {is_code=sp.is_code, remainder=sp.remainder, internal_remainder=sp.minimum_remainder,
-                     total_length=sp.total_length, full_remainder=sp.full_remainder}
+    current_trail = {is_code=sp.is_code, remainder=sp.remainder,
+                     internal_remainder=sp.minimum_remainder,
+                     total_length=sp.total_length,
+                     full_remainder=sp.full_remainder}
 
     current_line_indents[#current_line_indents + 1] = new_indent_info
     new_index = next_index
@@ -27027,34 +27117,36 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function check_trail_joined(s, i, indent_table, spacing, expect_code, omit_remainder) -- luacheck: ignore s i
-  local is_code
-  local remainder
+local check_trail_joined =
+  function(s, i, indent_table, -- luacheck: ignore s i
+           spacing, expect_code, omit_remainder)
+    local is_code
+    local remainder
 
-  if has_trail(indent_table) then
-    local trail = indent_table.trail
-    is_code = trail.is_code
-    if is_code then
-      remainder = trail.remainder
+    if has_trail(indent_table) then
+      local trail = indent_table.trail
+      is_code = trail.is_code
+      if is_code then
+        remainder = trail.remainder
+      else
+        remainder = trail.full_remainder
+      end
     else
-      remainder = trail.full_remainder
+      local sp = process_starter_spacing(0, spacing, 0, 0)
+      is_code = sp.is_code
+      if is_code then
+        remainder = sp.remainder
+      else
+        remainder = sp.full_remainder
+      end
     end
-  else
-    local sp = process_starter_spacing(0, spacing, 0, 0)
-    is_code = sp.is_code
-    if is_code then
-      remainder = sp.remainder
-    else
-      remainder = sp.full_remainder
-    end
-  end
 
-  local result = check_trail(expect_code, is_code)
-  if omit_remainder then
-    return result
+    local result = check_trail(expect_code, is_code)
+    if omit_remainder then
+      return result
+    end
+    return result, remainder
   end
-  return result, remainder
-end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27063,22 +27155,24 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function check_trail_length(s, i, indent_table, spacing, min, max) -- luacheck: ignore s i
-  local trail
+local check_trail_length =
+  function(s, i, indent_table, -- luacheck: ignore s i
+           spacing, min, max)
+    local trail
 
-  if has_trail(indent_table) then
-    trail = indent_table.trail
-  else
-    trail = process_starter_spacing(0, spacing, 0, 0)
+    if has_trail(indent_table) then
+      trail = indent_table.trail
+    else
+      trail = process_starter_spacing(0, spacing, 0, 0)
+    end
+
+    local total_length = trail.total_length
+    if total_length == nil then
+      return false
+    end
+
+    return min <= total_length and total_length <= max
   end
-
-  local total_length = trail.total_length
-  if total_length == nil then
-    return false
-  end
-
-  return min <= total_length and total_length <= max
-end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27088,7 +27182,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function check_continuation_indentation(s, i, indent_table, is_optional, is_blank)
+local function check_continuation_indentation(s, i, indent_table,
+                                              is_optional, is_blank)
   if not has_indents(indent_table) then
     return true
   end
@@ -27141,27 +27236,29 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function check_trail_type(s, i, trail, spacing, trail_type) -- luacheck: ignore s i
-  if trail == nil then
-    trail = process_starter_spacing(0, spacing, 0, 0)
-  end
-
-  if trail_type == "non-code" then
-    return check_trail(false, trail.is_code)
-  end
-  if trail_type == "code" then
-    return check_trail(true, trail.is_code)
-  end
-  if trail_type == "full-code" then
-    if (trail.is_code) then
-      return i, trail.remainder
+local check_trail_type =
+  function(s, i, -- luacheck: ignore s i
+           trail, spacing, trail_type)
+    if trail == nil then
+      trail = process_starter_spacing(0, spacing, 0, 0)
     end
-    return i, ""
+
+    if trail_type == "non-code" then
+      return check_trail(false, trail.is_code)
+    end
+    if trail_type == "code" then
+      return check_trail(true, trail.is_code)
+    end
+    if trail_type == "full-code" then
+      if (trail.is_code) then
+        return i, trail.remainder
+      end
+      return i, ""
+    end
+    if trail_type == "full-any" then
+      return i, trail.internal_remainder
+    end
   end
-  if trail_type == "full-any" then
-    return i, trail.internal_remainder
-  end
-end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27170,20 +27267,22 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function trail_freezing(s, i, indent_table, is_freezing) -- luacheck: ignore s i
-  if is_freezing then
-    if indent_table.is_trail_frozen then
-      indent_table.trail = indent_table.frozen_trail
+local trail_freezing =
+  function(s, i, -- luacheck: ignore s i
+           indent_table, is_freezing)
+    if is_freezing then
+      if indent_table.is_trail_frozen then
+        indent_table.trail = indent_table.frozen_trail
+      else
+        indent_table.frozen_trail = indent_table.trail
+        indent_table.is_trail_frozen = true
+      end
     else
-      indent_table.frozen_trail = indent_table.trail
-      indent_table.is_trail_frozen = true
+      indent_table.frozen_trail = nil
+      indent_table.is_trail_frozen = false
     end
-  else
-    indent_table.frozen_trail = nil
-    indent_table.is_trail_frozen = false
+    return true, indent_table
   end
-  return true, indent_table
-end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27194,53 +27293,59 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local function check_continuation_indentation_and_trail(s, i, indent_table, is_optional, is_blank, trail_type,
-                                                        reset_rem, omit_remainder)
-  if not has_indents(indent_table) then
-    local spacing, new_index = lpeg.match(C(parsers.spacechar^0) * Cp(), s, i)
-    local result, remainder = check_trail_type(s, i, indent_table.trail, spacing, trail_type)
-    if remainder == nil then
-      if result then
-        return new_index
+local check_continuation_indentation_and_trail =
+  function (s, i, indent_table, is_optional, is_blank, trail_type,
+            reset_rem, omit_remainder)
+    if not has_indents(indent_table) then
+      local spacing, new_index = lpeg.match( C(parsers.spacechar^0)
+                                           * Cp(), s, i)
+      local result, remainder = check_trail_type(s, i,
+        indent_table.trail, spacing, trail_type)
+      if remainder == nil then
+        if result then
+          return new_index
+        end
+        return false
       end
-      return false
-    end
-    if result then
-      return new_index, remainder
-    end
-    return false
-  end
-
-  local passes, new_index, current_trail = traverse_indent(s, i, indent_table, is_optional, is_blank)
-
-  if passes then
-    local spacing
-    if current_trail == nil then
-      local newer_spacing, newer_index = lpeg.match(C(parsers.spacechar^0) * Cp(), s, i)
-      current_trail = process_starter_spacing(0, newer_spacing, 0, 0)
-      new_index = newer_index
-      spacing = newer_spacing
-    else
-      spacing = current_trail.remainder
-    end
-    local result, remainder = check_trail_type(s, new_index, current_trail, spacing, trail_type)
-    if remainder == nil or omit_remainder then
       if result then
-        return new_index
+        return new_index, remainder
       end
       return false
     end
 
-    if is_blank and reset_rem then
-      remainder = remove_remainder_if_blank(indent_table, remainder)
-    end
-    if result then
-      return new_index, remainder
+    local passes, new_index, current_trail = traverse_indent(s, i,
+      indent_table, is_optional, is_blank)
+
+    if passes then
+      local spacing
+      if current_trail == nil then
+        local newer_spacing, newer_index = lpeg.match(
+          C(parsers.spacechar^0) * Cp(), s, i)
+        current_trail = process_starter_spacing(0, newer_spacing, 0, 0)
+        new_index = newer_index
+        spacing = newer_spacing
+      else
+        spacing = current_trail.remainder
+      end
+      local result, remainder = check_trail_type(s, new_index,
+        current_trail, spacing, trail_type)
+      if remainder == nil or omit_remainder then
+        if result then
+          return new_index
+        end
+        return false
+      end
+
+      if is_blank and reset_rem then
+        remainder = remove_remainder_if_blank(indent_table, remainder)
+      end
+      if result then
+        return new_index, remainder
+      end
+      return false
     end
     return false
   end
-  return false
-end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27249,14 +27354,20 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-parsers.check_trail = Cmt(Cb("indent_info") * C(parsers.spacechar^0) * Cc(false), check_trail_joined)
+parsers.check_trail = Cmt( Cb("indent_info") * C(parsers.spacechar^0)
+                         * Cc(false), check_trail_joined)
 
-parsers.check_trail_no_rem = Cmt(Cb("indent_info") * C(parsers.spacechar^0) * Cc(false) * Cc(true), check_trail_joined)
+parsers.check_trail_no_rem = Cmt( Cb("indent_info")
+                                * C(parsers.spacechar^0) * Cc(false)
+                                * Cc(true), check_trail_joined)
 
-parsers.check_code_trail  = Cmt(Cb("indent_info") * C(parsers.spacechar^0) * Cc(true), check_trail_joined)
+parsers.check_code_trail  = Cmt( Cb("indent_info")
+                               * C(parsers.spacechar^0)
+                               * Cc(true), check_trail_joined)
 
 parsers.check_trail_length_range  = function(min, max)
-  return Cmt(Cb("indent_info") * C(parsers.spacechar^0) * Cc(min) * Cc(max), check_trail_length)
+  return Cmt(Cb("indent_info") * C(parsers.spacechar^0) * Cc(min)
+       * Cc(max), check_trail_length)
 end
 
 parsers.check_trail_length = function(n)
@@ -27271,9 +27382,11 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-parsers.freeze_trail = Cg(Cmt(Cb("indent_info") * Cc(true), trail_freezing), "indent_info")
+parsers.freeze_trail = Cg( Cmt(Cb("indent_info")
+                         * Cc(true), trail_freezing), "indent_info")
 
-parsers.unfreeze_trail = Cg(Cmt(Cb("indent_info") * Cc(false), trail_freezing), "indent_info")
+parsers.unfreeze_trail = Cg(Cmt(Cb("indent_info") * Cc(false),
+                            trail_freezing), "indent_info")
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27282,11 +27395,15 @@ parsers.unfreeze_trail = Cg(Cmt(Cb("indent_info") * Cc(false), trail_freezing), 
 %
 % \end{markdown}
 %  \begin{macrocode}
-parsers.check_minimal_indent = Cmt(Cb("indent_info") * Cc(false), check_continuation_indentation)
+parsers.check_minimal_indent = Cmt(Cb("indent_info") * Cc(false),
+                                   check_continuation_indentation)
 
-parsers.check_optional_indent = Cmt(Cb("indent_info") * Cc(true), check_continuation_indentation)
+parsers.check_optional_indent = Cmt(Cb("indent_info") * Cc(true),
+                                    check_continuation_indentation)
 
-parsers.check_minimal_blank_indent = Cmt(Cb("indent_info") * Cc(false) * Cc(true), check_continuation_indentation)
+parsers.check_minimal_blank_indent = Cmt( Cb("indent_info") * Cc(false)
+                                        * Cc(true),
+                                         check_continuation_indentation)
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27297,37 +27414,45 @@ parsers.check_minimal_blank_indent = Cmt(Cb("indent_info") * Cc(false) * Cc(true
 % \end{markdown}
 %  \begin{macrocode}
 
-parsers.check_minimal_indent_and_trail = Cmt( Cb("indent_info")
-                                            * Cc(false) * Cc(false) * Cc("non-code") * Cc(true),
-                                            check_continuation_indentation_and_trail)
+parsers.check_minimal_indent_and_trail =
+  Cmt( Cb("indent_info")
+     * Cc(false) * Cc(false) * Cc("non-code") * Cc(true),
+      check_continuation_indentation_and_trail)
 
-parsers.check_minimal_indent_and_code_trail = Cmt( Cb("indent_info")
-                                                 * Cc(false) * Cc(false) * Cc("code") * Cc(false),
-                                                 check_continuation_indentation_and_trail)
+parsers.check_minimal_indent_and_code_trail =
+  Cmt( Cb("indent_info")
+     * Cc(false) * Cc(false) * Cc("code") * Cc(false),
+      check_continuation_indentation_and_trail)
 
-parsers.check_minimal_blank_indent_and_full_code_trail = Cmt( Cb("indent_info")
-                                                            * Cc(false) * Cc(true) * Cc("full-code") * Cc(true),
-                                                            check_continuation_indentation_and_trail)
+parsers.check_minimal_blank_indent_and_full_code_trail =
+  Cmt( Cb("indent_info")
+     * Cc(false) * Cc(true) * Cc("full-code") * Cc(true),
+      check_continuation_indentation_and_trail)
 
-parsers.check_minimal_indent_and_any_trail = Cmt( Cb("indent_info")
-                                                * Cc(false) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false),
-                                                check_continuation_indentation_and_trail)
+parsers.check_minimal_indent_and_any_trail =
+  Cmt( Cb("indent_info")
+     * Cc(false) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false),
+      check_continuation_indentation_and_trail)
 
-parsers.check_minimal_blank_indent_and_any_trail = Cmt( Cb("indent_info")
-                                                      * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false),
-                                                       check_continuation_indentation_and_trail)
+parsers.check_minimal_blank_indent_and_any_trail =
+  Cmt( Cb("indent_info")
+     * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false),
+      check_continuation_indentation_and_trail)
 
-parsers.check_minimal_blank_indent_and_any_trail_no_rem = Cmt( Cb("indent_info")
-                                                        * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(true),
-                                                        check_continuation_indentation_and_trail)
+parsers.check_minimal_blank_indent_and_any_trail_no_rem =
+  Cmt( Cb("indent_info")
+     * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(true),
+      check_continuation_indentation_and_trail)
 
-parsers.check_optional_indent_and_any_trail = Cmt( Cb("indent_info")
-                                                * Cc(true) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false),
-                                                check_continuation_indentation_and_trail)
+parsers.check_optional_indent_and_any_trail =
+  Cmt( Cb("indent_info")
+     * Cc(true) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false),
+      check_continuation_indentation_and_trail)
 
-parsers.check_optional_blank_indent_and_any_trail = Cmt( Cb("indent_info")
-                                                      * Cc(true) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false),
-                                                       check_continuation_indentation_and_trail)
+parsers.check_optional_blank_indent_and_any_trail =
+  Cmt( Cb("indent_info")
+     * Cc(true) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false),
+      check_continuation_indentation_and_trail)
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27338,7 +27463,8 @@ parsers.check_optional_blank_indent_and_any_trail = Cmt( Cb("indent_info")
 %  \begin{macrocode}
 
 parsers.spnlc_noexc = parsers.optionalspace
-                    * (parsers.newline * parsers.check_minimal_indent_and_any_trail)^-1
+                    * ( parsers.newline
+                      * parsers.check_minimal_indent_and_any_trail)^-1
 
 parsers.spnlc = parsers.optionalspace
               * (V("EndlineNoSub"))^-1
@@ -27346,7 +27472,8 @@ parsers.spnlc = parsers.optionalspace
 parsers.spnlc_sep  = parsers.optionalspace * V("EndlineNoSub")
                    + parsers.spacechar^1
 
-parsers.only_blank = parsers.spacechar^0 * (parsers.newline + parsers.eof)
+parsers.only_blank = parsers.spacechar^0
+                   * (parsers.newline + parsers.eof)
 
 %   \end{macrocode}
 % \begin{figure}
@@ -27393,64 +27520,66 @@ parsers.commented_line_letter  = parsers.linechar
                                + parsers.newline
                                - parsers.backslash
                                - parsers.percent
-parsers.commented_line         = Cg(Cc(""), "backslashes")
-                               * ((#(parsers.commented_line_letter
-                                    - parsers.newline)
-                                  * Cb("backslashes")
-                                  * Cs(parsers.commented_line_letter
-                                    - parsers.newline)^1  -- initial
-                                  * Cg(Cc(""), "backslashes"))
-                                 + #(parsers.backslash * parsers.backslash)
-                                 * Cg((parsers.backslash  -- even backslash
-                                      * parsers.backslash)^1, "backslashes")
-                                 + (parsers.backslash
-                                   * (#parsers.percent
-                                     * Cb("backslashes")
-                                     / function(backslashes)
-                                       return string.rep("\\", #backslashes / 2)
-                                     end
-                                     * C(parsers.percent)
-                                     + #parsers.commented_line_letter
-                                     * Cb("backslashes")
-                                     * Cc("\\")
-                                     * C(parsers.commented_line_letter))
-                                   * Cg(Cc(""), "backslashes")))^0
-                               * (#parsers.percent
-                                 * Cb("backslashes")
-                                 / function(backslashes)
-                                   return string.rep("\\", #backslashes / 2)
-                                 end
-                                 * ((parsers.percent  -- comment
-                                    * parsers.line
-                                    * #parsers.blankline) -- blank line
-                                   / "\n"
-                                   + parsers.percent  -- comment
-                                   * parsers.line
-                                   * parsers.optionalspace)  -- leading tabs and spaces
-                                 + #(parsers.newline)
-                                 * Cb("backslashes")
-                                 * C(parsers.newline))
+parsers.commented_line = Cg(Cc(""), "backslashes")
+                       * ((#(parsers.commented_line_letter
+                            - parsers.newline)
+                          * Cb("backslashes")
+                          * Cs(parsers.commented_line_letter
+                            - parsers.newline)^1  -- initial
+                          * Cg(Cc(""), "backslashes"))
+                         + #(parsers.backslash * parsers.backslash)
+                         * Cg((parsers.backslash  -- even backslash
+                              * parsers.backslash)^1, "backslashes")
+                         + (parsers.backslash
+                           * (#parsers.percent
+                             * Cb("backslashes")
+                             / function(backslashes)
+                               return string.rep("\\", #backslashes / 2)
+                             end
+                             * C(parsers.percent)
+                             + #parsers.commented_line_letter
+                             * Cb("backslashes")
+                             * Cc("\\")
+                             * C(parsers.commented_line_letter))
+                           * Cg(Cc(""), "backslashes")))^0
+                       * (#parsers.percent
+                         * Cb("backslashes")
+                         / function(backslashes)
+                           return string.rep("\\", #backslashes / 2)
+                         end
+                         * ((parsers.percent  -- comment
+                            * parsers.line
+                            * #parsers.blankline) -- blank line
+                           / "\n"
+                           + parsers.percent  -- comment
+                           * parsers.line
+                           * parsers.optionalspace)  -- leading spaces
+                         + #(parsers.newline)
+                         * Cb("backslashes")
+                         * C(parsers.newline))
 
-parsers.chunk                  = parsers.line * (parsers.optionallyindentedline
-                                                - parsers.blankline)^0
+parsers.chunk = parsers.line * (parsers.optionallyindentedline
+                                       - parsers.blankline)^0
 
-parsers.attribute_key_char     = parsers.alphanumeric + S("-_:.")
-parsers.attribute_raw_char     = parsers.alphanumeric + S("-_")
-parsers.attribute_key          = (parsers.attribute_key_char
-                                 - parsers.dash - parsers.digit)
-                               * parsers.attribute_key_char^0
-parsers.attribute_value        = ( (parsers.dquote / "")
-                                 * (parsers.anyescaped - parsers.dquote)^0
-                                 * (parsers.dquote / ""))
-                               + ( (parsers.squote / "")
-                                 * (parsers.anyescaped - parsers.squote)^0
-                                 * (parsers.squote / ""))
-                               + ( parsers.anyescaped - parsers.dquote - parsers.rbrace
-                                 - parsers.space)^0
-parsers.attribute_identifier   = parsers.attribute_key_char^1
-parsers.attribute_classname    = parsers.letter
-                               * parsers.attribute_key_char^0
-parsers.attribute_raw          = parsers.attribute_raw_char^1
+parsers.attribute_key_char = parsers.alphanumeric + S("-_:.")
+parsers.attribute_raw_char = parsers.alphanumeric + S("-_")
+parsers.attribute_key = (parsers.attribute_key_char
+                        - parsers.dash - parsers.digit)
+                      * parsers.attribute_key_char^0
+parsers.attribute_value = ( (parsers.dquote / "")
+                          * (parsers.anyescaped - parsers.dquote)^0
+                          * (parsers.dquote / ""))
+                        + ( (parsers.squote / "")
+                          * (parsers.anyescaped - parsers.squote)^0
+                          * (parsers.squote / ""))
+                        + ( parsers.anyescaped
+                          - parsers.dquote
+                          - parsers.rbrace
+                          - parsers.space)^0
+parsers.attribute_identifier = parsers.attribute_key_char^1
+parsers.attribute_classname = parsers.letter
+                            * parsers.attribute_key_char^0
+parsers.attribute_raw = parsers.attribute_raw_char^1
 
 parsers.attribute = (parsers.dash * Cc(".unnumbered"))
                   + C( parsers.hash
@@ -27458,7 +27587,9 @@ parsers.attribute = (parsers.dash * Cc(".unnumbered"))
                   + C( parsers.period
                      * parsers.attribute_classname)
                   + Cs( parsers.attribute_key
-                      * parsers.optionalspace * parsers.equal * parsers.optionalspace
+                      * parsers.optionalspace
+                      * parsers.equal
+                      * parsers.optionalspace
                       * parsers.attribute_value)
 parsers.attributes = parsers.lbrace
                    * parsers.optionalspace
@@ -27467,7 +27598,6 @@ parsers.attributes = parsers.lbrace
                      * parsers.attribute)^0
                    * parsers.optionalspace
                    * parsers.rbrace
-
 
 parsers.raw_attribute = parsers.lbrace
                       * parsers.optionalspace
@@ -27480,7 +27610,10 @@ parsers.raw_attribute = parsers.lbrace
 -- indented blocks with first line indented.
 parsers.indented_blocks = function(bl)
   return Cs( bl
-         * (parsers.blankline^1 * parsers.indent * -parsers.blankline * bl)^0
+         * ( parsers.blankline^1
+           * parsers.indent
+           * -parsers.blankline
+           * bl)^0
          * (parsers.blankline^1 + parsers.eof) )
 end
 %    \end{macrocode}
@@ -27496,15 +27629,18 @@ local function repeat_between(pattern, min, max)
 end
 
 parsers.hexentity = parsers.ampersand * parsers.hash * C(S("Xx"))
-                  * C(repeat_between(parsers.hexdigit, 1, 6)) * parsers.semicolon
+                  * C(repeat_between(parsers.hexdigit, 1, 6))
+                  * parsers.semicolon
 parsers.decentity = parsers.ampersand * parsers.hash
-                  * C(repeat_between(parsers.digit, 1, 7)) * parsers.semicolon
+                  * C(repeat_between(parsers.digit, 1, 7))
+                  * parsers.semicolon
 parsers.tagentity = parsers.ampersand * C(parsers.alphanumeric^1)
                   * parsers.semicolon
 
-parsers.html_entities = parsers.hexentity / entities.hex_entity_with_x_char
-                      + parsers.decentity / entities.dec_entity
-                      + parsers.tagentity / entities.char_entity
+parsers.html_entities
+  = parsers.hexentity / entities.hex_entity_with_x_char
+  + parsers.decentity / entities.dec_entity
+  + parsers.tagentity / entities.char_entity
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -27518,7 +27654,8 @@ parsers.bullet = function(bullet_char, interrupting)
   if interrupting then
     allowed_end = C(parsers.spacechar^1) * #parsers.linechar
   else
-    allowed_end = C(parsers.spacechar^1) + #(parsers.newline + parsers.eof)
+    allowed_end = C(parsers.spacechar^1)
+                + #(parsers.newline + parsers.eof)
   end
   return parsers.check_trail
         * Ct(C(bullet_char) * Cc(""))
@@ -27576,7 +27713,8 @@ parsers.inticks = parsers.openticks
 %
 % \end{markdown}
 %  \begin{macrocode}
--- case-insensitive match (we assume s is lowercase). must be single byte encoding
+-- case-insensitive match (we assume s is lowercase)
+-- must be single byte encoding
 parsers.keyword_exact = function(s)
   local parser = P(0)
   for i=1,#s do
@@ -27658,13 +27796,14 @@ parsers.block_keyword =
     parsers.keyword_exact("ul")
 
 -- end conditions
-parsers.html_blankline_end_condition  = parsers.linechar^0
-                                      * ( parsers.newline
-                                        * (parsers.check_minimal_blank_indent_and_any_trail
-                                          * #parsers.blankline
-                                          + parsers.check_minimal_indent_and_any_trail)
-                                        * parsers.linechar^1)^0
-                                      * (parsers.newline^-1 / "")
+parsers.html_blankline_end_condition
+  = parsers.linechar^0
+  * ( parsers.newline
+    * (parsers.check_minimal_blank_indent_and_any_trail
+      * #parsers.blankline
+      + parsers.check_minimal_indent_and_any_trail)
+    * parsers.linechar^1)^0
+  * (parsers.newline^-1 / "")
 
 local function remove_trailing_blank_lines(s)
   return s:gsub("[\n\r]+%s*$", "")
@@ -27686,9 +27825,14 @@ parsers.html_attribute_spacing  = parsers.optionalspace
                                 * parsers.optionalspace
                                 + parsers.spacechar^1
 
-parsers.html_attribute_name = (parsers.letter + parsers.colon + parsers.underscore)
-                            * (parsers.alphanumeric + parsers.colon + parsers.underscore
-                            + parsers.period + parsers.dash)^0
+parsers.html_attribute_name = ( parsers.letter
+                              + parsers.colon
+                              + parsers.underscore)
+                            * ( parsers.alphanumeric
+                              + parsers.colon
+                              + parsers.underscore
+                            + parsers.period
+                            + parsers.dash)^0
 
 parsers.html_attribute_value  = parsers.squote
                               * (parsers.linechar - parsers.squote)^0
@@ -27696,9 +27840,15 @@ parsers.html_attribute_value  = parsers.squote
                               + parsers.dquote
                               * (parsers.linechar - parsers.dquote)^0
                               * parsers.dquote
-                              + ( parsers.any - parsers.spacechar - parsers.newline
-                                - parsers.dquote - parsers.squote - parsers.backtick
-                                - parsers.equal - parsers.less - parsers.more)^1
+                              + ( parsers.any
+                                - parsers.spacechar
+                                - parsers.newline
+                                - parsers.dquote
+                                - parsers.squote
+                                - parsers.backtick
+                                - parsers.equal
+                                - parsers.less
+                                - parsers.more)^1
 
 parsers.html_inline_attribute_value = parsers.squote
                                     * (V("NoSoftLineBreakEndline")
@@ -27712,30 +27862,41 @@ parsers.html_inline_attribute_value = parsers.squote
                                       - parsers.blankline^2
                                       - parsers.dquote)^0
                                     * parsers.dquote
-                                    + (parsers.any - parsers.spacechar - parsers.newline
-                                      - parsers.dquote - parsers.squote - parsers.backtick
-                                      - parsers.equal - parsers.less - parsers.more)^1
+                                    + (parsers.any
+                                      - parsers.spacechar
+                                      - parsers.newline
+                                      - parsers.dquote
+                                      - parsers.squote
+                                      - parsers.backtick
+                                      - parsers.equal
+                                      - parsers.less
+                                      - parsers.more)^1
 
-parsers.html_attribute_value_specification  = parsers.optionalspace
-                                            * parsers.equal
-                                            * parsers.optionalspace
-                                            * parsers.html_attribute_value
+parsers.html_attribute_value_specification
+  = parsers.optionalspace
+  * parsers.equal
+  * parsers.optionalspace
+  * parsers.html_attribute_value
 
 parsers.html_spnl = parsers.optionalspace
-                  * (V("NoSoftLineBreakEndline") * parsers.optionalspace)^-1
+                  * (V("NoSoftLineBreakEndline")
+                  * parsers.optionalspace)^-1
 
-parsers.html_inline_attribute_value_specification = parsers.html_spnl
-                                                  * parsers.equal
-                                                  * parsers.html_spnl
-                                                  * parsers.html_inline_attribute_value
+parsers.html_inline_attribute_value_specification
+  = parsers.html_spnl
+  * parsers.equal
+  * parsers.html_spnl
+  * parsers.html_inline_attribute_value
 
-parsers.html_attribute  = parsers.html_attribute_spacing
-                        * parsers.html_attribute_name
-                        * parsers.html_inline_attribute_value_specification^-1
+parsers.html_attribute
+  = parsers.html_attribute_spacing
+  * parsers.html_attribute_name
+  * parsers.html_inline_attribute_value_specification^-1
 
-parsers.html_non_newline_attribute  = parsers.spacechar^1
-                                    * parsers.html_attribute_name
-                                    * parsers.html_attribute_value_specification^-1
+parsers.html_non_newline_attribute
+  = parsers.spacechar^1
+  * parsers.html_attribute_name
+  * parsers.html_attribute_value_specification^-1
 
 parsers.nested_breaking_blank = parsers.newline
                               * parsers.check_minimal_blank_indent
@@ -27745,49 +27906,59 @@ parsers.html_comment_start = P("<!--")
 
 parsers.html_comment_end = P("-->")
 
-parsers.html_comment = Cs( parsers.html_comment_start
-                         * parsers.html_until_end(parsers.html_comment_end))
+parsers.html_comment
+  = Cs( parsers.html_comment_start
+      * parsers.html_until_end(parsers.html_comment_end))
 
 parsers.html_inline_comment = (parsers.html_comment_start / "")
                             * -P(">") * -P("->")
-                            * Cs((V("NoSoftLineBreakEndline") + parsers.any
-                                - parsers.nested_breaking_blank - parsers.html_comment_end)^0)
+                            * Cs(( V("NoSoftLineBreakEndline")
+                                 + parsers.any
+                                 - parsers.nested_breaking_blank
+                                 - parsers.html_comment_end)^0)
                             * (parsers.html_comment_end / "")
 
 parsers.html_cdatasection_start = P("<![CDATA[")
 
 parsers.html_cdatasection_end = P("]]>")
 
-parsers.html_cdatasection = Cs( parsers.html_cdatasection_start
-                              * parsers.html_until_end(parsers.html_cdatasection_end))
+parsers.html_cdatasection
+  = Cs( parsers.html_cdatasection_start
+  * parsers.html_until_end(parsers.html_cdatasection_end))
 
-parsers.html_inline_cdatasection  = parsers.html_cdatasection_start
-                                  * Cs(V("NoSoftLineBreakEndline") + parsers.any
-                                      - parsers.nested_breaking_blank - parsers.html_cdatasection_end)^0
-                                  * parsers.html_cdatasection_end
+parsers.html_inline_cdatasection
+  = parsers.html_cdatasection_start
+  * Cs(V("NoSoftLineBreakEndline") + parsers.any
+      - parsers.nested_breaking_blank - parsers.html_cdatasection_end)^0
+  * parsers.html_cdatasection_end
 
 parsers.html_declaration_start = P("<!") * parsers.letter
 
 parsers.html_declaration_end = P(">")
 
-parsers.html_declaration  = Cs( parsers.html_declaration_start
-                              * parsers.html_until_end(parsers.html_declaration_end))
+parsers.html_declaration
+  = Cs( parsers.html_declaration_start
+  * parsers.html_until_end(parsers.html_declaration_end))
 
-parsers.html_inline_declaration = parsers.html_declaration_start
-                                * Cs(V("NoSoftLineBreakEndline") + parsers.any
-                                    - parsers.nested_breaking_blank - parsers.html_declaration_end)^0
-                                * parsers.html_declaration_end
+parsers.html_inline_declaration
+  = parsers.html_declaration_start
+  * Cs(V("NoSoftLineBreakEndline") + parsers.any
+      - parsers.nested_breaking_blank - parsers.html_declaration_end)^0
+  * parsers.html_declaration_end
 
 parsers.html_instruction_start = P("<?")
 
 parsers.html_instruction_end = P("?>")
 
-parsers.html_instruction  = Cs( parsers.html_instruction_start
-                              * parsers.html_until_end(parsers.html_instruction_end))
+parsers.html_instruction
+  = Cs( parsers.html_instruction_start
+      * parsers.html_until_end(parsers.html_instruction_end))
 
 parsers.html_inline_instruction = parsers.html_instruction_start
-                                * Cs(V("NoSoftLineBreakEndline") + parsers.any
-                                    - parsers.nested_breaking_blank - parsers.html_instruction_end)^0
+                                * Cs( V("NoSoftLineBreakEndline")
+                                    + parsers.any
+                                    - parsers.nested_breaking_blank
+                                    - parsers.html_instruction_end)^0
                                 * parsers.html_instruction_end
 
 parsers.html_blankline  = parsers.newline
@@ -27833,25 +28004,28 @@ parsers.incomplete_tag_following  = parsers.spacechar
                                   + parsers.slash * parsers.more
                                   + #(parsers.newline + parsers.eof)
 
-parsers.incomplete_special_tag_following  = parsers.spacechar
-                                          + parsers.more
-                                          + #(parsers.newline + parsers.eof)
+parsers.incomplete_special_tag_following = parsers.spacechar
+                                         + parsers.more
+                                         + #( parsers.newline
+                                            + parsers.eof)
 
 parsers.html_incomplete_open_tag  = parsers.html_tag_start
                                   * parsers.block_keyword
                                   * parsers.incomplete_tag_following
 
-parsers.html_incomplete_open_special_tag  = parsers.html_tag_start
-                                          * parsers.special_block_keyword
-                                          * parsers.incomplete_special_tag_following
+parsers.html_incomplete_open_special_tag
+  = parsers.html_tag_start
+  * parsers.special_block_keyword
+  * parsers.incomplete_special_tag_following
 
 parsers.html_incomplete_close_tag = parsers.html_tag_closing_start
                                   * parsers.block_keyword
                                   * parsers.incomplete_tag_following
 
-parsers.html_incomplete_close_special_tag = parsers.html_tag_closing_start
-                                          * parsers.special_block_keyword
-                                          * parsers.incomplete_tag_following
+parsers.html_incomplete_close_special_tag
+  = parsers.html_tag_closing_start
+  * parsers.special_block_keyword
+  * parsers.incomplete_tag_following
 
 -- closing tags
 parsers.html_close_tag  = parsers.html_tag_closing_start
@@ -27889,27 +28063,33 @@ parsers.html_empty_special_tag  = parsers.html_tag_start
                                 * parsers.html_attribute^0
                                 * parsers.html_empty_tag_end
 
-parsers.html_incomplete_blocks  = parsers.html_incomplete_open_tag
-                                + parsers.html_incomplete_open_special_tag
-                                + parsers.html_incomplete_close_tag
+parsers.html_incomplete_blocks
+  = parsers.html_incomplete_open_tag
+  + parsers.html_incomplete_open_special_tag
+  + parsers.html_incomplete_close_tag
 
 -- parse special html blocks
-parsers.html_blankline_ending_special_block_opening = (parsers.html_close_special_tag
-                                                      + parsers.html_empty_special_tag)
-                                                    * #(parsers.optionalspace
-                                                       * (parsers.newline + parsers.eof))
+parsers.html_blankline_ending_special_block_opening
+  = ( parsers.html_close_special_tag
+    + parsers.html_empty_special_tag)
+  * #( parsers.optionalspace
+     * (parsers.newline + parsers.eof))
 
-parsers.html_blankline_ending_special_block = parsers.html_blankline_ending_special_block_opening
-                                            * parsers.html_blankline_end_condition
+parsers.html_blankline_ending_special_block
+  = parsers.html_blankline_ending_special_block_opening
+  * parsers.html_blankline_end_condition
 
-parsers.html_special_block_opening  = parsers.html_incomplete_open_special_tag
-                                    - parsers.html_empty_special_tag
+parsers.html_special_block_opening
+  = parsers.html_incomplete_open_special_tag
+  - parsers.html_empty_special_tag
 
-parsers.html_closing_special_block  = parsers.html_special_block_opening
-                                    * parsers.html_until_end(parsers.html_close_special_tag)
+parsers.html_closing_special_block
+  = parsers.html_special_block_opening
+  * parsers.html_until_end(parsers.html_close_special_tag)
 
-parsers.html_special_block  = parsers.html_blankline_ending_special_block
-                            + parsers.html_closing_special_block
+parsers.html_special_block
+  = parsers.html_blankline_ending_special_block
+  + parsers.html_closing_special_block
 
 -- parse html blocks
 parsers.html_block_opening  = parsers.html_incomplete_open_tag
@@ -27919,18 +28099,21 @@ parsers.html_block  = parsers.html_block_opening
                     * parsers.html_blankline_end_condition
 
 -- parse any html blocks
-parsers.html_any_block_opening  = (parsers.html_any_open_tag
-                                + parsers.html_any_close_tag
-                                + parsers.html_any_empty_tag)
-                                * #(parsers.optionalspace * (parsers.newline + parsers.eof))
+parsers.html_any_block_opening
+  = ( parsers.html_any_open_tag
+    + parsers.html_any_close_tag
+    + parsers.html_any_empty_tag)
+  * #(parsers.optionalspace * (parsers.newline + parsers.eof))
 
 parsers.html_any_block  = parsers.html_any_block_opening
                         * parsers.html_blankline_end_condition
 
 parsers.html_inline_comment_full  = parsers.html_comment_start
                                   * -P(">") * -P("->")
-                                  * Cs((V("NoSoftLineBreakEndline") + parsers.any - P("--")
-                                      - parsers.nested_breaking_blank - parsers.html_comment_end)^0)
+                                  * Cs(( V("NoSoftLineBreakEndline")
+                                       + parsers.any - P("--")
+                                       - parsers.nested_breaking_blank
+                                       - parsers.html_comment_end)^0)
                                   * parsers.html_comment_end
 
 parsers.html_inline_tags  = parsers.html_inline_comment_full
@@ -27963,21 +28146,25 @@ parsers.auto_link_scheme  = parsers.letter
                           * parsers.auto_link_scheme_part^-30
 
 parsers.absolute_uri  = parsers.auto_link_scheme * parsers.colon
-                      * (parsers.any - parsers.spacing - parsers.less - parsers.more)^0
+                      * ( parsers.any - parsers.spacing
+                        - parsers.less - parsers.more)^0
 
 parsers.printable_characters = S(".!#$%&'*+/=?^_`{|}~-")
 
 parsers.email_address_local_part_char = parsers.alphanumeric
                                       + parsers.printable_characters
 
-parsers.email_address_local_part = parsers.email_address_local_part_char^1
+parsers.email_address_local_part
+  = parsers.email_address_local_part_char^1
 
 parsers.email_address_dns_label = parsers.alphanumeric
-                                * (parsers.alphanumeric + parsers.dash)^-62
+                                * ( parsers.alphanumeric
+                                  + parsers.dash)^-62
                                 * B(parsers.alphanumeric)
 
 parsers.email_address_domain  = parsers.email_address_dns_label
-                              * (parsers.period * parsers.email_address_dns_label)^0
+                              * ( parsers.period
+                                * parsers.email_address_dns_label)^0
 
 parsers.email_address = parsers.email_address_local_part
                       * parsers.at
@@ -28033,25 +28220,37 @@ parsers.link_text  = parsers.lbracket
                         + parsers.autolink
                         + V("InlineHtml")
                         + ( parsers.backslash * parsers.backslash)
-                        + ( parsers.backslash * (parsers.lbracket + parsers.rbracket)
+                        + ( parsers.backslash
+                          * ( parsers.lbracket
+                            + parsers.rbracket)
                           + V("NoSoftLineBreakSpace")
                           + V("NoSoftLineBreakEndline")
                           + (parsers.any
-                            - (parsers.newline + parsers.lbracket + parsers.rbracket + parsers.blankline^2))))^0)
+                            - ( parsers.newline
+                              + parsers.lbracket
+                              + parsers.rbracket
+                              + parsers.blankline^2))))^0)
                     * parsers.rbracket
 
 parsers.link_label_body = -#(parsers.sp * parsers.rbracket)
-                        * #((parsers.any - parsers.rbracket)^-999 * parsers.rbracket)
+                        * #( ( parsers.any
+                             - parsers.rbracket)^-999
+                           * parsers.rbracket)
                         * Cs((parsers.alphanumeric^1
                             + parsers.inticks
                             + parsers.autolink
                             + V("InlineHtml")
                             + ( parsers.backslash * parsers.backslash)
-                            + ( parsers.backslash * (parsers.lbracket + parsers.rbracket)
+                            + ( parsers.backslash
+                              * ( parsers.lbracket
+                                + parsers.rbracket)
                               + V("NoSoftLineBreakSpace")
                               + V("NoSoftLineBreakEndline")
                               + (parsers.any
-                                - (parsers.newline + parsers.lbracket + parsers.rbracket + parsers.blankline^2))))^1)
+                                - ( parsers.newline
+                                  + parsers.lbracket
+                                  + parsers.rbracket
+                                  + parsers.blankline^2))))^1)
 
 parsers.link_label  = parsers.lbracket
                     * parsers.link_label_body
@@ -28081,29 +28280,38 @@ parsers.title_s     = parsers.squote
                     * Cs((parsers.html_entities
                          + V("NoSoftLineBreakSpace")
                          + V("NoSoftLineBreakEndline")
-                         + (parsers.anyescaped - parsers.newline - parsers.squote - parsers.blankline^2))^0)
+                         + ( parsers.anyescaped
+                           - parsers.newline
+                           - parsers.squote
+                           - parsers.blankline^2))^0)
                     * parsers.squote
 
 parsers.title_d     = parsers.dquote
                     * Cs((parsers.html_entities
                          + V("NoSoftLineBreakSpace")
                          + V("NoSoftLineBreakEndline")
-                         + (parsers.anyescaped - parsers.newline - parsers.dquote - parsers.blankline^2))^0)
+                         + ( parsers.anyescaped
+                           - parsers.newline
+                           - parsers.dquote
+                           - parsers.blankline^2))^0)
                     * parsers.dquote
 
 parsers.title_p     = parsers.lparent
                     * Cs((parsers.html_entities
                          + V("NoSoftLineBreakSpace")
                          + V("NoSoftLineBreakEndline")
-                         + (parsers.anyescaped - parsers.newline - parsers.lparent - parsers.rparent
+                         + ( parsers.anyescaped
+                           - parsers.newline
+                           - parsers.lparent
+                           - parsers.rparent
                            - parsers.blankline^2))^0)
                     * parsers.rparent
 
-parsers.title       = parsers.title_d + parsers.title_s + parsers.title_p
+parsers.title
+  = parsers.title_d + parsers.title_s + parsers.title_p
 
 parsers.optionaltitle
-                    = parsers.spnlc * parsers.title * parsers.spacechar^0
-                    + Cc("")
+  = parsers.spnlc * parsers.title * parsers.spacechar^0 + Cc("")
 
 %    \end{macrocode}
 % \par
@@ -28114,9 +28322,11 @@ parsers.optionaltitle
 % \end{markdown}
 %  \begin{macrocode}
 -- parse a reference definition:  [foo]: /bar "title"
-parsers.define_reference_parser = (parsers.check_trail / "") * parsers.link_label * parsers.colon
+parsers.define_reference_parser = (parsers.check_trail / "")
+                                * parsers.link_label * parsers.colon
                                 * parsers.spnlc * parsers.url
-                                * ( parsers.spnlc_sep * parsers.title * parsers.only_blank
+                                * ( parsers.spnlc_sep * parsers.title
+                                  * parsers.only_blank
                                   + Cc("") * parsers.only_blank)
 %    \end{macrocode}
 % \par
@@ -28131,7 +28341,10 @@ parsers.Inline         = V("Inline")
 -- parse many p between starter and ender
 parsers.between = function(p, starter, ender)
   local ender2 = B(parsers.nonspacechar) * ender
-  return (starter * #parsers.nonspacechar * Ct(p * (p - ender2)^0) * ender2)
+  return ( starter
+         * #parsers.nonspacechar
+         * Ct(p * (p - ender2)^0)
+         * ender2)
 end
 
 %    \end{macrocode}
@@ -28143,7 +28356,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 parsers.lineof = function(c)
-    return (parsers.check_trail_no_rem * (P(c) * parsers.optionalspace)^3
+    return ( parsers.check_trail_no_rem
+           * (P(c) * parsers.optionalspace)^3
            * (parsers.newline + parsers.eof))
 end
 
@@ -28163,8 +28377,11 @@ parsers.heading_start = #parsers.hash * C(parsers.hash^-6)
                       * -parsers.hash / length
 
 -- parse setext header ending and return level
-parsers.heading_level = parsers.nonindentspace * parsers.equal^1 * parsers.optionalspace * #parsers.newline * Cc(1)
-                      + parsers.nonindentspace * parsers.dash^1 * parsers.optionalspace * #parsers.newline * Cc(2)
+parsers.heading_level
+  = parsers.nonindentspace * parsers.equal^1
+  * parsers.optionalspace * #parsers.newline * Cc(1)
+  + parsers.nonindentspace * parsers.dash^1
+  * parsers.optionalspace * #parsers.newline * Cc(2)
 
 local function strip_atx_end(s)
   return s:gsub("%s+#*%s*\n$","")
@@ -28336,9 +28553,11 @@ function M.reader.new(writer, options)
               local prefix = lpeg.match(C(parsers.optionalspace), line)
               local prefix_length = #prefix
               local is_shorter = min_prefix_length == nil
-              is_shorter = is_shorter or prefix_length < min_prefix_length
+              if not is_shorter then
+                is_shorter = prefix_length < min_prefix_length
+              end
               if is_shorter then
-                  min_prefix_length, min_prefix = prefix_length, prefix
+                min_prefix_length, min_prefix = prefix_length, prefix
               end
               return line
           end)
@@ -28360,7 +28579,8 @@ function M.reader.new(writer, options)
       end
       local res = lpeg.match(grammar(), str)
       if res == nil then
-        return writer.error(format("%s failed on:\n%s", name, str:sub(1,20)))
+        return writer.error(format("%s failed on:\n%s",
+                                   name, str:sub(1,20)))
       else
         return res
       end
@@ -28410,35 +28630,47 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.minimally_indented_blankline = parsers.check_minimal_indent * (parsers.blankline / "")
+  parsers.minimally_indented_blankline
+    = parsers.check_minimal_indent * (parsers.blankline / "")
 
-  parsers.minimally_indented_block = parsers.check_minimal_indent * V("Block")
+  parsers.minimally_indented_block
+    = parsers.check_minimal_indent * V("Block")
 
-  parsers.minimally_indented_block_or_paragraph = parsers.check_minimal_indent * V("BlockOrParagraph")
+  parsers.minimally_indented_block_or_paragraph
+    = parsers.check_minimal_indent * V("BlockOrParagraph")
 
-  parsers.minimally_indented_paragraph = parsers.check_minimal_indent * V("Paragraph")
+  parsers.minimally_indented_paragraph
+    = parsers.check_minimal_indent * V("Paragraph")
 
-  parsers.minimally_indented_plain = parsers.check_minimal_indent * V("Plain")
+  parsers.minimally_indented_plain
+    = parsers.check_minimal_indent * V("Plain")
 
-  parsers.minimally_indented_par_or_plain = parsers.minimally_indented_paragraph
-                                          + parsers.minimally_indented_plain
+  parsers.minimally_indented_par_or_plain
+    = parsers.minimally_indented_paragraph
+    + parsers.minimally_indented_plain
 
-  parsers.minimally_indented_par_or_plain_no_blank  = parsers.minimally_indented_par_or_plain
-                                                    - parsers.minimally_indented_blankline
+  parsers.minimally_indented_par_or_plain_no_blank
+    = parsers.minimally_indented_par_or_plain
+    - parsers.minimally_indented_blankline
 
-  parsers.minimally_indented_ref = parsers.check_minimal_indent * V("Reference")
+  parsers.minimally_indented_ref
+    = parsers.check_minimal_indent * V("Reference")
 
-  parsers.minimally_indented_blank = parsers.check_minimal_indent * V("Blank")
+  parsers.minimally_indented_blank
+    = parsers.check_minimal_indent * V("Blank")
 
-  parsers.conditionally_indented_blankline = parsers.check_minimal_blank_indent * (parsers.blankline / "")
+  parsers.conditionally_indented_blankline
+    = parsers.check_minimal_blank_indent * (parsers.blankline / "")
 
-  parsers.minimally_indented_ref_or_block = parsers.minimally_indented_ref
-                                          + parsers.minimally_indented_block
-                                          - parsers.minimally_indented_blankline
+  parsers.minimally_indented_ref_or_block
+    = parsers.minimally_indented_ref
+    + parsers.minimally_indented_block
+    - parsers.minimally_indented_blankline
 
-  parsers.minimally_indented_ref_or_block_or_par  = parsers.minimally_indented_ref
-                                                  + parsers.minimally_indented_block_or_paragraph
-                                                  - parsers.minimally_indented_blankline
+  parsers.minimally_indented_ref_or_block_or_par
+    = parsers.minimally_indented_ref
+    + parsers.minimally_indented_block_or_paragraph
+    - parsers.minimally_indented_blankline
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -28448,7 +28680,8 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
 
-  parsers.separator_loop = function(separated_block, paragraph, block_separator, paragraph_separator)
+  function parsers.separator_loop(separated_block, paragraph,
+                                  block_separator, paragraph_separator)
     return  separated_block
           + block_separator
             * paragraph
@@ -28457,10 +28690,14 @@ function M.reader.new(writer, options)
           * paragraph
   end
 
-  parsers.create_loop_body_pair = function(separated_block, paragraph, block_separator, paragraph_separator)
+  function parsers.create_loop_body_pair(separated_block, paragraph,
+                                         block_separator,
+                                         paragraph_separator)
     return {
-      block = parsers.separator_loop(separated_block, paragraph, block_separator, block_separator),
-      par = parsers.separator_loop(separated_block, paragraph, block_separator, paragraph_separator)
+      block = parsers.separator_loop(separated_block, paragraph,
+                                     block_separator, block_separator),
+      par = parsers.separator_loop(separated_block, paragraph,
+                                   block_separator, paragraph_separator)
     }
   end
 
@@ -28483,18 +28720,20 @@ function M.reader.new(writer, options)
 
   parsers.content_blank = parsers.minimally_indented_blankline
 
-  parsers.ref_or_block_separated  = parsers.sep_group_no_output(parsers.content_blank)
-                                  * ( parsers.minimally_indented_ref
-                                    - parsers.content_blank)
-                                  + parsers.block_sep_group(parsers.content_blank)
-                                  * ( parsers.minimally_indented_block
-                                    - parsers.content_blank)
+  parsers.ref_or_block_separated
+    = parsers.sep_group_no_output(parsers.content_blank)
+    * ( parsers.minimally_indented_ref
+      - parsers.content_blank)
+    + parsers.block_sep_group(parsers.content_blank)
+    * ( parsers.minimally_indented_block
+      - parsers.content_blank)
 
   parsers.loop_body_pair  =
-    parsers.create_loop_body_pair(parsers.ref_or_block_separated,
-                                  parsers.minimally_indented_par_or_plain_no_blank,
-                                  parsers.block_sep_group(parsers.content_blank),
-                                  parsers.par_sep_group(parsers.content_blank))
+    parsers.create_loop_body_pair(
+      parsers.ref_or_block_separated,
+      parsers.minimally_indented_par_or_plain_no_blank,
+      parsers.block_sep_group(parsers.content_blank),
+      parsers.par_sep_group(parsers.content_blank))
 
   parsers.content_loop  = ( V("Block")
                           * parsers.loop_body_pair.block^0
@@ -28518,7 +28757,8 @@ function M.reader.new(writer, options)
   parsers.add_indent = function(pattern, name, breakable)
     return  Cg(Cmt( Cb("indent_info")
                   * Ct(pattern)
-                  * (#parsers.linechar * Cc(false) + Cc(true)) -- check if starter is blank
+                  * ( #parsers.linechar  -- check if starter is blank
+                    * Cc(false) + Cc(true))
                   * Cc(name)
                   * Cc(breakable),
               process_starter_indent), "indent_info")
@@ -28546,7 +28786,8 @@ function M.reader.new(writer, options)
       allowed_end = C(parsers.spacechar^1) * #parsers.linechar
     else
       delimiter_range = parsers.dig * parsers.dig^-8
-      allowed_end = C(parsers.spacechar^1) + #(parsers.newline + parsers.eof)
+      allowed_end = C(parsers.spacechar^1)
+                  + #(parsers.newline + parsers.eof)
     end
 
     return parsers.check_trail
@@ -28568,16 +28809,21 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.blockquote_start = parsers.check_trail * C(parsers.more) * C(parsers.spacechar^0)
+  parsers.blockquote_start
+    = parsers.check_trail
+    * C(parsers.more)
+    * C(parsers.spacechar^0)
 
-  parsers.blockquote_body = parsers.add_indent(parsers.blockquote_start, "bq", true)
-                          * parsers.indented_content()
-                          * remove_indent("bq")
+  parsers.blockquote_body
+    = parsers.add_indent(parsers.blockquote_start, "bq", true)
+    * parsers.indented_content()
+    * remove_indent("bq")
 
   if not options.breakableBlockquotes then
-    parsers.blockquote_body = parsers.add_indent(parsers.blockquote_start, "bq", false)
-                            * parsers.indented_content()
-                            * remove_indent("bq")
+    parsers.blockquote_body
+      = parsers.add_indent(parsers.blockquote_start, "bq", false)
+      * parsers.indented_content()
+      * remove_indent("bq")
   end
 %    \end{macrocode}
 % \par
@@ -28591,7 +28837,8 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local function parse_content_part(content_part)
     local rope = util.rope_to_string(content_part)
-    local parsed = self.parser_functions.parse_inlines_no_link_or_emphasis(rope)
+    local parsed
+      = self.parser_functions.parse_inlines_no_link_or_emphasis(rope)
     parsed.indent_info = nil
     return parsed
   end
@@ -28603,37 +28850,40 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function collect_emphasis_content(t, opening_index, closing_index)
-    local content = {}
+  local collect_emphasis_content =
+    function(t, opening_index, closing_index)
+      local content = {}
 
-    local content_part = {}
-    for i = opening_index, closing_index do
-      local value = t[i]
+      local content_part = {}
+      for i = opening_index, closing_index do
+        local value = t[i]
 
-      if value.rendered ~= nil then
-        content[#content + 1] = parse_content_part(content_part)
-        content_part = {}
-        content[#content + 1] = value.rendered
-        value.rendered = nil
-      else
-        if value.type == "delimiter" and value.element == "emphasis" then
-          if value.is_active then
-            content_part[#content_part + 1] = string.rep(value.character, value.current_count)
-          end
+        if value.rendered ~= nil then
+          content[#content + 1] = parse_content_part(content_part)
+          content_part = {}
+          content[#content + 1] = value.rendered
+          value.rendered = nil
         else
-          content_part[#content_part + 1] = value.content
+          if value.type == "delimiter"
+              and value.element == "emphasis" then
+            if value.is_active then
+              content_part[#content_part + 1]
+                = string.rep(value.character, value.current_count)
+            end
+          else
+            content_part[#content_part + 1] = value.content
+          end
+          value.content = ''
+          value.is_active = false
         end
-        value.content = ''
-        value.is_active = false
       end
-    end
 
-    if next(content_part) ~= nil then
-      content[#content + 1] = parse_content_part(content_part)
-    end
+      if next(content_part) ~= nil then
+        content[#content + 1] = parse_content_part(content_part)
+      end
 
-    return content
-  end
+      return content
+    end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -28644,7 +28894,9 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function fill_emph(t, opening_index, closing_index)
-    local content = collect_emphasis_content(t, opening_index + 1, closing_index - 1)
+    local content
+      = collect_emphasis_content(t, opening_index + 1,
+                                 closing_index - 1)
     t[opening_index + 1].is_active = true
     t[opening_index + 1].rendered = writer.emphasis(content)
   end
@@ -28658,7 +28910,9 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function fill_strong(t, opening_index, closing_index)
-    local content = collect_emphasis_content(t, opening_index + 1, closing_index - 1)
+    local content
+      = collect_emphasis_content(t, opening_index + 1,
+                                 closing_index - 1)
     t[opening_index + 1].is_active = true
     t[opening_index + 1].rendered = writer.strong(content)
   end
@@ -28672,9 +28926,12 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function breaks_three_rule(opening_delimiter, closing_delimiter)
-    return (opening_delimiter.is_closing or closing_delimiter.is_opening) and
-      ((opening_delimiter.original_count + closing_delimiter.original_count) % 3 == 0) and
-      (opening_delimiter.original_count % 3 ~= 0 or closing_delimiter.original_count % 3 ~= 0)
+    return ( opening_delimiter.is_closing
+          or closing_delimiter.is_opening)
+       and (( opening_delimiter.original_count
+            + closing_delimiter.original_count) % 3 == 0)
+       and ( opening_delimiter.original_count % 3 ~= 0
+          or closing_delimiter.original_count % 3 ~= 0)
   end
 
 %    \end{macrocode}
@@ -28686,7 +28943,8 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function find_emphasis_opener(t, bottom_index, latest_index, character, closing_delimiter)
+  local find_emphasis_opener = function(t, bottom_index, latest_index,
+                                        character, closing_delimiter)
     for i = latest_index, bottom_index, -1 do
       local value = t[i]
       if value.is_active and
@@ -28750,12 +29008,18 @@ function M.reader.new(writer, options)
       local is_opening = value.is_opening
       local closing_length_modulo_three = value.original_count % 3
 
-      local current_openers_bottom = openers_bottom[character][is_opening][closing_length_modulo_three + 1]
+      local current_openers_bottom
+        = openers_bottom[character][is_opening]
+                        [closing_length_modulo_three + 1]
 
-      local opener_position = find_emphasis_opener(t, current_openers_bottom, current_position - 1, character, value)
+      local opener_position
+        = find_emphasis_opener(t, current_openers_bottom,
+                               current_position - 1, character, value)
 
       if (opener_position == nil) then
-        openers_bottom[character][is_opening][closing_length_modulo_three + 1] = current_position
+        openers_bottom[character][is_opening]
+                      [closing_length_modulo_three + 1]
+          = current_position
         current_position = current_position + 1
         goto continue
       end
@@ -28765,7 +29029,8 @@ function M.reader.new(writer, options)
       local current_opening_count = opening_delimiter.current_count
       local current_closing_count = t[current_position].current_count
 
-      if (current_opening_count >= 2) and (current_closing_count >= 2) then
+      if (current_opening_count >= 2)
+          and (current_closing_count >= 2) then
         opening_delimiter.current_count = current_opening_count - 2
         t[current_position].current_count = current_closing_count - 2
         fill_strong(t, opener_position, current_position)
@@ -28849,15 +29114,19 @@ function M.reader.new(writer, options)
     return check_unicode_type(s, i, 0, 3, "%s")
   end
 
-  parsers.unicode_preceding_punctuation = B(parsers.escapable)
-                                        + Cmt(parsers.succeed, check_preceding_unicode_punctuation)
+  parsers.unicode_preceding_punctuation
+    = B(parsers.escapable)
+    + Cmt(parsers.succeed, check_preceding_unicode_punctuation)
 
-  parsers.unicode_preceding_whitespace = Cmt(parsers.succeed, check_preceding_unicode_whitespace)
+  parsers.unicode_preceding_whitespace
+    = Cmt(parsers.succeed, check_preceding_unicode_whitespace)
 
-  parsers.unicode_following_punctuation = #parsers.escapable
-                                        + Cmt(parsers.succeed, check_following_unicode_punctuation)
+  parsers.unicode_following_punctuation
+    = #parsers.escapable
+    + Cmt(parsers.succeed, check_following_unicode_punctuation)
 
-  parsers.unicode_following_whitespace = Cmt(parsers.succeed, check_following_unicode_whitespace)
+  parsers.unicode_following_whitespace
+    = Cmt(parsers.succeed, check_following_unicode_whitespace)
 
   parsers.delimiter_run = function(character)
     return  (B(parsers.backslash * character) + -B(character))
@@ -28867,49 +29136,58 @@ function M.reader.new(writer, options)
 
   parsers.left_flanking_delimiter_run = function(character)
     return  (B( parsers.any)
-              * (parsers.unicode_preceding_punctuation + parsers.unicode_preceding_whitespace)
+              * ( parsers.unicode_preceding_punctuation
+                + parsers.unicode_preceding_whitespace)
              + -B(parsers.any))
             * parsers.delimiter_run(character)
             * parsers.unicode_following_punctuation
             + parsers.delimiter_run(character)
-            * -#(parsers.unicode_following_punctuation + parsers.unicode_following_whitespace
+            * -#( parsers.unicode_following_punctuation
+                + parsers.unicode_following_whitespace
                 + parsers.eof)
   end
 
   parsers.right_flanking_delimiter_run = function(character)
     return  parsers.unicode_preceding_punctuation
           * parsers.delimiter_run(character)
-          * (parsers.unicode_following_punctuation + parsers.unicode_following_whitespace
+          * ( parsers.unicode_following_punctuation
+            + parsers.unicode_following_whitespace
             + parsers.eof)
           + (B(parsers.any)
-            * -(parsers.unicode_preceding_punctuation + parsers.unicode_preceding_whitespace))
+            * -( parsers.unicode_preceding_punctuation
+               + parsers.unicode_preceding_whitespace))
           * parsers.delimiter_run(character)
   end
 
   if options.underscores then
-    parsers.emph_start = parsers.left_flanking_delimiter_run(parsers.asterisk)
-                      + (-#parsers.right_flanking_delimiter_run(parsers.underscore)
-                          + (parsers.unicode_preceding_punctuation
-                            * #parsers.right_flanking_delimiter_run(parsers.underscore)))
-                      * parsers.left_flanking_delimiter_run(parsers.underscore)
+    parsers.emph_start
+      = parsers.left_flanking_delimiter_run(parsers.asterisk)
+      + ( -#parsers.right_flanking_delimiter_run(parsers.underscore)
+        + ( parsers.unicode_preceding_punctuation
+          * #parsers.right_flanking_delimiter_run(parsers.underscore)))
+      * parsers.left_flanking_delimiter_run(parsers.underscore)
 
-    parsers.emph_end  = parsers.right_flanking_delimiter_run(parsers.asterisk)
-                      + (-#parsers.left_flanking_delimiter_run(parsers.underscore)
-                        + #(parsers.left_flanking_delimiter_run(parsers.underscore)
-                          * parsers.unicode_following_punctuation))
-                      * parsers.right_flanking_delimiter_run(parsers.underscore)
+    parsers.emph_end
+      = parsers.right_flanking_delimiter_run(parsers.asterisk)
+      + ( -#parsers.left_flanking_delimiter_run(parsers.underscore)
+        + #( parsers.left_flanking_delimiter_run(parsers.underscore)
+           * parsers.unicode_following_punctuation))
+      * parsers.right_flanking_delimiter_run(parsers.underscore)
   else
-    parsers.emph_start = parsers.left_flanking_delimiter_run(parsers.asterisk)
+    parsers.emph_start
+      = parsers.left_flanking_delimiter_run(parsers.asterisk)
 
-    parsers.emph_end  = parsers.right_flanking_delimiter_run(parsers.asterisk)
+    parsers.emph_end
+      = parsers.right_flanking_delimiter_run(parsers.asterisk)
   end
 
-  parsers.emph_capturing_open_and_close = #parsers.emph_start * #parsers.emph_end
-                                        * Ct( Cg(Cc("delimiter"), "type")
-                                            * Cg(Cc("emphasis"), "element")
-                                            * Cg(C(parsers.emph_start), "content")
-                                            * Cg(Cc(true), "is_opening")
-                                            * Cg(Cc(true), "is_closing"))
+  parsers.emph_capturing_open_and_close
+    = #parsers.emph_start * #parsers.emph_end
+    * Ct( Cg(Cc("delimiter"), "type")
+        * Cg(Cc("emphasis"), "element")
+        * Cg(C(parsers.emph_start), "content")
+        * Cg(Cc(true), "is_opening")
+        * Cg(Cc(true), "is_closing"))
 
   parsers.emph_capturing_open = Ct( Cg(Cc("delimiter"), "type")
                                   * Cg(Cc("emphasis"), "element")
@@ -28999,17 +29277,24 @@ function M.reader.new(writer, options)
 
   parsers.title_s_direct_ref  = parsers.squote
                               * Cs((parsers.html_entities
-                                  + (parsers.anyescaped - parsers.squote - parsers.blankline^2))^0)
+                                  + ( parsers.anyescaped
+                                    - parsers.squote
+                                    - parsers.blankline^2))^0)
                               * parsers.squote
 
   parsers.title_d_direct_ref  = parsers.dquote
                               * Cs((parsers.html_entities
-                                  + (parsers.anyescaped - parsers.dquote - parsers.blankline^2))^0)
+                                  + ( parsers.anyescaped
+                                    - parsers.dquote
+                                    - parsers.blankline^2))^0)
                               * parsers.dquote
 
   parsers.title_p_direct_ref  = parsers.lparent
                               * Cs((parsers.html_entities
-                                  + (parsers.anyescaped - parsers.lparent - parsers.rparent - parsers.blankline^2))^0)
+                                  + ( parsers.anyescaped
+                                    - parsers.lparent
+                                    - parsers.rparent
+                                    - parsers.blankline^2))^0)
                               * parsers.rparent
 
   parsers.title_direct_ref  = parsers.title_s_direct_ref
@@ -29019,7 +29304,8 @@ function M.reader.new(writer, options)
   parsers.inline_direct_ref_inside  = parsers.lparent * parsers.spnl
                                     * Cg(parsers.url + Cc(""), "url")
                                     * parsers.spnl
-                                    * Cg(parsers.title_direct_ref + Cc(""), "title")
+                                    * Cg( parsers.title_direct_ref
+                                        + Cc(""), "title")
                                     * parsers.spnl * parsers.rparent
 
   parsers.inline_direct_ref = parsers.lparent * parsers.spnlc
@@ -29047,7 +29333,8 @@ function M.reader.new(writer, options)
                         * Cg(Cc("inline"), "link_type")
                         + #(parsers.exclamation * parsers.full_link)
                         * Cg(Cc("full"), "link_type")
-                        + #(parsers.exclamation * parsers.collapsed_link)
+                        + #( parsers.exclamation
+                           * parsers.collapsed_link)
                         * Cg(Cc("collapsed"), "link_type")
                         + #(parsers.exclamation * parsers.shortcut_link)
                         * Cg(Cc("shortcut"), "link_type")
@@ -29078,15 +29365,18 @@ function M.reader.new(writer, options)
 
   local inline_note_element = Cg(Cc("note"), "element")
                             * parsers.note_opening
-                            * Cg(parsers.circumflex * parsers.lbracket, "content")
+                            * Cg( parsers.circumflex
+                                * parsers.lbracket, "content")
 
   local image_element = Cg(Cc("image"), "element")
                       * parsers.image_opening
-                      * Cg(parsers.exclamation * parsers.lbracket, "content")
+                      * Cg( parsers.exclamation
+                          * parsers.lbracket, "content")
 
   local note_element  = Cg(Cc("note"), "element")
                       * parsers.raw_note_opening
-                      * Cg(parsers.lbracket * parsers.circumflex, "content")
+                      * Cg( parsers.lbracket
+                          * parsers.circumflex, "content")
 
   local link_element  = Cg(Cc("link"), "element")
                       * parsers.link_opening
@@ -29116,7 +29406,9 @@ function M.reader.new(writer, options)
                                   * Cg(Cc(false), "is_opening")
                                   * Cg(Cc(true), "is_closing")
                                   * ( Cg(Cc(true), "is_direct")
-                                    * Cg(parsers.rbracket * #parsers.inline_direct_ref, "content")
+                                    * Cg( parsers.rbracket
+                                        * #parsers.inline_direct_ref,
+                                         "content")
                                     + Cg(Cc(false), "is_direct")
                                     * Cg(parsers.rbracket, "content")))
 
@@ -29140,19 +29432,21 @@ function M.reader.new(writer, options)
                                   * -parsers.starter) / "")
                                 * parsers.spacechar^0 / "\n"
 
-  parsers.link_and_emph_content = Ct( Cg(Cc("content"), "type")
-                                    * Cg(Cs(( parsers.link_emph_precedence
-                                            + parsers.backslash * parsers.any
-                                            + parsers.link_and_emph_endline
-                                            + (parsers.linechar
-                                              - parsers.blankline^2
-                                              - parsers.link_image_open_or_close
-                                              - parsers.emph_open_or_close))^0), "content"))
+  parsers.link_and_emph_content
+    = Ct( Cg(Cc("content"), "type")
+        * Cg(Cs(( parsers.link_emph_precedence
+                + parsers.backslash * parsers.any
+                + parsers.link_and_emph_endline
+                + (parsers.linechar
+                  - parsers.blankline^2
+                  - parsers.link_image_open_or_close
+                  - parsers.emph_open_or_close))^0), "content"))
 
-  parsers.link_and_emph_table = (parsers.link_image_opening + parsers.emph_open)
-                              * parsers.link_and_emph_content
-                              * ((parsers.link_image_open_or_close + parsers.emph_open_or_close)
-                                * parsers.link_and_emph_content)^1
+  parsers.link_and_emph_table
+    = (parsers.link_image_opening + parsers.emph_open)
+    * parsers.link_and_emph_content
+    * ((parsers.link_image_open_or_close + parsers.emph_open_or_close)
+      * parsers.link_and_emph_content)^1
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -29182,7 +29476,9 @@ function M.reader.new(writer, options)
       local value = t[i]
       if value.type == "delimiter" and
          value.is_opening and
-         (value.element == "link" or value.element == "image" or value.element == "note")
+         ( value.element == "link"
+        or value.element == "image"
+        or value.element == "note")
          and not value.removed then
         if value.is_active then
           return i
@@ -29263,11 +29559,12 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function delete_parsed_content_in_range(t, opening_index, closing_index)
-    for i = opening_index, closing_index do
-      t[i].rendered = nil
+  local delete_parsed_content_in_range =
+    function(t, opening_index, closing_index)
+      for i = opening_index, closing_index do
+        t[i].rendered = nil
+      end
     end
-  end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -29312,34 +29609,40 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function render_link_or_image(t, opening_index, closing_index, content_end_index, reference)
-    process_emphasis(t, opening_index, content_end_index)
-    local mapped = collect_emphasis_content(t, opening_index + 1, content_end_index - 1)
+  local render_link_or_image =
+    function(t, opening_index, closing_index, content_end_index,
+             reference)
+      process_emphasis(t, opening_index, content_end_index)
+      local mapped = collect_emphasis_content(t, opening_index + 1,
+                                              content_end_index - 1)
 
-    local rendered = {}
-    if (t[opening_index].element == "link") then
-      rendered = writer.link(mapped, reference.url, reference.title, reference.attributes)
-    end
-
-    if (t[opening_index].element == "image") then
-      rendered = writer.image(mapped, reference.url, reference.title, reference.attributes)
-    end
-
-    if (t[opening_index].element == "note") then
-      if (t[opening_index].link_type == "note_inline") then
-        rendered = writer.note(mapped)
+      local rendered = {}
+      if (t[opening_index].element == "link") then
+        rendered = writer.link(mapped, reference.url,
+                               reference.title, reference.attributes)
       end
-      if (t[opening_index].link_type == "raw_note") then
-        rendered = writer.note(reference)
-      end
-    end
 
-    t[opening_index].rendered = rendered
-    delete_parsed_content_in_range(t, opening_index + 1, closing_index)
-    empty_content_in_range(t, opening_index, closing_index)
-    disable_previous_link_openers(t, opening_index)
-    disable_range(t, opening_index, closing_index)
-  end
+      if (t[opening_index].element == "image") then
+        rendered = writer.image(mapped, reference.url, reference.title,
+                                reference.attributes)
+      end
+
+      if (t[opening_index].element == "note") then
+        if (t[opening_index].link_type == "note_inline") then
+          rendered = writer.note(mapped)
+        end
+        if (t[opening_index].link_type == "raw_note") then
+          rendered = writer.note(reference)
+        end
+      end
+
+      t[opening_index].rendered = rendered
+      delete_parsed_content_in_range(t, opening_index + 1,
+                                     closing_index)
+      empty_content_in_range(t, opening_index, closing_index)
+      disable_previous_link_openers(t, opening_index)
+      disable_range(t, opening_index, closing_index)
+    end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -29350,51 +29653,55 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function resolve_inline_following_content(t, closing_index, match_reference, match_link_attributes)
-    local content = ""
-    for i = closing_index + 1, #t do
-      content = content .. t[i].content
-    end
-
-    local matching_content = parsers.succeed
-
-    if match_reference then
-      matching_content = matching_content * parsers.inline_direct_ref_inside
-    end
-
-    if match_link_attributes then
-      matching_content = matching_content * Cg(Ct(parsers.attributes^-1), "attributes")
-    end
-
-    local matched = lpeg.match(Ct(matching_content * Cg(Cp(), "end_position")), content)
-
-    local matched_count = matched.end_position - 1
-    for i = closing_index + 1, #t do
-      local value = t[i]
-
-      local chars_left = matched_count
-      matched_count = matched_count - #value.content
-
-      if matched_count <= 0 then
-        value.content = value.content:sub(chars_left + 1)
-        break
+  local resolve_inline_following_content =
+    function(t, closing_index, match_reference, match_link_attributes)
+      local content = ""
+      for i = closing_index + 1, #t do
+        content = content .. t[i].content
       end
 
-      value.content = ''
-      value.is_active = false
-    end
+      local matching_content = parsers.succeed
 
-    local attributes = matched.attributes
-    if attributes == nil or next(attributes) == nil then
-      attributes = nil
-    end
+      if match_reference then
+        matching_content = matching_content
+                         * parsers.inline_direct_ref_inside
+      end
 
-    return {
-      url = matched.url or "",
-      title = matched.title or "",
-      attributes = attributes
-    }
-  end
+      if match_link_attributes then
+        matching_content = matching_content
+                         * Cg(Ct(parsers.attributes^-1), "attributes")
+      end
+
+      local matched = lpeg.match(Ct( matching_content
+                                   * Cg(Cp(), "end_position")), content)
+
+      local matched_count = matched.end_position - 1
+      for i = closing_index + 1, #t do
+        local value = t[i]
+
+        local chars_left = matched_count
+        matched_count = matched_count - #value.content
+
+        if matched_count <= 0 then
+          value.content = value.content:sub(chars_left + 1)
+          break
+        end
+
+        value.content = ''
+        value.is_active = false
+      end
+
+      local attributes = matched.attributes
+      if attributes == nil or next(attributes) == nil then
+        attributes = nil
+      end
+
+      return {
+        url = matched.url or "",
+        title = matched.title or "",
+        attributes = attributes
+      }
+    end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -29405,8 +29712,11 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function resolve_inline_link(t, opening_index, closing_index)
-    local inline_content = resolve_inline_following_content(t, closing_index, true, t.match_link_attributes)
-    render_link_or_image(t, opening_index, closing_index, closing_index, inline_content)
+    local inline_content
+      = resolve_inline_following_content(t, closing_index, true,
+                                         t.match_link_attributes)
+    render_link_or_image(t, opening_index, closing_index,
+                         closing_index, inline_content)
   end
 
 %    \end{macrocode}
@@ -29417,10 +29727,14 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  local function resolve_note_inline_link(t, opening_index, closing_index)
-    local inline_content = resolve_inline_following_content(t, closing_index, false, false)
-    render_link_or_image(t, opening_index, closing_index, closing_index, inline_content)
-  end
+  local resolve_note_inline_link =
+    function(t, opening_index, closing_index)
+      local inline_content
+        = resolve_inline_following_content(t, closing_index,
+                                           false, false)
+      render_link_or_image(t, opening_index, closing_index,
+                           closing_index, inline_content)
+    end
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -29431,13 +29745,18 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function resolve_shortcut_link(t, opening_index, closing_index)
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
+    local content
+      = collect_link_content(t, opening_index + 1, closing_index - 1)
     local r = self.lookup_reference(content)
 
     if r then
-      local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_link_attributes)
-      r.attributes = join_attributes(r.attributes, inline_content.attributes)
-      render_link_or_image(t, opening_index, closing_index, closing_index, r)
+      local inline_content
+        = resolve_inline_following_content(t, closing_index, false,
+                                           t.match_link_attributes)
+      r.attributes
+        = join_attributes(r.attributes, inline_content.attributes)
+      render_link_or_image(t, opening_index, closing_index,
+                           closing_index, r)
     end
   end
 
@@ -29450,12 +29769,14 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function resolve_raw_note_link(t, opening_index, closing_index)
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
+    local content
+      = collect_link_content(t, opening_index + 1, closing_index - 1)
     local r = self.lookup_note_reference(content)
 
     if r then
       local parsed_ref = self.parser_functions.parse_blocks_nested(r)
-      render_link_or_image(t, opening_index, closing_index, closing_index, parsed_ref)
+      render_link_or_image(t, opening_index, closing_index,
+                           closing_index, parsed_ref)
     end
   end
 
@@ -29468,15 +29789,22 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function resolve_full_link(t, opening_index, closing_index)
-    local next_link_closing_index = find_next_link_closing_index(t, closing_index + 4)
-    local next_link_content = collect_link_content(t, closing_index + 3, next_link_closing_index - 1)
+    local next_link_closing_index
+      = find_next_link_closing_index(t, closing_index + 4)
+    local next_link_content
+      = collect_link_content(t, closing_index + 3,
+                             next_link_closing_index - 1)
     local r = self.lookup_reference(next_link_content)
 
     if r then
-      local inline_content = resolve_inline_following_content(t, next_link_closing_index, false,
-                                                              t.match_link_attributes)
-      r.attributes = join_attributes(r.attributes, inline_content.attributes)
-      render_link_or_image(t, opening_index, next_link_closing_index, closing_index, r)
+      local inline_content
+        = resolve_inline_following_content(t, next_link_closing_index,
+                                           false,
+                                           t.match_link_attributes)
+      r.attributes
+        = join_attributes(r.attributes, inline_content.attributes)
+      render_link_or_image(t, opening_index, next_link_closing_index,
+                           closing_index, r)
     end
   end
 
@@ -29490,14 +29818,20 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function resolve_collapsed_link(t, opening_index, closing_index)
-    local next_link_closing_index = find_next_link_closing_index(t, closing_index + 4)
-    local content = collect_link_content(t, opening_index + 1, closing_index - 1)
+    local next_link_closing_index
+      = find_next_link_closing_index(t, closing_index + 4)
+    local content
+      = collect_link_content(t, opening_index + 1, closing_index - 1)
     local r = self.lookup_reference(content)
 
     if r then
-      local inline_content = resolve_inline_following_content(t, closing_index, false, t.match_link_attributes)
-      r.attributes = join_attributes(r.attributes, inline_content.attributes)
-      render_link_or_image(t, opening_index, next_link_closing_index, closing_index, r)
+      local inline_content
+        = resolve_inline_following_content(t, closing_index, false,
+                                           t.match_link_attributes)
+      r.attributes
+        = join_attributes(r.attributes, inline_content.attributes)
+      render_link_or_image(t, opening_index, next_link_closing_index,
+                           closing_index, r)
     end
   end
 
@@ -29519,7 +29853,9 @@ function M.reader.new(writer, options)
     for i,value in ipairs(t) do
       if not value.is_closing
           or value.type ~= "delimiter"
-          or not (value.element == "link" or value.element == "image" or value.element == "note")
+          or not ( value.element == "link"
+                or value.element == "image"
+                or value.element == "note")
           or value.removed then
         goto continue
       end
@@ -29577,7 +29913,8 @@ function M.reader.new(writer, options)
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.Str      = (parsers.normalchar * (parsers.normalchar + parsers.at)^0)
+  parsers.Str      = ( parsers.normalchar
+                     * (parsers.normalchar + parsers.at)^0)
                    / writer.string
 
   parsers.Symbol   = (parsers.backtick^1 + V("SpecialChar"))
@@ -29605,25 +29942,28 @@ function M.reader.new(writer, options)
     parsers.interrupting_bullets = parsers.fail
     parsers.interrupting_enumerators = parsers.fail
   else
-    parsers.interrupting_bullets  = parsers.bullet(parsers.dash, true)
-                                  + parsers.bullet(parsers.asterisk, true)
-                                  + parsers.bullet(parsers.plus, true)
+    parsers.interrupting_bullets
+      = parsers.bullet(parsers.dash, true)
+      + parsers.bullet(parsers.asterisk, true)
+      + parsers.bullet(parsers.plus, true)
 
-    parsers.interrupting_enumerators  = parsers.enumerator(parsers.period, true)
-                                      + parsers.enumerator(parsers.rparent, true)
+    parsers.interrupting_enumerators
+      = parsers.enumerator(parsers.period, true)
+      + parsers.enumerator(parsers.rparent, true)
   end
 
   if options.html then
-    parsers.html_interrupting = parsers.check_trail
-                              * ( parsers.html_incomplete_open_tag
-                                + parsers.html_incomplete_close_tag
-                                + parsers.html_incomplete_open_special_tag
-                                + parsers.html_comment_start
-                                + parsers.html_cdatasection_start
-                                + parsers.html_declaration_start
-                                + parsers.html_instruction_start
-                                - parsers.html_close_special_tag
-                                - parsers.html_empty_special_tag)
+    parsers.html_interrupting
+      = parsers.check_trail
+      * ( parsers.html_incomplete_open_tag
+        + parsers.html_incomplete_close_tag
+        + parsers.html_incomplete_open_special_tag
+        + parsers.html_comment_start
+        + parsers.html_cdatasection_start
+        + parsers.html_declaration_start
+        + parsers.html_instruction_start
+        - parsers.html_close_special_tag
+        - parsers.html_empty_special_tag)
   else
     parsers.html_interrupting = parsers.fail
   end
@@ -29671,18 +30011,24 @@ function M.reader.new(writer, options)
 
   parsers.Space      = parsers.spacechar^2 * parsers.Endline
                                            / writer.hard_line_break
-                     + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / self.expandtabs
+                     + parsers.spacechar^1
+                     * parsers.Endline^-1
+                     * parsers.eof / self.expandtabs
                      + parsers.spacechar^1 * parsers.Endline
                                            / writer.soft_line_break
-                     + parsers.spacechar^1 * -parsers.newline / self.expandtabs
+                     + parsers.spacechar^1
+                     * -parsers.newline / self.expandtabs
 
   parsers.NoSoftLineBreakSpace
                      = parsers.spacechar^2 * parsers.Endline
                                            / writer.hard_line_break
-                     + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / self.expandtabs
+                     + parsers.spacechar^1
+                     * parsers.Endline^-1
+                     * parsers.eof / self.expandtabs
                      + parsers.spacechar^1 * parsers.Endline
                                            / writer.soft_line_break
-                     + parsers.spacechar^1 * -parsers.newline / self.expandtabs
+                     + parsers.spacechar^1
+                     * -parsers.newline / self.expandtabs
 
   parsers.NonbreakingEndline
                     = parsers.endline
@@ -29691,7 +30037,8 @@ function M.reader.new(writer, options)
   parsers.NonbreakingSpace
                   = parsers.spacechar^2 * parsers.Endline
                                         / writer.hard_line_break
-                  + parsers.spacechar^1 * parsers.Endline^-1 * parsers.eof / ""
+                  + parsers.spacechar^1
+                  * parsers.Endline^-1 * parsers.eof / ""
                   + parsers.spacechar^1 * parsers.Endline
                                         * parsers.optionalspace
                                         / writer.soft_line_break
@@ -29743,18 +30090,20 @@ end
   parsers.LinkAndEmph = Ct(parsers.link_and_emph_table)
                       / self.defer_link_and_emphasis_processing
 
-  parsers.EscapedChar   = parsers.backslash * C(parsers.escapable) / writer.string
+  parsers.EscapedChar = parsers.backslash
+                      * C(parsers.escapable) / writer.string
 
-  parsers.InlineHtml    = Cs(parsers.html_inline_comment) / writer.inline_html_comment
-                        + Cs(parsers.html_any_empty_inline_tag
-                            + parsers.html_inline_instruction
-                            + parsers.html_inline_cdatasection
-                            + parsers.html_inline_declaration
-                            + parsers.html_any_open_inline_tag
-                            + parsers.html_any_close_tag)
-                          / writer.inline_html_tag
+  parsers.InlineHtml = Cs(parsers.html_inline_comment)
+                     / writer.inline_html_comment
+                     + Cs(parsers.html_any_empty_inline_tag
+                         + parsers.html_inline_instruction
+                         + parsers.html_inline_cdatasection
+                         + parsers.html_inline_declaration
+                         + parsers.html_any_open_inline_tag
+                         + parsers.html_any_close_tag)
+                       / writer.inline_html_tag
 
-  parsers.HtmlEntity    = parsers.html_entities / writer.string
+  parsers.HtmlEntity = parsers.html_entities / writer.string
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -29773,15 +30122,18 @@ end
                             + parsers.html_declaration))
                         / writer.block_html_element
 
-  parsers.indented_non_blank_line = parsers.indentedline - parsers.blankline
+  parsers.indented_non_blank_line = parsers.indentedline
+                                  - parsers.blankline
 
-  parsers.Verbatim  = Cs(
-                        parsers.check_code_trail
-                      * (parsers.line - parsers.blankline)
-                      * ((parsers.check_minimal_blank_indent_and_full_code_trail * parsers.blankline)^0
-                        * ((parsers.check_minimal_indent / "") * parsers.check_code_trail
-                           * (parsers.line - parsers.blankline))^1)^0
-                      ) / self.expandtabs / writer.verbatim
+  parsers.Verbatim
+    = Cs( parsers.check_code_trail
+        * (parsers.line - parsers.blankline)
+        * (( parsers.check_minimal_blank_indent_and_full_code_trail
+           * parsers.blankline)^0
+          * ( (parsers.check_minimal_indent / "")
+            * parsers.check_code_trail
+            * (parsers.line - parsers.blankline))^1)^0)
+    / self.expandtabs / writer.verbatim
 
   parsers.Blockquote   = parsers.blockquote_body
                        / writer.blockquote
@@ -29820,73 +30172,79 @@ end
 
   parsers.list_blank = parsers.conditionally_indented_blankline
 
-  parsers.ref_or_block_list_separated = parsers.sep_group_no_output(parsers.list_blank)
-                                      * parsers.minimally_indented_ref
-                                      + parsers.block_sep_group(parsers.list_blank)
-                                      * parsers.minimally_indented_block
+  parsers.ref_or_block_list_separated
+    = parsers.sep_group_no_output(parsers.list_blank)
+    * parsers.minimally_indented_ref
+    + parsers.block_sep_group(parsers.list_blank)
+    * parsers.minimally_indented_block
 
-  parsers.ref_or_block_non_separated  = parsers.minimally_indented_ref
-                                      + (parsers.succeed / writer.interblocksep)
-                                      * parsers.minimally_indented_block
-                                      - parsers.minimally_indented_blankline
+  parsers.ref_or_block_non_separated
+    = parsers.minimally_indented_ref
+    + (parsers.succeed / writer.interblocksep)
+    * parsers.minimally_indented_block
+    - parsers.minimally_indented_blankline
 
-  parsers.tight_list_loop_body_pair  =
-    parsers.create_loop_body_pair(parsers.ref_or_block_non_separated,
-                                  parsers.minimally_indented_par_or_plain_no_blank,
-                                  (parsers.succeed / writer.interblocksep),
-                                  (parsers.succeed / writer.paragraphsep))
+  parsers.tight_list_loop_body_pair =
+    parsers.create_loop_body_pair(
+      parsers.ref_or_block_non_separated,
+      parsers.minimally_indented_par_or_plain_no_blank,
+      (parsers.succeed / writer.interblocksep),
+      (parsers.succeed / writer.paragraphsep))
 
-  parsers.loose_list_loop_body_pair  =
-    parsers.create_loop_body_pair(parsers.ref_or_block_list_separated,
-                                  parsers.minimally_indented_par_or_plain,
-                                  parsers.block_sep_group(parsers.list_blank),
-                                  parsers.par_sep_group(parsers.list_blank))
+  parsers.loose_list_loop_body_pair =
+    parsers.create_loop_body_pair(
+      parsers.ref_or_block_list_separated,
+      parsers.minimally_indented_par_or_plain,
+      parsers.block_sep_group(parsers.list_blank),
+      parsers.par_sep_group(parsers.list_blank))
 
-  parsers.tight_list_content_loop = V("Block")
-                                  * parsers.tight_list_loop_body_pair.block^0
-                                  + (V("Paragraph") + V("Plain"))
-                                  * parsers.ref_or_block_non_separated
-                                  * parsers.tight_list_loop_body_pair.block^0
-                                  +  (V("Paragraph") + V("Plain"))
-                                  * parsers.tight_list_loop_body_pair.par^0
+  parsers.tight_list_content_loop
+    = V("Block")
+    * parsers.tight_list_loop_body_pair.block^0
+    + (V("Paragraph") + V("Plain"))
+    * parsers.ref_or_block_non_separated
+    * parsers.tight_list_loop_body_pair.block^0
+    +  (V("Paragraph") + V("Plain"))
+    * parsers.tight_list_loop_body_pair.par^0
 
-  parsers.loose_list_content_loop = V("Block")
-                                  * parsers.loose_list_loop_body_pair.block^0
-                                  + (V("Paragraph") + V("Plain"))
-                                  * parsers.ref_or_block_list_separated
-                                  * parsers.loose_list_loop_body_pair.block^0
-                                  + (V("Paragraph") + V("Plain"))
-                                  * parsers.loose_list_loop_body_pair.par^0
+  parsers.loose_list_content_loop
+    = V("Block")
+    * parsers.loose_list_loop_body_pair.block^0
+    + (V("Paragraph") + V("Plain"))
+    * parsers.ref_or_block_list_separated
+    * parsers.loose_list_loop_body_pair.block^0
+    + (V("Paragraph") + V("Plain"))
+    * parsers.loose_list_loop_body_pair.par^0
 
-  parsers.list_item_tightness_condition = -#( parsers.list_blank^0
-                                            * parsers.minimally_indented_ref_or_block_or_par)
-                                        * remove_indent("li")
-                                        + remove_indent("li")
-                                        * parsers.fail
+  parsers.list_item_tightness_condition
+    = -#( parsers.list_blank^0
+        * parsers.minimally_indented_ref_or_block_or_par)
+    * remove_indent("li")
+    + remove_indent("li")
+    * parsers.fail
 
-  parsers.indented_content_tight  = Ct( (parsers.blankline / "")
-                                      * #parsers.list_blank
-                                      * remove_indent("li")
-                                      + ( (V("Reference") + (parsers.blankline / ""))
-                                        * parsers.check_minimal_indent
-                                        * parsers.tight_list_content_loop
-                                        + (V("Reference") + (parsers.blankline / ""))
-                                        + (parsers.tickbox^-1 / writer.escape)
-                                        * parsers.tight_list_content_loop
-                                        )
-                                      * parsers.list_item_tightness_condition
-                                  )
+  parsers.indented_content_tight
+    = Ct( (parsers.blankline / "")
+        * #parsers.list_blank
+        * remove_indent("li")
+        + ( (V("Reference") + (parsers.blankline / ""))
+          * parsers.check_minimal_indent
+          * parsers.tight_list_content_loop
+          + (V("Reference") + (parsers.blankline / ""))
+          + (parsers.tickbox^-1 / writer.escape)
+          * parsers.tight_list_content_loop
+          )
+        * parsers.list_item_tightness_condition)
 
-  parsers.indented_content_loose  = Ct( (parsers.blankline / "")
-                                      * #parsers.list_blank
-                                      + ( (V("Reference") + (parsers.blankline / ""))
-                                        * parsers.check_minimal_indent
-                                        * parsers.loose_list_content_loop
-                                        + (V("Reference") + (parsers.blankline / ""))
-                                        + (parsers.tickbox^-1 / writer.escape)
-                                        * parsers.loose_list_content_loop
-                                        )
-                                  )
+  parsers.indented_content_loose
+    = Ct( (parsers.blankline / "")
+        * #parsers.list_blank
+        + ( (V("Reference") + (parsers.blankline / ""))
+          * parsers.check_minimal_indent
+          * parsers.loose_list_content_loop
+          + (V("Reference") + (parsers.blankline / ""))
+          + (parsers.tickbox^-1 / writer.escape)
+          * parsers.loose_list_content_loop))
 
   parsers.TightListItem = function(starter)
     return  -parsers.ThematicBreak
@@ -29944,13 +30302,15 @@ end
     local enumerator = parsers.enumerator(delimiter_type)
     return  Cg(enumerator, "listtype")
           * (Ct( parsers.TightListItem(Cb("listtype"))
-               * ((parsers.check_minimal_indent / "") * parsers.TightListItem(enumerator))^0)
+               * ( (parsers.check_minimal_indent / "")
+                 * parsers.TightListItem(enumerator))^0)
           * Cc(true)
           * -#((parsers.list_blank^0 / "")
               * parsers.check_minimal_indent * enumerator)
           + Ct( parsers.LooseListItem(Cb("listtype"))
               * ((parsers.list_blank^0 / "")
-                * (parsers.check_minimal_indent / "") * parsers.LooseListItem(enumerator))^0)
+                * (parsers.check_minimal_indent / "")
+                * parsers.LooseListItem(enumerator))^0)
           * Cc(false)
           ) * Ct(Cb("listtype")) / ordered_list
   end
@@ -30003,15 +30363,21 @@ end
                         - parsers.thematic_break_lines
 
   parsers.heading_text = parsers.heading_line
-                       * ((V("Endline") / "\n") * (parsers.heading_line - parsers.heading_level))^0
+                       * ( (V("Endline") / "\n")
+                         * ( parsers.heading_line
+                           - parsers.heading_level))^0
                        * parsers.newline^-1
 
-  parsers.SetextHeading = parsers.freeze_trail * parsers.check_trail_no_rem
-                        * #(parsers.heading_text
-                           * parsers.check_minimal_indent * parsers.check_trail * parsers.heading_level)
+  parsers.SetextHeading = parsers.freeze_trail
+                        * parsers.check_trail_no_rem
+                        * #( parsers.heading_text
+                           * parsers.check_minimal_indent
+                           * parsers.check_trail
+                           * parsers.heading_level)
                         * Cs(parsers.heading_text)
                         / parsers.parse_heading_text
-                        * parsers.check_minimal_indent_and_trail * parsers.heading_level
+                        * parsers.check_minimal_indent_and_trail
+                        * parsers.heading_level
                         * parsers.newline
                         * parsers.unfreeze_trail
                         / writer.heading
@@ -30063,14 +30429,18 @@ end
     local current_extension_name = nil
     self.insert_pattern = function(selector, pattern, pattern_name)
       assert(pattern_name == nil or type(pattern_name) == "string")
-      local _, _, lhs, pos, rhs = selector:find("^(%a+)%s+([%a%s]+%a+)%s+(%a+)$")
+      local _, _, lhs, pos, rhs
+        = selector:find("^(%a+)%s+([%a%s]+%a+)%s+(%a+)$")
       assert(lhs ~= nil,
-        [[Expected selector in form "LHS (before|after|instead of) RHS", not "]]
+        [[Expected selector in form ]]
+        .. [["LHS (before|after|instead of) RHS", not "]]
         .. selector .. [["]])
       assert(walkable_syntax[lhs] ~= nil,
-        [[Rule ]] .. lhs .. [[ -> ... does not exist in markdown grammar]])
+        [[Rule ]] .. lhs
+        .. [[ -> ... does not exist in markdown grammar]])
       assert(pos == "before" or pos == "after" or pos == "instead of",
-        [[Expected positional specifier "before", "after", or "instead of", not "]]
+        [[Expected positional specifier "before", "after", ]]
+        .. [[or "instead of", not "]]
         .. pos .. [["]])
       local rule = walkable_syntax[lhs]
       local index = nil
@@ -30088,10 +30458,12 @@ end
           .. [[ does not exist in markdown grammar]])
       local accountable_pattern
       if current_extension_name then
-        accountable_pattern = { pattern, current_extension_name, pattern_name }
+        accountable_pattern
+          = {pattern, current_extension_name, pattern_name}
       else
         assert(type(pattern) == "string",
-          [[reader->insert_pattern() was called outside an extension with ]]
+          [[reader->insert_pattern() was called outside ]]
+          .. [[an extension with ]]
           .. [[a PEG pattern instead of a rule name]])
         accountable_pattern = pattern
       end
@@ -30114,9 +30486,9 @@ end
     local syntax =
       { "Blocks",
 
-        Blocks                = V("InitializeState")
-                              * V("ExpectedJekyllData")
-                              * V("Blank")^0
+        Blocks = V("InitializeState")
+               * V("ExpectedJekyllData")
+               * V("Blank")^0
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -30127,71 +30499,72 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-                              * ( V("Block")
-                                * ( V("Blank")^0 * parsers.eof
-                                  + ( V("Blank")^2 / writer.paragraphsep
-                                    + V("Blank")^0 / writer.interblocksep
-                                    )
-                                  )
-                                + ( V("Paragraph") + V("Plain") )
-                                * ( V("Blank")^0 * parsers.eof
-                                  + ( V("Blank")^2 / writer.paragraphsep
-                                    + V("Blank")^0 / writer.interblocksep
-                                    )
-                                  )
-                                * V("Block")
-                                * ( V("Blank")^0 * parsers.eof
-                                  + ( V("Blank")^2 / writer.paragraphsep
-                                    + V("Blank")^0 / writer.interblocksep
-                                    )
-                                  )
-                                + ( V("Paragraph") + V("Plain") )
-                                * ( V("Blank")^0 * parsers.eof
-                                  + V("Blank")^0 / writer.paragraphsep
-                                  )
-                                )^0,
+               * ( V("Block")
+                 * ( V("Blank")^0 * parsers.eof
+                   + ( V("Blank")^2 / writer.paragraphsep
+                     + V("Blank")^0 / writer.interblocksep
+                     )
+                   )
+                 + ( V("Paragraph") + V("Plain") )
+                 * ( V("Blank")^0 * parsers.eof
+                   + ( V("Blank")^2 / writer.paragraphsep
+                     + V("Blank")^0 / writer.interblocksep
+                     )
+                   )
+                 * V("Block")
+                 * ( V("Blank")^0 * parsers.eof
+                   + ( V("Blank")^2 / writer.paragraphsep
+                     + V("Blank")^0 / writer.interblocksep
+                     )
+                   )
+                 + ( V("Paragraph") + V("Plain") )
+                 * ( V("Blank")^0 * parsers.eof
+                   + V("Blank")^0 / writer.paragraphsep
+                   )
+                 )^0,
 
-        ExpectedJekyllData    = parsers.succeed,
+        ExpectedJekyllData = parsers.succeed,
 
-        Blank                 = parsers.Blank,
-        Reference             = parsers.Reference,
+        Blank              = parsers.Blank,
+        Reference          = parsers.Reference,
 
-        Blockquote            = parsers.Blockquote,
-        Verbatim              = parsers.Verbatim,
-        ThematicBreak         = parsers.ThematicBreak,
-        BulletList            = parsers.BulletList,
-        OrderedList           = parsers.OrderedList,
-        DisplayHtml           = parsers.DisplayHtml,
-        Heading               = parsers.Heading,
-        Paragraph             = parsers.Paragraph,
-        Plain                 = parsers.Plain,
+        Blockquote         = parsers.Blockquote,
+        Verbatim           = parsers.Verbatim,
+        ThematicBreak      = parsers.ThematicBreak,
+        BulletList         = parsers.BulletList,
+        OrderedList        = parsers.OrderedList,
+        DisplayHtml        = parsers.DisplayHtml,
+        Heading            = parsers.Heading,
+        Paragraph          = parsers.Paragraph,
+        Plain              = parsers.Plain,
 
-        EndlineExceptions     = parsers.EndlineExceptions,
+        EndlineExceptions  = parsers.EndlineExceptions,
         NoSoftLineBreakEndlineExceptions
-                              = parsers.NoSoftLineBreakEndlineExceptions,
+                           = parsers.NoSoftLineBreakEndlineExceptions,
 
-        Str                   = parsers.Str,
-        Space                 = parsers.Space,
-        NoSoftLineBreakSpace  = parsers.NoSoftLineBreakSpace,
-        OptionalIndent        = parsers.OptionalIndent,
-        Endline               = parsers.Endline,
-        EndlineNoSub          = parsers.EndlineNoSub,
+        Str                = parsers.Str,
+        Space              = parsers.Space,
+        NoSoftLineBreakSpace
+                           = parsers.NoSoftLineBreakSpace,
+        OptionalIndent     = parsers.OptionalIndent,
+        Endline            = parsers.Endline,
+        EndlineNoSub       = parsers.EndlineNoSub,
         NoSoftLineBreakEndline
-                              = parsers.NoSoftLineBreakEndline,
-        EndlineBreak          = parsers.EndlineBreak,
-        LinkAndEmph           = parsers.LinkAndEmph,
-        Code                  = parsers.Code,
-        AutoLinkUrl           = parsers.AutoLinkUrl,
-        AutoLinkEmail         = parsers.AutoLinkEmail,
+                           = parsers.NoSoftLineBreakEndline,
+        EndlineBreak       = parsers.EndlineBreak,
+        LinkAndEmph        = parsers.LinkAndEmph,
+        Code               = parsers.Code,
+        AutoLinkUrl        = parsers.AutoLinkUrl,
+        AutoLinkEmail      = parsers.AutoLinkEmail,
         AutoLinkRelativeReference
-                              = parsers.AutoLinkRelativeReference,
-        InlineHtml            = parsers.InlineHtml,
-        HtmlEntity            = parsers.HtmlEntity,
-        EscapedChar           = parsers.EscapedChar,
-        Smart                 = parsers.Smart,
-        Symbol                = parsers.Symbol,
-        SpecialChar           = parsers.fail,
-        InitializeState       = parsers.succeed,
+                           = parsers.AutoLinkRelativeReference,
+        InlineHtml         = parsers.InlineHtml,
+        HtmlEntity         = parsers.HtmlEntity,
+        EscapedChar        = parsers.EscapedChar,
+        Smart              = parsers.Smart,
+        Symbol             = parsers.Symbol,
+        SpecialChar        = parsers.fail,
+        InitializeState    = parsers.succeed,
       }
 %    \end{macrocode}
 % \par
@@ -30209,13 +30582,17 @@ end
     self.update_rule = function(rule_name, get_pattern)
       assert(current_extension_name ~= nil)
       assert(syntax[rule_name] ~= nil,
-        [[Rule ]] .. rule_name .. [[ -> ... does not exist in markdown grammar]])
+        [[Rule ]] .. rule_name
+        .. [[ -> ... does not exist in markdown grammar]])
       local previous_pattern
       local extension_name
       if walkable_syntax[rule_name] then
-        local previous_accountable_pattern = walkable_syntax[rule_name][1]
+        local previous_accountable_pattern
+          = walkable_syntax[rule_name][1]
         previous_pattern = previous_accountable_pattern[1]
-        extension_name = previous_accountable_pattern[2] .. ", " .. current_extension_name
+        extension_name
+          = previous_accountable_pattern[2]
+          .. ", " .. current_extension_name
       else
         previous_pattern = nil
         extension_name = current_extension_name
@@ -30345,9 +30722,11 @@ end
               pattern_name = "Anonymous Pattern"
             end
             local extension_name = rhs[2]
-            human_readable_rhs = pattern_name .. [[ (]] .. extension_name .. [[)]]
+            human_readable_rhs = pattern_name .. [[ (]]
+                               .. extension_name .. [[)]]
           end
-          local encoded_rhs = util.encode_json_string(human_readable_rhs)
+          local encoded_rhs
+            = util.encode_json_string(human_readable_rhs)
           local output_line = [[        ]] .. encoded_rhs
           if rhs_index < #rule then
             output_line = output_line .. ","
@@ -30365,7 +30744,8 @@ end
       local output = table.concat(output_lines, "\n")
       local output_filename = options.debugExtensionsFileName
       local output_file = assert(io.open(output_filename, "w"),
-        [[Could not open file "]] .. output_filename .. [[" for writing]])
+        [[Could not open file "]] .. output_filename
+        .. [[" for writing]])
       assert(output_file:write(output))
       assert(output_file:close())
     end
@@ -30488,8 +30868,10 @@ end
 
     local inlines_no_link_or_emphasis_t = util.table_copy(inlines_t)
     inlines_no_link_or_emphasis_t.LinkAndEmph = parsers.fail
-    inlines_no_link_or_emphasis_t.EndlineExceptions = parsers.EndlineExceptions - parsers.eof
-    parsers.inlines_no_link_or_emphasis = Ct(inlines_no_link_or_emphasis_t)
+    inlines_no_link_or_emphasis_t.EndlineExceptions
+      = parsers.EndlineExceptions - parsers.eof
+    parsers.inlines_no_link_or_emphasis
+      = Ct(inlines_no_link_or_emphasis_t)
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -30516,7 +30898,8 @@ end
         elseif form == "nfkd" then
           input = uni_algos.normalize.NFKD(input)
         else
-          return writer.error(format("Unknown normalization form %s", form))
+          return writer.error(
+            format("Unknown normalization form %s", form))
         end
       end
 %    \end{macrocode}
@@ -30551,7 +30934,8 @@ end
         end
       end
       table.sort(opt_string)
-      local salt = table.concat(opt_string, ",") .. "," .. metadata.version
+      local salt = table.concat(opt_string, ",")
+                .. "," .. metadata.version
       local output
       local function convert(input)
         local document = self.parser_functions.parse_blocks(input)
@@ -30568,32 +30952,41 @@ end
         local potential_sep_start, sep_start
         while true do
           -- find a `writer->undosep`
-          undosep_start, undosep_end = output:find(writer.undosep_text, 1, true)
+          undosep_start, undosep_end
+            = output:find(writer.undosep_text, 1, true)
           if undosep_start == nil then break end
           -- skip any preceding section ends
           secend_start = undosep_start
           while true do
             potential_secend_start = secend_start - #writer.secend_text
             if potential_secend_start < 1
-               or output:sub(potential_secend_start, secend_start - 1) ~= writer.secend_text then
+               or output:sub(potential_secend_start,
+                             secend_start - 1) ~= writer.secend_text
+               then
               break
             end
             secend_start = potential_secend_start
           end
-          -- find an immediately preceding block element / paragraph separator
+          -- find an immediately preceding
+          -- block element / paragraph separator
           sep_start = secend_start
           potential_sep_start = sep_start - #writer.interblocksep_text
           if potential_sep_start >= 1
-             and output:sub(potential_sep_start, sep_start - 1) == writer.interblocksep_text then
+             and output:sub(potential_sep_start,
+                            sep_start - 1) == writer.interblocksep_text
+             then
             sep_start = potential_sep_start
           else
             potential_sep_start = sep_start - #writer.paragraphsep_text
             if potential_sep_start >= 1
-               and output:sub(potential_sep_start, sep_start - 1) == writer.paragraphsep_text then
+               and output:sub(potential_sep_start,
+                              sep_start - 1) == writer.paragraphsep_text
+               then
               sep_start = potential_sep_start
             end
           end
-          -- remove `writer->undosep` and immediately preceding block element / paragraph separator
+          -- remove `writer->undosep` and immediately preceding
+          -- block element / paragraph separator
           output = output:sub(1, sep_start - 1)
                 .. output:sub(secend_start, undosep_start - 1)
                 .. output:sub(undosep_end + 1)
@@ -30635,7 +31028,8 @@ end
         file = assert(io.open(options.frozenCacheFileName, mode),
           [[Could not open file "]] .. options.frozenCacheFileName
           .. [[" for writing]])
-        assert(file:write([[\expandafter\global\expandafter\def\csname ]]
+        assert(file:write(
+          [[\expandafter\global\expandafter\def\csname ]]
           .. [[markdownFrozenCache]] .. options.frozenCacheCounter
           .. [[\endcsname{]] .. output .. [[}]] .. "\n"))
         assert(file:close())
@@ -30700,10 +31094,13 @@ M.extensions.bracketed_spans = function()
                               + parsers.autolink
                               + V("InlineHtml")
                               + ( parsers.backslash * parsers.backslash)
-                              + ( parsers.backslash * (parsers.lbracket + parsers.rbracket)
+                              + ( parsers.backslash
+                                * (parsers.lbracket + parsers.rbracket)
                                 + V("Space") + V("Endline")
                                 + (parsers.any
-                                  - (parsers.newline + parsers.lbracket + parsers.rbracket
+                                  - ( parsers.newline
+                                    + parsers.lbracket
+                                    + parsers.rbracket
                                     + parsers.blankline^2))))^1)
                           / self.parser_functions.parse_inlines)
                           * parsers.rbracket
@@ -30766,11 +31163,15 @@ M.extensions.citations = function(citation_nbsps)
             end
           end
         else
-          table.insert(buffer, {"\\markdownRenderer", text_cites and "TextCite" or "Cite",
-            "{", #cites, "}"})
+          table.insert(buffer,
+                       {"\\markdownRenderer",
+                        text_cites and "TextCite" or "Cite",
+                        "{", #cites, "}"})
           for _,cite in ipairs(cites) do
-            table.insert(buffer, {cite.suppress_author and "-" or "+", "{",
-              cite.prenote or "", "}{", cite.postnote or "", "}{", cite.name, "}"})
+            table.insert(buffer,
+                         {cite.suppress_author and "-" or "+", "{",
+                          cite.prenote or "", "}{",
+                          cite.postnote or "", "}{", cite.name, "}"})
           end
         end
         return buffer
@@ -30786,12 +31187,16 @@ M.extensions.citations = function(citation_nbsps)
       local citation_name
                     = Cs(parsers.dash^-1) * parsers.at
                     * Cs(citation_chars
-                        * (((citation_chars + parsers.internal_punctuation
+                        * ((( citation_chars
+                            + parsers.internal_punctuation
                             - parsers.comma - parsers.semicolon)
-                           * -#((parsers.internal_punctuation - parsers.comma
+                           * -#(( parsers.internal_punctuation
+                                - parsers.comma
                                 - parsers.semicolon)^0
-                               * -(citation_chars + parsers.internal_punctuation
-                                  - parsers.comma - parsers.semicolon)))^0
+                               * -( citation_chars
+                                  + parsers.internal_punctuation
+                                  - parsers.comma
+                                  - parsers.semicolon)))^0
                           * citation_chars)^-1)
 
       local citation_body_prenote
@@ -30802,8 +31207,12 @@ M.extensions.citations = function(citation_nbsps)
                          + V("InlineHtml")
                          + V("Space") + V("Endline")
                          + (parsers.anyescaped
-                           - (parsers.newline + parsers.rbracket + parsers.blankline^2))
-                         - (parsers.spnl * parsers.dash^-1 * parsers.at))^1)
+                           - ( parsers.newline
+                             + parsers.rbracket
+                             + parsers.blankline^2))
+                         - ( parsers.spnl
+                           * parsers.dash^-1
+                           * parsers.at))^1)
 
       local citation_body_postnote
                     = Cs((parsers.alphanumeric^1
@@ -30813,7 +31222,9 @@ M.extensions.citations = function(citation_nbsps)
                          + V("InlineHtml")
                          + V("Space") + V("Endline")
                          + (parsers.anyescaped
-                           - (parsers.newline + parsers.rbracket + parsers.semicolon
+                           - ( parsers.newline
+                             + parsers.rbracket
+                             + parsers.semicolon
                              + parsers.blankline^2))
                          - (parsers.spnl * parsers.rbracket))^1)
 
@@ -30824,7 +31235,8 @@ M.extensions.citations = function(citation_nbsps)
                       * parsers.spnlc
                     )
                     * citation_name
-                    * (parsers.internal_punctuation - parsers.semicolon)^-1
+                    * ( parsers.internal_punctuation
+                      - parsers.semicolon)^-1
                     * ( parsers.spnlc / function(_) return end
                       * citation_body_postnote
                       + Cc("")
@@ -30846,7 +31258,9 @@ M.extensions.citations = function(citation_nbsps)
                          + V("InlineHtml")
                          + V("Space") + V("Endline")
                          + (parsers.anyescaped
-                           - (parsers.newline + parsers.rbracket + parsers.at
+                           - ( parsers.newline
+                             + parsers.rbracket
+                             + parsers.at
                              + parsers.semicolon + parsers.blankline^2))
                          - (parsers.spnl * parsers.rbracket))^0)
 
@@ -30940,7 +31354,8 @@ M.extensions.content_blocks = function(language_map)
 %  \begin{macrocode}
   local languages_json = (function()
     local base, prev, curr
-    for _, pathname in ipairs{kpse.lookup(language_map, { all=true })} do
+    for _, pathname in ipairs{kpse.lookup(language_map,
+                                          {all=true})} do
       local file = io.open(pathname, "r")
       if not file then goto continue end
       local input = assert(file:read("*a"))
@@ -30981,20 +31396,20 @@ M.extensions.content_blocks = function(language_map)
         suf = suf:lower()
         if type == "onlineimage" then
           return {"\\markdownRendererContentBlockOnlineImage{",suf,"}",
-                                 "{",self.string(src),"}",
-                                 "{",self.uri(src),"}",
-                                 "{",self.string(tit or ""),"}"}
+                  "{",self.string(src),"}",
+                  "{",self.uri(src),"}",
+                  "{",self.string(tit or ""),"}"}
         elseif languages_json[suf] then
           return {"\\markdownRendererContentBlockCode{",suf,"}",
-                                 "{",self.string(languages_json[suf]),"}",
-                                 "{",self.string(src),"}",
-                                 "{",self.uri(src),"}",
-                                 "{",self.string(tit or ""),"}"}
+                  "{",self.string(languages_json[suf]),"}",
+                  "{",self.string(src),"}",
+                  "{",self.uri(src),"}",
+                  "{",self.string(tit or ""),"}"}
         else
           return {"\\markdownRendererContentBlock{",suf,"}",
-                                 "{",self.string(src),"}",
-                                 "{",self.uri(src),"}",
-                                 "{",self.string(tit or ""),"}"}
+                  "{",self.string(src),"}",
+                  "{",self.uri(src),"}",
+                  "{",self.string(tit or ""),"}"}
         end
       end
     end, extend_reader = function(self)
@@ -31029,8 +31444,8 @@ M.extensions.content_blocks = function(language_map)
                         return parser
                       end)("png", "jpg", "jpeg", "gif", "tif", "tiff")
 
-      -- online image url for iA Writer content blocks with mandatory suffix,
-      -- allowing nested brackets:
+      -- online image url for iA Writer content blocks with
+      -- mandatory suffix, allowing nested brackets:
       local onlineimageurl
                     = (parsers.less
                       * Cs((parsers.anyescaped
@@ -31108,8 +31523,9 @@ M.extensions.definition_lists = function(tight_lists)
       local function dlitem(term, defs)
         local retVal = {"\\markdownRendererDlItem{",term,"}"}
         for _, def in ipairs(defs) do
-          retVal[#retVal+1] = {"\\markdownRendererDlDefinitionBegin ",def,
-                               "\\markdownRendererDlDefinitionEnd "}
+          retVal[#retVal+1]
+            = {"\\markdownRendererDlDefinitionBegin ",def,
+               "\\markdownRendererDlDefinitionEnd "}
         end
         retVal[#retVal+1] = "\\markdownRendererDlItemEnd "
         return retVal
@@ -31135,17 +31551,26 @@ M.extensions.definition_lists = function(tight_lists)
 
       local defstartchar = S("~:")
 
-      local defstart  = parsers.check_trail_length(0) * defstartchar * #parsers.spacing
-                                      * (parsers.tab + parsers.space^-3)
-                      + parsers.check_trail_length(1) * defstartchar * #parsers.spacing
-                                       * (parsers.tab + parsers.space^-2)
-                      + parsers.check_trail_length(2) * defstartchar * #parsers.spacing
-                                       * (parsers.tab + parsers.space^-1)
-                      + parsers.check_trail_length(3) * defstartchar * #parsers.spacing
+      local defstart
+        = parsers.check_trail_length(0) * defstartchar
+        * #parsers.spacing
+        * (parsers.tab + parsers.space^-3)
+        + parsers.check_trail_length(1)
+        * defstartchar * #parsers.spacing
+        * (parsers.tab + parsers.space^-2)
+        + parsers.check_trail_length(2)
+        * defstartchar * #parsers.spacing
+        * (parsers.tab + parsers.space^-1)
+        + parsers.check_trail_length(3)
+        * defstartchar * #parsers.spacing
 
-      local indented_line = (parsers.check_minimal_indent / "") * parsers.check_code_trail * parsers.line
+      local indented_line
+        = (parsers.check_minimal_indent / "")
+        * parsers.check_code_trail * parsers.line
 
-      local blank = parsers.check_minimal_blank_indent_and_any_trail * parsers.optionalspace * parsers.newline
+      local blank
+        = parsers.check_minimal_blank_indent_and_any_trail
+        * parsers.optionalspace * parsers.newline
 
       local dlchunk = Cs(parsers.line * (indented_line - blank)^0)
 
@@ -31162,24 +31587,24 @@ M.extensions.definition_lists = function(tight_lists)
       end
 
       local DefinitionListItemLoose
-                    = C(parsers.line) * blank^0
-                    * Ct((parsers.check_minimal_indent * (defstart
-                         * indented_blocks(dlchunk)
-                         / self.parser_functions.parse_blocks_nested))^1)
-                    * Cc(false) / definition_list_item
+        = C(parsers.line) * blank^0
+        * Ct((parsers.check_minimal_indent * (defstart
+             * indented_blocks(dlchunk)
+             / self.parser_functions.parse_blocks_nested))^1)
+        * Cc(false) / definition_list_item
 
       local DefinitionListItemTight
-                    = C(parsers.line)
-                    * Ct((parsers.check_minimal_indent * (defstart * dlchunk
-                         / self.parser_functions.parse_blocks_nested))^1)
-                    * Cc(true) / definition_list_item
+        = C(parsers.line)
+        * Ct((parsers.check_minimal_indent * (defstart * dlchunk
+             / self.parser_functions.parse_blocks_nested))^1)
+        * Cc(true) / definition_list_item
 
       local DefinitionList
-                    = ( Ct(DefinitionListItemLoose^1) * Cc(false)
-                      + Ct(DefinitionListItemTight^1)
-                      * (blank^0
-                        * -DefinitionListItemLoose * Cc(true))
-                      ) / writer.definitionlist
+        = ( Ct(DefinitionListItemLoose^1) * Cc(false)
+          + Ct(DefinitionListItemTight^1)
+          * (blank^0
+            * -DefinitionListItemLoose * Cc(true))
+          ) / writer.definitionlist
 
       self.insert_pattern("Block after Heading",
                           DefinitionList, "DefinitionList")
@@ -31264,7 +31689,8 @@ M.extensions.fancy_lists = function()
           return {"\\markdownRendererFancyOlItemWithNumber{",num,"}",s,
                   "\\markdownRendererFancyOlItemEnd "}
         else
-          return {"\\markdownRendererFancyOlItem ",s,"\\markdownRendererFancyOlItemEnd "}
+          return {"\\markdownRendererFancyOlItem ",s,
+                  "\\markdownRendererFancyOlItemEnd "}
         end
       end
     end, extend_reader = function(self)
@@ -31285,7 +31711,8 @@ M.extensions.fancy_lists = function()
             continuation_marker = marker
           end
           for _,delim in ipairs(delims) do
-            table.insert(markers_table, {start_marker, continuation_marker, delim})
+            table.insert(markers_table,
+                         {start_marker, continuation_marker, delim})
           end
         end
         return markers_table
@@ -31304,15 +31731,18 @@ M.extensions.fancy_lists = function()
 
       local roman_marker = function(chars)
         local m, d, c = P(chars[1]), P(chars[2]), P(chars[3])
-        local l, x, v, i = P(chars[4]), P(chars[5]), P(chars[6]), P(chars[7])
+        local l, x, v, i
+          = P(chars[4]), P(chars[5]), P(chars[6]), P(chars[7])
         return  m^-3
                 * (c*m + c*d + d^-1 * c^-3)
                 * (x*c + x*l + l^-1 * x^-3)
                 * (i*x + i*v + v^-1 * i^-3)
       end
 
-      local lowercase_roman_marker  = roman_marker({"m", "d", "c", "l", "x", "v", "i"})
-      local uppercase_roman_marker  = roman_marker({"M", "D", "C", "L", "X", "V", "I"})
+      local lowercase_roman_marker
+        = roman_marker({"m", "d", "c", "l", "x", "v", "i"})
+      local uppercase_roman_marker
+        = roman_marker({"M", "D", "C", "L", "X", "V", "I"})
 
       local lowercase_opening_roman_marker  = P("i")
       local uppercase_opening_roman_marker  = P("I")
@@ -31336,7 +31766,8 @@ M.extensions.fancy_lists = function()
 
       local markers_table = combine_markers_and_delims(markers, delims)
 
-      local function enumerator(start_marker, _, delimiter_type, interrupting)
+      local function enumerator(start_marker, _,
+                                delimiter_type, interrupting)
         local delimiter_range
         local allowed_end
         if interrupting then
@@ -31344,7 +31775,8 @@ M.extensions.fancy_lists = function()
           allowed_end = C(parsers.spacechar^1) * #parsers.linechar
         else
           delimiter_range = start_marker
-          allowed_end = C(parsers.spacechar^1) + #(parsers.newline + parsers.eof)
+          allowed_end = C(parsers.spacechar^1)
+                      + #(parsers.newline + parsers.eof)
         end
 
         return parsers.check_trail
@@ -31366,13 +31798,15 @@ M.extensions.fancy_lists = function()
       end
 
       local function roman2number(roman)
-        local romans = { ["M"] = 1000, ["D"] = 500, ["C"] = 100, ["L"] = 50, ["X"] = 10, ["V"] = 5, ["I"] = 1 }
+        local romans = { ["M"] = 1000, ["D"] = 500, ["C"] = 100,
+                         ["L"] = 50, ["X"] = 10, ["V"] = 5, ["I"] = 1 }
         local numeral = 0
 
         local i = 1
         local len = string.len(roman)
         while i < len do
-          local z1, z2 = romans[ string.sub(roman, i, i) ], romans[ string.sub(roman, i+1, i+1) ]
+          local z1, z2 = romans[ string.sub(roman, i, i) ],
+                         romans[ string.sub(roman, i+1, i+1) ]
           if z1 < z2 then
               numeral = numeral + (z2 - z1)
               i = i + 2
@@ -31381,7 +31815,9 @@ M.extensions.fancy_lists = function()
               i = i + 1
           end
         end
-        if i <= len then numeral = numeral + romans[ string.sub(roman,i,i) ] end
+        if i <= len then
+          numeral = numeral + romans[ string.sub(roman,i,i) ]
+        end
         return numeral
       end
 
@@ -31406,11 +31842,13 @@ M.extensions.fancy_lists = function()
         end
         num = numstr:match("^([A-Z])$")
         if num then
-          return string.byte(num) - string.byte("A") + 1, "UpperAlpha", numdelim
+          return string.byte(num) - string.byte("A") + 1,
+                 "UpperAlpha", numdelim
         end
         num = numstr:match("^([a-z])$")
         if num then
-          return string.byte(num) - string.byte("a") + 1, "LowerAlpha", numdelim
+          return string.byte(num) - string.byte("a") + 1,
+                 "LowerAlpha", numdelim
         end
         num = numstr:match("^([IVXLCDM]+)")
         if num then
@@ -31424,30 +31862,39 @@ M.extensions.fancy_lists = function()
       end
 
       local function fancylist(items,tight,start)
-        local startnum, numstyle, numdelim = sniffstyle(start[2][1], start[2][2])
+        local startnum, numstyle, numdelim
+          = sniffstyle(start[2][1], start[2][2])
         return writer.fancylist(items,tight,
                                 options.startNumber and startnum or 1,
                                 numstyle or "Decimal",
                                 numdelim or "Default")
       end
 
-      local FancyListOfType = function(start_marker, continuation_marker, delimiter_type)
-        local enumerator_start = enumerator(start_marker, continuation_marker, delimiter_type)
-        local enumerator_cont = enumerator(continuation_marker, continuation_marker, delimiter_type)
-        return Cg(enumerator_start, "listtype")
-             * (Ct( TightListItem(Cb("listtype"))
-                 * ((parsers.check_minimal_indent / "") * TightListItem(enumerator_cont))^0)
-             * Cc(true)
-             * -#((parsers.conditionally_indented_blankline^0 / "")
-                 * parsers.check_minimal_indent * enumerator_cont)
-             + Ct( LooseListItem(Cb("listtype"))
-                 * ((parsers.conditionally_indented_blankline^0 / "")
-                   * (parsers.check_minimal_indent / "") * LooseListItem(enumerator_cont))^0)
-             * Cc(false)
-             ) * Ct(Cb("listtype")) / fancylist
-      end
+      local FancyListOfType
+        = function(start_marker, continuation_marker, delimiter_type)
+          local enumerator_start
+            = enumerator(start_marker, continuation_marker,
+                         delimiter_type)
+          local enumerator_cont
+            = enumerator(continuation_marker, continuation_marker,
+                         delimiter_type)
+          return Cg(enumerator_start, "listtype")
+               * (Ct( TightListItem(Cb("listtype"))
+                   * ((parsers.check_minimal_indent / "")
+                   * TightListItem(enumerator_cont))^0)
+               * Cc(true)
+               * -#((parsers.conditionally_indented_blankline^0 / "")
+                   * parsers.check_minimal_indent * enumerator_cont)
+               + Ct( LooseListItem(Cb("listtype"))
+                   * ((parsers.conditionally_indented_blankline^0 / "")
+                     * (parsers.check_minimal_indent / "")
+                     * LooseListItem(enumerator_cont))^0)
+               * Cc(false)
+               ) * Ct(Cb("listtype")) / fancylist
+        end
 
-      local FancyList = join_table_with_func(FancyListOfType, markers_table)
+      local FancyList
+        = join_table_with_func(FancyListOfType, markers_table)
 
       local Endline   = parsers.newline
                       * (parsers.check_minimal_indent
@@ -31503,14 +31950,17 @@ M.extensions.fenced_code = function(blank_before_code_fence,
         s = s:gsub("\n$", "")
         local buf = {}
         if attr ~= nil then
-          table.insert(buf, {"\\markdownRendererFencedCodeAttributeContextBegin",
-                             self.attributes(attr)})
+          table.insert(buf,
+            {"\\markdownRendererFencedCodeAttributeContextBegin",
+             self.attributes(attr)})
         end
         local name = util.cache_verbatim(options.cacheDir, s)
-        table.insert(buf, {"\\markdownRendererInputFencedCode{",
-                           name,"}{",self.string(i),"}{",self.infostring(i),"}"})
+        table.insert(buf,
+          {"\\markdownRendererInputFencedCode{",
+           name,"}{",self.string(i),"}{",self.infostring(i),"}"})
         if attr ~= nil then
-          table.insert(buf, "\\markdownRendererFencedCodeAttributeContextEnd{}")
+          table.insert(buf,
+            "\\markdownRendererFencedCodeAttributeContextEnd{}")
         end
         return buf
       end
@@ -31550,11 +32000,13 @@ M.extensions.fenced_code = function(blank_before_code_fence,
                                      - parsers.newline)^0)
                                  / strip_enclosing_whitespaces)
 
-      local backtick_infostring = Cs(Cs((V("HtmlEntity")
-                                        + (-#(parsers.backslash * parsers.backtick) * parsers.anyescaped)
-                                         - parsers.newline
-                                         - parsers.backtick)^0)
-                                    / strip_enclosing_whitespaces)
+      local backtick_infostring
+        = Cs( Cs((V("HtmlEntity")
+            + ( -#(parsers.backslash * parsers.backtick)
+              * parsers.anyescaped)
+              - parsers.newline
+              - parsers.backtick)^0)
+        / strip_enclosing_whitespaces)
 
       local fenceindent
 
@@ -31576,77 +32028,93 @@ M.extensions.fenced_code = function(blank_before_code_fence,
         end
       end
 
-      local function count_fenced_start_indent(_, _, indent_table, trail)
-        local last_indent_name = get_last_indent_name(indent_table)
-        fenceindent = 0
-        if last_indent_name ~= "li" then
-          fenceindent = #trail
-        end
-        return true
-      end
-
-      local fencehead      = function(char, infostring)
-        return               Cmt(Cb("indent_info") * parsers.check_trail, count_fenced_start_indent)
-                           * Cg(char^3, "fencelength")
-                           * parsers.optionalspace
-                           * infostring
-                           * (parsers.newline + parsers.eof)
-      end
-
-      local fencetail      = function(char)
-        return               parsers.check_trail_no_rem
-                           * Cmt(C(char^3) * Cb("fencelength"), captures_geq_length)
-                           * parsers.optionalspace * (parsers.newline + parsers.eof)
-                           + parsers.eof
-      end
-
-      local function process_fenced_line(s, i, indent_table, line_content, is_blank) -- luacheck: ignore s i
-        local remainder = ""
-        if has_trail(indent_table) then
-          remainder = indent_table.trail.internal_remainder
-        end
-
-        if is_blank and get_last_indent_name(indent_table) == "li" then
-          remainder = ""
-        end
-
-        local str = remainder .. line_content
-        local index = 1
-        local remaining = fenceindent
-
-        while true do
-          local c = str:sub(index, index)
-          if c == " " and remaining > 0 then
-            remaining = remaining - 1
-            index = index + 1
-          elseif c == "\t" and remaining > 3 then
-            remaining = remaining - 4
-            index = index + 1
-          else
-            break
+      local count_fenced_start_indent =
+        function(_, _, indent_table, trail)
+          local last_indent_name = get_last_indent_name(indent_table)
+          fenceindent = 0
+          if last_indent_name ~= "li" then
+            fenceindent = #trail
           end
+          return true
         end
 
-        return true, str:sub(index)
+      local fencehead = function(char, infostring)
+        return Cmt( Cb("indent_info")
+                  * parsers.check_trail, count_fenced_start_indent)
+             * Cg(char^3, "fencelength")
+             * parsers.optionalspace
+             * infostring
+             * (parsers.newline + parsers.eof)
       end
+
+      local fencetail = function(char)
+        return parsers.check_trail_no_rem
+             * Cmt(C(char^3) * Cb("fencelength"), captures_geq_length)
+             * parsers.optionalspace * (parsers.newline + parsers.eof)
+             + parsers.eof
+      end
+
+      local process_fenced_line =
+        function(s, i, -- luacheck: ignore s i
+                 indent_table, line_content, is_blank)
+          local remainder = ""
+          if has_trail(indent_table) then
+            remainder = indent_table.trail.internal_remainder
+          end
+
+          if is_blank
+             and get_last_indent_name(indent_table) == "li" then
+            remainder = ""
+          end
+
+          local str = remainder .. line_content
+          local index = 1
+          local remaining = fenceindent
+
+          while true do
+            local c = str:sub(index, index)
+            if c == " " and remaining > 0 then
+              remaining = remaining - 1
+              index = index + 1
+            elseif c == "\t" and remaining > 3 then
+              remaining = remaining - 4
+              index = index + 1
+            else
+              break
+            end
+          end
+
+          return true, str:sub(index)
+        end
 
       local fencedline = function(char)
-        return Cmt(Cb("indent_info") * C(parsers.line - fencetail(char)) * Cc(false), process_fenced_line)
+        return Cmt( Cb("indent_info")
+                  * C(parsers.line - fencetail(char))
+                  * Cc(false), process_fenced_line)
       end
 
-      local blankfencedline = Cmt(Cb("indent_info") * C(parsers.blankline) * Cc(true), process_fenced_line)
+      local blankfencedline
+        = Cmt( Cb("indent_info")
+             * C(parsers.blankline)
+             * Cc(true), process_fenced_line)
 
       local TildeFencedCode
-             = fencehead(parsers.tilde, tilde_infostring)
-             * Cs(((parsers.check_minimal_blank_indent / "") * blankfencedline
-                   + (parsers.check_minimal_indent / "") * fencedline(parsers.tilde))^0)
-             * ((parsers.check_minimal_indent / "") * fencetail(parsers.tilde) + parsers.succeed)
+        = fencehead(parsers.tilde, tilde_infostring)
+        * Cs(( (parsers.check_minimal_blank_indent / "")
+             * blankfencedline
+             + ( parsers.check_minimal_indent / "")
+               * fencedline(parsers.tilde))^0)
+        * ( (parsers.check_minimal_indent / "")
+          * fencetail(parsers.tilde) + parsers.succeed)
 
       local BacktickFencedCode
              = fencehead(parsers.backtick, backtick_infostring)
-             * Cs(((parsers.check_minimal_blank_indent / "") * blankfencedline
-                   + (parsers.check_minimal_indent / "") * fencedline(parsers.backtick))^0)
-             * ((parsers.check_minimal_indent / "") * fencetail(parsers.backtick) + parsers.succeed)
+             * Cs(( (parsers.check_minimal_blank_indent / "")
+                  * blankfencedline
+                  + (parsers.check_minimal_indent / "")
+                  * fencedline(parsers.backtick))^0)
+             * ( (parsers.check_minimal_indent / "")
+               * fencetail(parsers.backtick) + parsers.succeed)
 
       local infostring_with_attributes
                         = Ct(C((parsers.linechar
@@ -31656,28 +32124,28 @@ M.extensions.fenced_code = function(blank_before_code_fence,
                             * Ct(parsers.attributes))
 
       local FencedCode
-               = ((TildeFencedCode + BacktickFencedCode)
-               / function(infostring, code)
-                   local expanded_code = self.expandtabs(code)
+        = ((TildeFencedCode + BacktickFencedCode)
+        / function(infostring, code)
+          local expanded_code = self.expandtabs(code)
 
-                   if allow_raw_blocks then
-                     local raw_attr = lpeg.match(parsers.raw_attribute,
-                                                 infostring)
-                     if raw_attr then
-                       return writer.rawBlock(expanded_code, raw_attr)
-                     end
-                   end
+          if allow_raw_blocks then
+            local raw_attr = lpeg.match(parsers.raw_attribute,
+                                        infostring)
+            if raw_attr then
+              return writer.rawBlock(expanded_code, raw_attr)
+            end
+          end
 
-                   local attr = nil
-                   if allow_attributes then
-                     local match = lpeg.match(infostring_with_attributes,
-                                              infostring)
-                     if match then
-                       infostring, attr = table.unpack(match)
-                     end
-                   end
-                   return writer.fencedCode(expanded_code, infostring, attr)
-                 end)
+          local attr = nil
+          if allow_attributes then
+            local match = lpeg.match(infostring_with_attributes,
+                                     infostring)
+            if match then
+              infostring, attr = table.unpack(match)
+            end
+          end
+          return writer.fencedCode(expanded_code, infostring, attr)
+        end)
 
       self.insert_pattern("Block after Verbatim",
                           FencedCode, "FencedCode")
@@ -31729,10 +32197,13 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 % \end{markdown}
 %  \begin{macrocode}
       function self.div_begin(attributes)
-        local start_output = {"\\markdownRendererFencedDivAttributeContextBegin\n",
-                              self.attributes(attributes)}
-        local end_output = {"\\markdownRendererFencedDivAttributeContextEnd{}"}
-        return self.push_attributes("div", attributes, start_output, end_output)
+        local start_output
+          = {"\\markdownRendererFencedDivAttributeContextBegin\n",
+             self.attributes(attributes)}
+        local end_output
+          = {"\\markdownRendererFencedDivAttributeContextEnd{}"}
+        return self.push_attributes(
+          "div", attributes, start_output, end_output)
       end
 %    \end{macrocode}
 % \par
@@ -31793,21 +32264,24 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       self.initialize_named_group("fenced_div_num_opening_indents")
 
       local function increment_div_level()
-        local function push_indent_table(s, i, indent_table, -- luacheck: ignore s i
-                                         fenced_div_num_opening_indents, fenced_div_level)
-          fenced_div_level = tonumber(fenced_div_level) + 1
-          local num_opening_indents = 0
-          if indent_table.indents ~= nil then
-            num_opening_indents = #indent_table.indents
+        local push_indent_table =
+          function(s, i, indent_table, -- luacheck: ignore s i
+                   fenced_div_num_opening_indents, fenced_div_level)
+            fenced_div_level = tonumber(fenced_div_level) + 1
+            local num_opening_indents = 0
+            if indent_table.indents ~= nil then
+              num_opening_indents = #indent_table.indents
+            end
+            fenced_div_num_opening_indents[fenced_div_level]
+              = num_opening_indents
+            return true, fenced_div_num_opening_indents
           end
-          fenced_div_num_opening_indents[fenced_div_level] = num_opening_indents
-          return true, fenced_div_num_opening_indents
-        end
 
-        local function increment_level(s, i, fenced_div_level) -- luacheck: ignore s i
-          fenced_div_level = tonumber(fenced_div_level) + 1
-          return true, tostring(fenced_div_level)
-        end
+        local increment_level =
+          function(s, i, fenced_div_level) -- luacheck: ignore s i
+            fenced_div_level = tonumber(fenced_div_level) + 1
+            return true, tostring(fenced_div_level)
+          end
 
         return Cg( Cmt( Cb("indent_info")
                       * Cb("fenced_div_num_opening_indents")
@@ -31818,11 +32292,13 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       end
 
       local function decrement_div_level()
-        local function pop_indent_table(s, i, fenced_div_indent_table, fenced_div_level) -- luacheck: ignore s i
-          fenced_div_level = tonumber(fenced_div_level)
-          fenced_div_indent_table[fenced_div_level] = nil
-          return true, tostring(fenced_div_level - 1)
-        end
+        local pop_indent_table =
+          function(s, i, -- luacheck: ignore s i
+                   fenced_div_indent_table, fenced_div_level)
+            fenced_div_level = tonumber(fenced_div_level)
+            fenced_div_indent_table[fenced_div_level] = nil
+            return true, tostring(fenced_div_level - 1)
+          end
 
         return Cg( Cmt( Cb("fenced_div_num_opening_indents")
                       * Cb("fenced_div_level"), pop_indent_table)
@@ -31830,21 +32306,24 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       end
 
 
-      local non_fenced_div_block  = parsers.check_minimal_indent * V("Block")
-                                  - parsers.check_minimal_indent_and_trail * fenced_div_end
+      local non_fenced_div_block
+        = parsers.check_minimal_indent * V("Block")
+        - parsers.check_minimal_indent_and_trail * fenced_div_end
 
-      local non_fenced_div_paragraph  = parsers.check_minimal_indent * V("Paragraph")
-                                      - parsers.check_minimal_indent_and_trail * fenced_div_end
+      local non_fenced_div_paragraph
+        = parsers.check_minimal_indent * V("Paragraph")
+        - parsers.check_minimal_indent_and_trail * fenced_div_end
 
       local blank = parsers.minimally_indented_blank
 
-      local block_separated  = parsers.block_sep_group(blank)
-                             * non_fenced_div_block
+      local block_separated = parsers.block_sep_group(blank)
+                            * non_fenced_div_block
 
-      local loop_body_pair  = parsers.create_loop_body_pair(block_separated,
-                                                            non_fenced_div_paragraph,
-                                                            parsers.block_sep_group(blank),
-                                                            parsers.par_sep_group(blank))
+      local loop_body_pair
+        = parsers.create_loop_body_pair(block_separated,
+                                        non_fenced_div_paragraph,
+                                        parsers.block_sep_group(blank),
+                                        parsers.par_sep_group(blank))
 
       local content_loop  = ( non_fenced_div_block
                             * loop_body_pair.block^0
@@ -31857,7 +32336,9 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 
       local FencedDiv = fenced_div_begin
                       / function (infostring)
-                          local attr = lpeg.match(Ct(parsers.attributes), infostring)
+                          local attr
+                            = lpeg.match(Ct(parsers.attributes),
+                                         infostring)
                           if attr == nil then
                             attr = {"." .. infostring}
                           end
@@ -31868,7 +32349,8 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                       * parsers.skipblanklines
                       * Ct(content_loop)
                       * parsers.minimally_indented_blank^0
-                      * parsers.check_minimal_indent_and_trail * fenced_div_end
+                      * parsers.check_minimal_indent_and_trail
+                      * fenced_div_end
                       * decrement_div_level()
                       * (Cc("") / writer.div_end)
 
@@ -31889,23 +32371,27 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
 % \end{markdown}
 %  \begin{macrocode}
       local function is_inside_div()
-        local function check_div_level(s, i, fenced_div_level) -- luacheck: ignore s i
-          fenced_div_level = tonumber(fenced_div_level)
-          return fenced_div_level > 0
-        end
+        local check_div_level =
+          function(s, i, fenced_div_level) -- luacheck: ignore s i
+            fenced_div_level = tonumber(fenced_div_level)
+            return fenced_div_level > 0
+          end
 
         return Cmt(Cb("fenced_div_level"), check_div_level)
       end
 
       local function check_indent()
-        local function compare_indent(s, i, indent_table, -- luacheck: ignore s i
-                                      fenced_div_num_opening_indents, fenced_div_level)
-          fenced_div_level = tonumber(fenced_div_level)
-          local num_current_indents = (indent_table.current_line_indents ~= nil and
-                                      #indent_table.current_line_indents) or 0
-          local num_opening_indents = fenced_div_num_opening_indents[fenced_div_level]
-          return num_current_indents == num_opening_indents
-        end
+        local compare_indent =
+          function(s, i, indent_table, -- luacheck: ignore s i
+                   fenced_div_num_opening_indents, fenced_div_level)
+            fenced_div_level = tonumber(fenced_div_level)
+            local num_current_indents
+              = ( indent_table.current_line_indents ~= nil and
+                 #indent_table.current_line_indents) or 0
+            local num_opening_indents
+              = fenced_div_num_opening_indents[fenced_div_level]
+            return num_current_indents == num_opening_indents
+          end
 
         return Cmt( Cb("indent_info")
                   * Cb("fenced_div_num_opening_indents")
@@ -31977,26 +32463,31 @@ M.extensions.header_attributes = function()
                               * parsers.newline))^1
                           - parsers.thematic_break_lines
 
-      local heading_text  = heading_line
-                          * ((V("Endline") / "\n") * (heading_line - parsers.heading_level))^0
-                          * parsers.newline^-1
+      local heading_text
+        = heading_line
+        * ( (V("Endline") / "\n")
+          * (heading_line - parsers.heading_level))^0
+        * parsers.newline^-1
 
-      local SetextHeading  = parsers.freeze_trail * parsers.check_trail_no_rem
-                           * #(heading_text
-                              * (parsers.attributes
-                                * parsers.optionalspace
-                                * parsers.newline)^-1
-                              * parsers.check_minimal_indent * parsers.check_trail * parsers.heading_level)
-                           * Cs(heading_text) / strip_trailing_spaces
-                           / parsers.parse_heading_text
-                           * Cg(Ct((parsers.attributes
-                                 * parsers.optionalspace
-                                 * parsers.newline)^-1), "attributes")
-                           * parsers.check_minimal_indent_and_trail * parsers.heading_level
-                           * Cb("attributes")
-                           * parsers.newline
-                           * parsers.unfreeze_trail
-                           / writer.heading
+      local SetextHeading
+        = parsers.freeze_trail * parsers.check_trail_no_rem
+        * #(heading_text
+           * (parsers.attributes
+             * parsers.optionalspace
+             * parsers.newline)^-1
+           * parsers.check_minimal_indent
+           * parsers.check_trail
+           * parsers.heading_level)
+        * Cs(heading_text) / strip_trailing_spaces
+        / parsers.parse_heading_text
+        * Cg(Ct((parsers.attributes
+              * parsers.optionalspace
+              * parsers.newline)^-1), "attributes")
+        * parsers.check_minimal_indent_and_trail * parsers.heading_level
+        * Cb("attributes")
+        * parsers.newline
+        * parsers.unfreeze_trail
+        / writer.heading
 
       local Heading = AtxHeading + SetextHeading
       self.update_rule("Heading", Heading)
@@ -32070,18 +32561,18 @@ M.extensions.line_blocks = function()
       local parsers = self.parsers
       local writer = self.writer
 
-      local LineBlock = Ct(
-                        (Cs(
-                          ( (parsers.pipe * parsers.space)/""
-                          * ((parsers.space)/entities.char_entity("nbsp"))^0
-                          * parsers.linechar^0 * (parsers.newline/""))
-                          * (-parsers.pipe
-                            * (parsers.space^1/" ")
-                            * parsers.linechar^1
-                            * (parsers.newline/"")
-                            )^0
-                          * (parsers.blankline/"")^0
-                        ) / self.parser_functions.parse_inlines)^1) / writer.lineblock
+      local LineBlock
+        = Ct((Cs(( (parsers.pipe * parsers.space) / ""
+                 * ((parsers.space)/entities.char_entity("nbsp"))^0
+                 * parsers.linechar^0 * (parsers.newline/""))
+                 * (-parsers.pipe
+                   * (parsers.space^1/" ")
+                   * parsers.linechar^1
+                   * (parsers.newline/"")
+                   )^0
+                 * (parsers.blankline/"")^0)
+             / self.parser_functions.parse_inlines)^1)
+        / writer.lineblock
 
       self.insert_pattern("Block after Blockquote",
                            LineBlock, "LineBlock")
@@ -32121,8 +32612,9 @@ M.extensions.mark = function()
 
       local doubleequals = P("==")
 
-      local Mark = parsers.between(V("Inline"), doubleequals, doubleequals)
-                 / function (inlines) return writer.mark(inlines) end
+      local Mark
+        = parsers.between(V("Inline"), doubleequals, doubleequals)
+        / function (inlines) return writer.mark(inlines) end
 
       self.add_special_character("=")
       self.insert_pattern("Inline before LinkAndEmph",
@@ -32155,13 +32647,18 @@ M.extensions.link_attributes = function()
 %
 % \end{markdown}
 %  \begin{macrocode}
-      local define_reference_parser = (parsers.check_trail / "") * parsers.link_label * parsers.colon
-                                    * parsers.spnlc * parsers.url
-                                    * ( parsers.spnlc_sep * parsers.title * (parsers.spnlc * Ct(parsers.attributes))
-                                      * parsers.only_blank
-                                      + parsers.spnlc_sep * parsers.title * parsers.only_blank
-                                      + Cc("") * (parsers.spnlc * Ct(parsers.attributes)) * parsers.only_blank
-                                      + Cc("") * parsers.only_blank)
+      local define_reference_parser
+        = (parsers.check_trail / "")
+        * parsers.link_label
+        * parsers.colon
+        * parsers.spnlc * parsers.url
+        * ( parsers.spnlc_sep * parsers.title
+          * (parsers.spnlc * Ct(parsers.attributes))
+          * parsers.only_blank
+          + parsers.spnlc_sep * parsers.title * parsers.only_blank
+          + Cc("") * (parsers.spnlc * Ct(parsers.attributes))
+          * parsers.only_blank
+          + Cc("") * parsers.only_blank)
 
       local ReferenceWithAttributes = define_reference_parser
                                     / self.register_link
@@ -32176,8 +32673,10 @@ M.extensions.link_attributes = function()
 % \end{markdown}
 %  \begin{macrocode}
 
-      local LinkWithAttributesAndEmph = Ct(parsers.link_and_emph_table * Cg(Cc(true), "match_link_attributes"))
-                                      / self.defer_link_and_emphasis_processing
+      local LinkWithAttributesAndEmph
+        = Ct(parsers.link_and_emph_table * Cg(Cc(true),
+             "match_link_attributes"))
+        / self.defer_link_and_emphasis_processing
 
       self.update_rule("LinkAndEmph", LinkWithAttributesAndEmph)
 
@@ -32262,9 +32761,10 @@ M.extensions.notes = function(notes, inline_notes)
 
       if inline_notes then
         local InlineNote
-                    = parsers.circumflex
-                    * (parsers.link_label / self.parser_functions.parse_inlines_no_inline_note)
-                    / writer.note
+          = parsers.circumflex
+          * ( parsers.link_label
+            / self.parser_functions.parse_inlines_no_inline_note)
+          / writer.note
 
         self.insert_pattern("Inline after LinkAndEmph",
                             InlineNote, "InlineNote")
@@ -32302,20 +32802,27 @@ M.extensions.notes = function(notes, inline_notes)
 
         local NoteRef = RawNoteRef / lookup_note
 
-        local optionally_indented_line = parsers.check_optional_indent_and_any_trail * parsers.line
+        local optionally_indented_line
+          = parsers.check_optional_indent_and_any_trail * parsers.line
 
-        local blank = parsers.check_optional_blank_indent_and_any_trail * parsers.optionalspace * parsers.newline
+        local blank
+          = parsers.check_optional_blank_indent_and_any_trail
+          * parsers.optionalspace * parsers.newline
 
-        local chunk = Cs(parsers.line * (optionally_indented_line - blank)^0)
+        local chunk
+          = Cs(parsers.line
+          * (optionally_indented_line - blank)^0)
 
         local indented_blocks = function(bl)
           return Cs( bl
-                * (blank^1 * (parsers.check_optional_indent / "")
-                  * parsers.check_code_trail * -parsers.blankline * bl)^0)
+                * ( blank^1 * (parsers.check_optional_indent / "")
+                  * parsers.check_code_trail
+                  * -parsers.blankline * bl)^0)
         end
 
         local NoteBlock
-                    = parsers.check_trail_no_rem * RawNoteRef * parsers.colon
+                    = parsers.check_trail_no_rem
+                    * RawNoteRef * parsers.colon
                     * parsers.spnlc * indented_blocks(chunk)
                     / register_note
 
@@ -32473,24 +32980,26 @@ M.extensions.pipe_tables = function(table_captions, table_attributes)
                                         , table_hline_separator
                                         , table_hline_column)
 
-      local table_caption_beginning = (parsers.check_minimal_blank_indent_and_any_trail_no_rem
-                                      * parsers.optionalspace * parsers.newline)^0
-                                    * parsers.check_minimal_indent_and_trail
-                                    * (P("Table")^-1 * parsers.colon)
-                                    * parsers.optionalspace
+      local table_caption_beginning
+        = ( parsers.check_minimal_blank_indent_and_any_trail_no_rem
+          * parsers.optionalspace * parsers.newline)^0
+        * parsers.check_minimal_indent_and_trail
+        * (P("Table")^-1 * parsers.colon)
+        * parsers.optionalspace
 
       local function strip_trailing_spaces(s)
         return s:gsub("%s*$","")
       end
 
-      local table_row = pipe_table_row(true
-                                      , (C((parsers.linechar - parsers.pipe)^1)
-                                        / strip_trailing_spaces
-                                        / self.parser_functions.parse_inlines)
-                                      , parsers.pipe
-                                      , (C((parsers.linechar - parsers.pipe)^0)
-                                        / strip_trailing_spaces
-                                        / self.parser_functions.parse_inlines))
+      local table_row
+        = pipe_table_row(true
+                        , (C((parsers.linechar - parsers.pipe)^1)
+                          / strip_trailing_spaces
+                          / self.parser_functions.parse_inlines)
+                        , parsers.pipe
+                        , (C((parsers.linechar - parsers.pipe)^0)
+                          / strip_trailing_spaces
+                          / self.parser_functions.parse_inlines))
 
       local table_caption
       if table_captions then
@@ -32507,7 +33016,8 @@ M.extensions.pipe_tables = function(table_captions, table_attributes)
                               + ( parsers.newline
                                 * #( parsers.optionalspace
                                    * parsers.linechar)
-                                * C(parsers.optionalspace) / writer.space))
+                                * C(parsers.optionalspace)
+                                / writer.space))
                              * (parsers.linechar
                                - parsers.lbrace)^0)^1)
                              / self.parser_functions.parse_inlines)
@@ -32521,7 +33031,8 @@ M.extensions.pipe_tables = function(table_captions, table_attributes)
                             + ( parsers.newline
                               * #( parsers.optionalspace
                                  * parsers.linechar)
-                              * C(parsers.optionalspace) / writer.space))^1)
+                              * C(parsers.optionalspace)
+                              / writer.space))^1)
                         / self.parser_functions.parse_inlines
                         * parsers.newline
         end
@@ -32529,12 +33040,15 @@ M.extensions.pipe_tables = function(table_captions, table_attributes)
         table_caption = parsers.fail
       end
 
-      local PipeTable = Ct(table_row * parsers.newline * (parsers.check_minimal_indent_and_trail / {})
-                        * table_hline * parsers.newline
-                        * ((parsers.check_minimal_indent / {}) * table_row * parsers.newline)^0)
-                      / make_pipe_table_rectangular
-                      * table_caption^-1
-                      / writer.table
+      local PipeTable
+        = Ct( table_row * parsers.newline
+            * (parsers.check_minimal_indent_and_trail / {})
+          * table_hline * parsers.newline
+          * ( (parsers.check_minimal_indent / {})
+            * table_row * parsers.newline)^0)
+        / make_pipe_table_rectangular
+        * table_caption^-1
+        / writer.table
 
       self.insert_pattern("Block after Blockquote",
                           PipeTable, "PipeTable")
@@ -32702,7 +33216,8 @@ M.extensions.superscripts = function()
       local writer = self.writer
 
       local Superscript = (
-        parsers.between(parsers.Str, parsers.circumflex, parsers.circumflex)
+        parsers.between(parsers.Str, parsers.circumflex,
+                        parsers.circumflex)
       ) / writer.superscript
 
       self.insert_pattern("Inline after LinkAndEmph",
@@ -32765,11 +33280,13 @@ M.extensions.tex_math = function(tex_math_dollars,
         return str:gsub("^%s*(.-)$", "%1")
       end
 
-      local allowed_before_closing = B( parsers.backslash * parsers.any
-                                      + parsers.any * (parsers.any - parsers.backslash))
+      local allowed_before_closing
+        = B( parsers.backslash * parsers.any
+           + parsers.any * (parsers.any - parsers.backslash))
 
-      local allowed_before_closing_no_space = B( parsers.backslash * parsers.any
-                                               + parsers.any * (parsers.nonspacechar - parsers.backslash))
+      local allowed_before_closing_no_space
+        = B( parsers.backslash * parsers.any
+           + parsers.any * (parsers.nonspacechar - parsers.backslash))
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -32778,18 +33295,20 @@ M.extensions.tex_math = function(tex_math_dollars,
 %
 % \end{markdown}
 %  \begin{macrocode}
-      local dollar_math_content = (parsers.newline * (parsers.check_optional_indent / "")
-                                + parsers.backslash^-1
-                                * parsers.linechar)
-                                - parsers.blankline^2
-                                - parsers.dollar
+      local dollar_math_content
+        = (parsers.newline * (parsers.check_optional_indent / "")
+        + parsers.backslash^-1
+        * parsers.linechar)
+        - parsers.blankline^2
+        - parsers.dollar
 
       local inline_math_opening_dollars = parsers.dollar
                                         * #(parsers.nonspacechar)
 
-      local inline_math_closing_dollars = allowed_before_closing_no_space
-                                        * parsers.dollar
-                                        * -#(parsers.digit)
+      local inline_math_closing_dollars
+        = allowed_before_closing_no_space
+        * parsers.dollar
+        * -#(parsers.digit)
 
       local inline_math_dollars = between(Cs( dollar_math_content),
                                           inline_math_opening_dollars,
@@ -32812,9 +33331,10 @@ M.extensions.tex_math = function(tex_math_dollars,
 %
 % \end{markdown}
 %  \begin{macrocode}
-      local backslash_math_content  = (parsers.newline * (parsers.check_optional_indent / "")
-                                    + parsers.linechar)
-                                    - parsers.blankline^2
+      local backslash_math_content
+        = (parsers.newline * (parsers.check_optional_indent / "")
+        + parsers.linechar)
+        - parsers.blankline^2
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -32941,7 +33461,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-M.extensions.jekyll_data = function(expect_jekyll_data, ensure_jekyll_data)
+M.extensions.jekyll_data = function(expect_jekyll_data,
+                                    ensure_jekyll_data)
   return {
     name = "built-in jekyll_data syntax extension",
     extend_writer = function(self)
@@ -33000,17 +33521,18 @@ M.extensions.jekyll_data = function(expect_jekyll_data, ensure_jekyll_data)
         ::not_a_sequence::
 
         if is_sequence then
-            table.insert(buf, "\\markdownRendererJekyllDataSequenceBegin{")
-            table.insert(buf, self.identifier(p or "null"))
-            table.insert(buf, "}{")
-            table.insert(buf, #keys)
-            table.insert(buf, "}")
+          table.insert(buf,
+            "\\markdownRendererJekyllDataSequenceBegin{")
+          table.insert(buf, self.identifier(p or "null"))
+          table.insert(buf, "}{")
+          table.insert(buf, #keys)
+          table.insert(buf, "}")
         else
-            table.insert(buf, "\\markdownRendererJekyllDataMappingBegin{")
-            table.insert(buf, self.identifier(p or "null"))
-            table.insert(buf, "}{")
-            table.insert(buf, #keys)
-            table.insert(buf, "}")
+          table.insert(buf, "\\markdownRendererJekyllDataMappingBegin{")
+          table.insert(buf, self.identifier(p or "null"))
+          table.insert(buf, "}{")
+          table.insert(buf, #keys)
+          table.insert(buf, "}")
         end
 
         for _, k in ipairs(keys) do
@@ -33038,12 +33560,14 @@ M.extensions.jekyll_data = function(expect_jekyll_data, ensure_jekyll_data)
               table.insert(buf, v)
               table.insert(buf, "}")
             elseif typ == "string" then
-              table.insert(buf, "\\markdownRendererJekyllDataProgrammaticString{")
+              table.insert(buf,
+                "\\markdownRendererJekyllDataProgrammaticString{")
               table.insert(buf, k)
               table.insert(buf, "}{")
               table.insert(buf, self.identifier(v))
               table.insert(buf, "}")
-              table.insert(buf, "\\markdownRendererJekyllDataTypographicString{")
+              table.insert(buf,
+                "\\markdownRendererJekyllDataTypographicString{")
               table.insert(buf, k)
               table.insert(buf, "}{")
               table.insert(buf, t(v))
@@ -33053,8 +33577,9 @@ M.extensions.jekyll_data = function(expect_jekyll_data, ensure_jekyll_data)
               table.insert(buf, k)
               table.insert(buf, "}")
             else
-              local error = self.error(format("Unexpected type %s for value of " ..
-                                              "YAML key %s", typ, k))
+              local error = self.error(format(
+                "Unexpected type %s for value of "
+                .. "YAML key %s", typ, k))
               table.insert(buf, error)
             end
           end
@@ -33077,38 +33602,40 @@ M.extensions.jekyll_data = function(expect_jekyll_data, ensure_jekyll_data)
       local writer = self.writer
 
       local JekyllData
-                    = Cmt( C((parsers.line - P("---") - P("..."))^0)
-                         , function(s, i, text) -- luacheck: ignore s i
-                             local data
-                             local ran_ok, _ = pcall(function()
-                               -- TODO: Replace with `require("tinyyaml")` in TeX Live 2023
-                               local tinyyaml = require("markdown-tinyyaml")
-                               data = tinyyaml.parse(text, {timestamps=false})
-                             end)
-                             if ran_ok and data ~= nil then
-                               return true, writer.jekyllData(data, function(s)
-                                 return self.parser_functions.parse_blocks_nested(s)
-                               end, nil)
-                             else
-                               return false
-                             end
-                           end
-                         )
+        = Cmt( C((parsers.line - P("---") - P("..."))^0)
+             , function(s, i, text) -- luacheck: ignore s i
+                 local data
+                 local ran_ok, _ = pcall(function()
+                   -- TODO: Use `require("tinyyaml")` in TeX Live 2023
+                   local tinyyaml = require("markdown-tinyyaml")
+                   data = tinyyaml.parse(text, {timestamps=false})
+                 end)
+                 if ran_ok and data ~= nil then
+                   return true, writer.jekyllData(data, function(s)
+                     return self.parser_functions.parse_blocks_nested(s)
+                   end, nil)
+                 else
+                   return false
+                 end
+               end
+             )
 
       local UnexpectedJekyllData
-                    = P("---")
-                    * parsers.blankline / 0
-                    * #(-parsers.blankline)  -- if followed by blank, it's thematic break
-                    * JekyllData
-                    * (P("---") + P("..."))
+        = P("---")
+        * parsers.blankline / 0
+        -- if followed by blank, it's thematic break
+        * #(-parsers.blankline)
+        * JekyllData
+        * (P("---") + P("..."))
 
       local ExpectedJekyllData
-                    = ( P("---")
-                      * parsers.blankline / 0
-                      * #(-parsers.blankline)  -- if followed by blank, it's thematic break
-                      )^-1
-                    * JekyllData
-                    * (P("---") + P("..."))^-1
+        = ( P("---")
+          * parsers.blankline / 0
+          -- if followed by blank, it's thematic break
+          * #(-parsers.blankline)
+          )^-1
+        * JekyllData
+        * (P("---") + P("..."))^-1
 
       if ensure_jekyll_data then
         ExpectedJekyllData = ExpectedJekyllData
@@ -33291,7 +33818,8 @@ function M.new(options)
   end
 
   if options.citations then
-    local citations_extension = M.extensions.citations(options.citationNbsps)
+    local citations_extension
+      = M.extensions.citations(options.citationNbsps)
     table.insert(extensions, citations_extension)
   end
 
@@ -33348,7 +33876,8 @@ function M.new(options)
         .. type(user_extension.api_version)
         .. [[" but "number" was expected]])
       assert(user_extension.api_version > 0
-         and user_extension.api_version <= metadata.user_extension_api_version,
+         and user_extension.api_version
+          <= metadata.user_extension_api_version,
         [[User-defined syntax extension "]] .. pathname
         .. [[" uses syntax extension API version "]]
         .. user_extension.api_version .. [[ but markdown.lua ]]
@@ -33366,7 +33895,8 @@ function M.new(options)
         .. [[" but "number" was expected]])
       assert(user_extension.grammar_version == metadata.grammar_version,
         [[User-defined syntax extension "]] .. pathname
-        .. [[" uses grammar version "]] .. user_extension.grammar_version
+        .. [[" uses grammar version "]]
+        .. user_extension.grammar_version
         .. [[ but markdown.lua ]] .. metadata.version
         .. [[ uses grammar version ]] .. metadata.grammar_version
         .. [[, which is incompatible]])
@@ -33806,18 +34336,22 @@ end
 \def\markdownRendererUlEndTightPrototype{}%
 \def\markdownRendererOlBeginPrototype{}%
 \def\markdownRendererOlBeginTightPrototype{}%
-\def\markdownRendererFancyOlBeginPrototype#1#2{\markdownRendererOlBegin}%
-\def\markdownRendererFancyOlBeginTightPrototype#1#2{\markdownRendererOlBeginTight}%
+\def\markdownRendererFancyOlBeginPrototype#1#2{%
+  \markdownRendererOlBegin}%
+\def\markdownRendererFancyOlBeginTightPrototype#1#2{%
+  \markdownRendererOlBeginTight}%
 \def\markdownRendererOlItemPrototype{}%
 \def\markdownRendererOlItemWithNumberPrototype#1{}%
 \def\markdownRendererOlItemEndPrototype{}%
 \def\markdownRendererFancyOlItemPrototype{\markdownRendererOlItem}%
-\def\markdownRendererFancyOlItemWithNumberPrototype{\markdownRendererOlItemWithNumber}%
+\def\markdownRendererFancyOlItemWithNumberPrototype{%
+  \markdownRendererOlItemWithNumber}%
 \def\markdownRendererFancyOlItemEndPrototype{}%
 \def\markdownRendererOlEndPrototype{}%
 \def\markdownRendererOlEndTightPrototype{}%
 \def\markdownRendererFancyOlEndPrototype{\markdownRendererOlEnd}%
-\def\markdownRendererFancyOlEndTightPrototype{\markdownRendererOlEndTight}%
+\def\markdownRendererFancyOlEndTightPrototype{%
+  \markdownRendererOlEndTight}%
 \def\markdownRendererDlBeginPrototype{}%
 \def\markdownRendererDlBeginTightPrototype{}%
 \def\markdownRendererDlItemPrototype#1{#1}%
@@ -33907,7 +34441,7 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \cs_new:Nn
-  \@@_plain_tex_default_input_raw_inline_renderer_prototype:nn
+  \@@_plain_tex_default_input_raw_inline:nn
   {
     \str_case:nn
       { #2 }
@@ -33917,7 +34451,7 @@ end
       }
   }
 \cs_new:Nn
-  \@@_plain_tex_default_input_raw_block_renderer_prototype:nn
+  \@@_plain_tex_default_input_raw_block:nn
   {
     \str_case:nn
       { #2 }
@@ -33929,14 +34463,14 @@ end
 \cs_gset:Npn
   \markdownRendererInputRawInlinePrototype#1#2
   {
-    \@@_plain_tex_default_input_raw_inline_renderer_prototype:nn
+    \@@_plain_tex_default_input_raw_inline:nn
       { #1 }
       { #2 }
   }
 \cs_gset:Npn
   \markdownRendererInputRawBlockPrototype#1#2
   {
-    \@@_plain_tex_default_input_raw_block_renderer_prototype:nn
+    \@@_plain_tex_default_input_raw_block:nn
       { #1 }
       { #2 }
   }
@@ -34712,12 +35246,14 @@ end
 \msg_new:nnn
   { markdown }
   { buffering-markinline }
-  { Buffering~inline~markdown~input~into~the~temporary~input~file~"#1". }
+  { Buffering~inline~markdown~input~into~
+    the~temporary~input~file~"#1". }
 \msg_new:nnnn
   { markdown }
   { markinline-peek-failure }
   { Use~of~\iow_char:N \\ markinline~doesn't~match~its~definition }
-  { The~macro~should~be~followed~by~inline~markdown~text~in~curly~braces }
+  { The~macro~should~be~followed~by~inline~
+    markdown~text~in~curly~braces }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}
@@ -34811,7 +35347,8 @@ end
       |fi
       |markdownInfo{Including markdown document number
         "|the|markdownOptionFrozenCacheCounter" from frozen cache}%
-      |csname markdownFrozenCache|the|markdownOptionFrozenCacheCounter|endcsname
+      |csname markdownFrozenCache
+        |the|markdownOptionFrozenCacheCounter|endcsname
       |global|advance|markdownOptionFrozenCacheCounter by 1|relax
     }{%
       |markdownInfo{Including markdown document "&1"}%
@@ -35295,7 +35832,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
     }{%
-      \markdown@witiko@dot@oldRendererInputFencedCodePrototype{#1}{#2}{#3}%
+      \markdown@witiko@dot@oldRendererInputFencedCodePrototype
+        {#1}{#2}{#3}%
     }%
   }%
   \next#2 \relax}%
@@ -36111,8 +36649,9 @@ end
   \advance\markdownLaTeXCitationsCounter by 1\relax
   \ifx\relax#4\relax
     \ifx\relax#5\relax
-      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
-        \cite{#1#2#6}%  Without prenotes and postnotes, just accumulate cites
+      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+        \relax
+        \cite{#1#2#6}%  No prenotes/postnotes, just accumulate cites
         \expandafter\expandafter\expandafter
         \expandafter\expandafter\expandafter\expandafter
         \@gobblethree
@@ -36122,7 +36661,8 @@ end
         \cite{#1}%
       \fi
       \cite[#5]{#6}%
-      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
+      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+      \relax
       \else
         \expandafter\expandafter\expandafter
         \expandafter\expandafter\expandafter\expandafter
@@ -36149,7 +36689,8 @@ end
       \space  % Insert a space before the prenote in later citations
     \fi
     #4~\expandafter\cite\ifx\relax#5\relax{#6}\else[#5]{#6}\fi
-    \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
+    \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+    \relax
     \else
       \expandafter\expandafter\expandafter
       \expandafter\expandafter\expandafter\expandafter
@@ -36169,8 +36710,9 @@ end
   \advance\markdownLaTeXCitationsCounter by 1\relax
   \ifx\relax#3\relax
     \ifx\relax#4\relax
-      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
-        \citep{#1,#5}%  Without prenotes and postnotes, just accumulate cites
+      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+      \relax
+        \citep{#1,#5}%  No prenotes/postnotes, just accumulate cites
         \expandafter\expandafter\expandafter
         \expandafter\expandafter\expandafter\expandafter
         \@gobbletwo
@@ -36180,7 +36722,8 @@ end
         \citep{#1}%
       \fi
       \citep[][#4]{#5}%
-      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
+      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+      \relax
       \else
         \expandafter\expandafter\expandafter
         \expandafter\expandafter\expandafter\expandafter
@@ -36200,7 +36743,8 @@ end
       \citep{#1}%
     \fi
     \citep[#3][#4]{#5}%
-    \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
+    \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+    \relax
     \else
       \expandafter\expandafter\expandafter
       \expandafter\expandafter\expandafter\expandafter
@@ -36215,8 +36759,9 @@ end
   \advance\markdownLaTeXCitationsCounter by 1\relax
   \ifx\relax#3\relax
     \ifx\relax#4\relax
-      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
-        \citet{#1,#5}%  Without prenotes and postnotes, just accumulate cites
+      \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+      \relax
+        \citet{#1,#5}%  No prenotes/postnotes, just accumulate cites
         \expandafter\expandafter\expandafter
         \expandafter\expandafter\expandafter\expandafter
         \@gobbletwo
@@ -36226,10 +36771,13 @@ end
         \citet{#1}%
       \fi
       , \citet[#3][#4]{#5}%
-      \ifnum\markdownLaTeXCitationsCounter<\markdownLaTeXCitationsTotal\relax
+      \ifnum\markdownLaTeXCitationsCounter<\markdownLaTeXCitationsTotal
+      \relax
         ,
       \else
-        \ifnum\markdownLaTeXCitationsCounter=\markdownLaTeXCitationsTotal\relax
+        \ifnum
+        \markdownLaTeXCitationsCounter=\markdownLaTeXCitationsTotal
+        \relax
           ,
         \fi
       \fi
@@ -36248,10 +36796,13 @@ end
       \citet{#1}%
     \fi
     , \citet[#3][#4]{#5}%
-    \ifnum\markdownLaTeXCitationsCounter<\markdownLaTeXCitationsTotal\relax
+    \ifnum\markdownLaTeXCitationsCounter<\markdownLaTeXCitationsTotal
+    \relax
       ,
     \else
-      \ifnum\markdownLaTeXCitationsCounter=\markdownLaTeXCitationsTotal\relax
+      \ifnum
+      \markdownLaTeXCitationsCounter=\markdownLaTeXCitationsTotal
+      \relax
         ,
       \fi
     \fi
@@ -36266,13 +36817,15 @@ end
 % BibLaTeX implementation
 \def\markdownLaTeXBibLaTeXCitations#1#2#3#4#5{%
   \advance\markdownLaTeXCitationsCounter by 1\relax
-  \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
+  \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+  \relax
     \autocites#1[#3][#4]{#5}%
     \expandafter\@gobbletwo
   \fi\markdownLaTeXBibLaTeXCitations{#1[#3][#4]{#5}}}
 \def\markdownLaTeXBibLaTeXTextCitations#1#2#3#4#5{%
   \advance\markdownLaTeXCitationsCounter by 1\relax
-  \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal\relax
+  \ifnum\markdownLaTeXCitationsCounter>\markdownLaTeXCitationsTotal
+  \relax
     \textcites#1[#3][#4]{#5}%
     \expandafter\@gobbletwo
   \fi\markdownLaTeXBibLaTeXTextCitations{#1[#3][#4]{#5}}}
@@ -36365,7 +36918,8 @@ end
     {
       \markdownLaTeXRendererAutolink { #2 } { #3 }
     }{
-      \markdownLaTeXRendererDirectOrIndirectLink { #1 } { #2 } { #3 } { #4 }
+      \markdownLaTeXRendererDirectOrIndirectLink
+        { #1 } { #2 } { #3 } { #4 }
     }
 }
 \def\markdownLaTeXRendererAutolink#1#2{%
@@ -36664,13 +37218,13 @@ end
       {
         { latex }
           {
-            \@@_plain_tex_default_input_raw_inline_renderer_prototype:nn
+            \@@_plain_tex_default_input_raw_inline:nn
               { #1 }
               { tex }
           }
       }
       {
-        \@@_plain_tex_default_input_raw_inline_renderer_prototype:nn
+        \@@_plain_tex_default_input_raw_inline:nn
           { #1 }
           { #2 }
       }
@@ -36683,13 +37237,13 @@ end
       {
         { latex }
           {
-            \@@_plain_tex_default_input_raw_block_renderer_prototype:nn
+            \@@_plain_tex_default_input_raw_block:nn
               { #1 }
               { tex }
           }
       }
       {
-        \@@_plain_tex_default_input_raw_block_renderer_prototype:nn
+        \@@_plain_tex_default_input_raw_block:nn
           { #1 }
           { #2 }
       }
@@ -36872,7 +37426,7 @@ end
 %    \end{macrocode}
 % \iffalse
 %</context>
-%<*themes-witiko-markdown-defaults-context>
+%<*themes-witiko-markdown-defaults-ctx>
 % \fi
 % \par
 % \begin{markdown}
@@ -37054,7 +37608,8 @@ end
 \def\markdownRendererStrikeThroughPrototype#1{\overstrikes{#1}}
 \def\markdownRendererSuperscriptPrototype#1{\high{#1}}
 \def\markdownRendererSubscriptPrototype#1{\low{#1}}
-\def\markdownRendererDisplayMathPrototype#1{\startformula#1\stopformula}%
+\def\markdownRendererDisplayMathPrototype#1{%
+  \startformula#1\stopformula}%
 %    \end{macrocode}
 % \par
 % \begin{markdown}
@@ -37080,8 +37635,10 @@ end
       \placetable{#1}{\the\markdownConTeXtTable}}%
   \fi
   \begingroup
-  \setupTABLE[r][each][topframe=off, bottomframe=off, leftframe=off, rightframe=off]
-  \setupTABLE[c][each][topframe=off, bottomframe=off, leftframe=off, rightframe=off]
+  \setupTABLE[r][each][topframe=off, bottomframe=off,
+                       leftframe=off, rightframe=off]
+  \setupTABLE[c][each][topframe=off, bottomframe=off,
+                       leftframe=off, rightframe=off]
   \setupTABLE[r][1][topframe=on, bottomframe=on]
   \setupTABLE[r][#1][bottomframe=on]
   \markdownConTeXtRowCounter=0%
@@ -37119,14 +37676,16 @@ end
   \fi\if#1r%
     \setupTABLE[c][\the\markdownConTeXtColumnCounter][align=left]
   \fi
-  \ifnum\markdownConTeXtColumnCounter<\markdownConTeXtColumnTotal\relax\else
+  \ifnum\markdownConTeXtColumnCounter<\markdownConTeXtColumnTotal\relax
+  \else
     \expandafter\gobbleoneargument
   \fi\markdownConTeXtReadAlignments}
 \def\markdownConTeXtRenderTableCell#1{%
   \advance\markdownConTeXtColumnCounter by 1\relax
   \markdownConTeXtTable=\expandafter{%
     \the\markdownConTeXtTable\bTD#1\eTD}%
-  \ifnum\markdownConTeXtColumnCounter<\markdownConTeXtColumnTotal\relax\else
+  \ifnum\markdownConTeXtColumnCounter<\markdownConTeXtColumnTotal\relax
+  \else
     \expandafter\gobbleoneargument
   \fi\markdownConTeXtRenderTableCell}
 %    \end{macrocode}
@@ -37149,13 +37708,13 @@ end
       {
         { latex }
           {
-            \@@_plain_tex_default_input_raw_inline_renderer_prototype:nn
+            \@@_plain_tex_default_input_raw_inline:nn
               { #1 }
               { context }
           }
       }
       {
-        \@@_plain_tex_default_input_raw_inline_renderer_prototype:nn
+        \@@_plain_tex_default_input_raw_inline:nn
           { #1 }
           { #2 }
       }
@@ -37168,13 +37727,13 @@ end
       {
         { context }
           {
-            \@@_plain_tex_default_input_raw_block_renderer_prototype:nn
+            \@@_plain_tex_default_input_raw_block:nn
               { #1 }
               { tex }
           }
       }
       {
-        \@@_plain_tex_default_input_raw_block_renderer_prototype:nn
+        \@@_plain_tex_default_input_raw_block:nn
           { #1 }
           { #2 }
       }
@@ -37188,7 +37747,7 @@ end
 \protect
 %    \end{macrocode}
 % \iffalse
-%</themes-witiko-markdown-defaults-context>
+%</themes-witiko-markdown-defaults-ctx>
 %<*context>
 % \fi
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35358,7 +35358,7 @@ end
       |fi
       |markdownInfo{Including markdown document number
         "|the|markdownOptionFrozenCacheCounter" from frozen cache}%
-      |csname markdownFrozenCache^^J
+      |csname markdownFrozenCache%
         |the|markdownOptionFrozenCacheCounter|endcsname
       |global|advance|markdownOptionFrozenCacheCounter by 1|relax
     }{%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11503,7 +11503,7 @@ for i = 1, #arg do
             warn('Option "' .. key .. '" not recognized.')
           else
             warn('Option "' .. key .. '" type not recognized, ' ..
-                 'file a report to the package maintainer.')
+                 'please file a report to the package maintainer.')
           end
           warn('Parsing the ' .. 'value "' .. value ..'" of option "' ..
                key .. '" as a string.')
@@ -25523,8 +25523,8 @@ function M.writer.new(options)
     ["☒"] = "\\markdownRendererTickedBox{}",
     ["⌛"] = "\\markdownRendererHalfTickedBox{}",
     ["☐"] = "\\markdownRendererUntickedBox{}",
-    [entities.hex_entity('FFFD')] =
-      "\\markdownRendererReplacementCharacter{}",
+    [entities.hex_entity('FFFD')]
+      = "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
 % \par
@@ -25559,8 +25559,8 @@ function M.writer.new(options)
     ["^"] = "\\markdownRendererCircumflex{}",
     ["~"] = "\\markdownRendererTilde{}",
     ["|"] = "\\markdownRendererPipe{}",
-    [entities.hex_entity('0000')] =
-      "\\markdownRendererReplacementCharacter{}",
+    [entities.hex_entity('0000')]
+      = "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
 % \par
@@ -26137,10 +26137,10 @@ function M.writer.new(options)
 %  \begin{macrocode}
   function self.push_attributes(attribute_type, attributes,
                                 start_output, end_output)
-    local attribute_type_level =
-      self.attribute_type_levels[attribute_type]
-    self.attribute_type_levels[attribute_type] =
-      attribute_type_level + 1
+    local attribute_type_level
+      = self.attribute_type_levels[attribute_type]
+    self.attribute_type_levels[attribute_type]
+      = attribute_type_level + 1
 
     -- index attributes in a hash table for easy lookup
     attributes = attributes or {}
@@ -26195,10 +26195,10 @@ function M.writer.new(options)
       local attributes, _, end_output
       current_attribute_type, attributes, _, end_output = table.unpack(
         self.active_attributes[#self.active_attributes])
-      local attribute_type_level =
-        self.attribute_type_levels[current_attribute_type]
-      self.attribute_type_levels[current_attribute_type] =
-        attribute_type_level - 1
+      local attribute_type_level
+        = self.attribute_type_levels[current_attribute_type]
+      self.attribute_type_levels[current_attribute_type]
+        = attribute_type_level - 1
       if self.is_writing and end_output ~= nil then
         table.insert(buf, end_output)
       end
@@ -26233,7 +26233,7 @@ function M.writer.new(options)
     local letter_found = false
     local normalized_s = s
     if not options.unicodeNormalization
-        or options.unicodeNormalizationForm ~= "nfc" then
+       or options.unicodeNormalizationForm ~= "nfc" then
       normalized_s = uni_algos.normalize.NFC(normalized_s)
     end
 
@@ -26296,7 +26296,7 @@ function M.writer.new(options)
     local letter_found = false
     local normalized_s = s
     if not options.unicodeNormalization
-        or options.unicodeNormalizationForm ~= "nfc" then
+       or options.unicodeNormalizationForm ~= "nfc" then
       normalized_s = uni_algos.normalize.NFC(normalized_s)
     end
 
@@ -26720,7 +26720,7 @@ local function update_indent_table(indent_table, new_indent, add)
     indent_table.indents[#indent_table.indents + 1] = new_indent
   else
     if indent_table.indents[#indent_table.indents].name
-        == new_indent.name then
+       == new_indent.name then
       indent_table.indents[#indent_table.indents] = nil
     end
   end
@@ -27009,7 +27009,7 @@ local function traverse_indent(s, i, indent_table, is_optional,
       local blankline_end = lpeg.match(
         Ct(parsers.blankline * Cg(Cp(), "pos")), s, new_index)
       if is_optional or not indent_table.ignore_blockquote_blank
-          or not blankline_end then
+         or not blankline_end then
         return is_optional, new_index, current_trail,
                current_line_indents
       end
@@ -27366,8 +27366,8 @@ parsers.check_code_trail  = Cmt( Cb("indent_info")
                                * Cc(true), check_trail_joined)
 
 parsers.check_trail_length_range  = function(min, max)
-  return Cmt(Cb("indent_info") * C(parsers.spacechar^0) * Cc(min)
-       * Cc(max), check_trail_length)
+  return Cmt( Cb("indent_info") * C(parsers.spacechar^0) * Cc(min)
+            * Cc(max), check_trail_length)
 end
 
 parsers.check_trail_length = function(n)
@@ -27402,8 +27402,8 @@ parsers.check_optional_indent = Cmt(Cb("indent_info") * Cc(true),
                                     check_continuation_indentation)
 
 parsers.check_minimal_blank_indent = Cmt( Cb("indent_info") * Cc(false)
-                                        * Cc(true),
-                                         check_continuation_indentation)
+                                        * Cc(true)
+                                        , check_continuation_indentation)
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27416,43 +27416,43 @@ parsers.check_minimal_blank_indent = Cmt( Cb("indent_info") * Cc(false)
 
 parsers.check_minimal_indent_and_trail =
   Cmt( Cb("indent_info")
-     * Cc(false) * Cc(false) * Cc("non-code") * Cc(true),
-      check_continuation_indentation_and_trail)
+     * Cc(false) * Cc(false) * Cc("non-code") * Cc(true)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_minimal_indent_and_code_trail =
   Cmt( Cb("indent_info")
-     * Cc(false) * Cc(false) * Cc("code") * Cc(false),
-      check_continuation_indentation_and_trail)
+     * Cc(false) * Cc(false) * Cc("code") * Cc(false)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_minimal_blank_indent_and_full_code_trail =
   Cmt( Cb("indent_info")
-     * Cc(false) * Cc(true) * Cc("full-code") * Cc(true),
-      check_continuation_indentation_and_trail)
+     * Cc(false) * Cc(true) * Cc("full-code") * Cc(true)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_minimal_indent_and_any_trail =
   Cmt( Cb("indent_info")
-     * Cc(false) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false),
-      check_continuation_indentation_and_trail)
+     * Cc(false) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_minimal_blank_indent_and_any_trail =
   Cmt( Cb("indent_info")
-     * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false),
-      check_continuation_indentation_and_trail)
+     * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_minimal_blank_indent_and_any_trail_no_rem =
   Cmt( Cb("indent_info")
-     * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(true),
-      check_continuation_indentation_and_trail)
+     * Cc(false) * Cc(true) * Cc("full-any") * Cc(true) * Cc(true)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_optional_indent_and_any_trail =
   Cmt( Cb("indent_info")
-     * Cc(true) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false),
-      check_continuation_indentation_and_trail)
+     * Cc(true) * Cc(false) * Cc("full-any") * Cc(true) * Cc(false)
+     , check_continuation_indentation_and_trail)
 
 parsers.check_optional_blank_indent_and_any_trail =
   Cmt( Cb("indent_info")
-     * Cc(true) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false),
-      check_continuation_indentation_and_trail)
+     * Cc(true) * Cc(true) * Cc("full-any") * Cc(true) * Cc(false)
+     , check_continuation_indentation_and_trail)
 
 %    \end{macrocode}
 % \begin{markdown}
@@ -27924,7 +27924,7 @@ parsers.html_cdatasection_end = P("]]>")
 
 parsers.html_cdatasection
   = Cs( parsers.html_cdatasection_start
-  * parsers.html_until_end(parsers.html_cdatasection_end))
+      * parsers.html_until_end(parsers.html_cdatasection_end))
 
 parsers.html_inline_cdatasection
   = parsers.html_cdatasection_start
@@ -27938,7 +27938,7 @@ parsers.html_declaration_end = P(">")
 
 parsers.html_declaration
   = Cs( parsers.html_declaration_start
-  * parsers.html_until_end(parsers.html_declaration_end))
+      * parsers.html_until_end(parsers.html_declaration_end))
 
 parsers.html_inline_declaration
   = parsers.html_declaration_start
@@ -29030,7 +29030,7 @@ function M.reader.new(writer, options)
       local current_closing_count = t[current_position].current_count
 
       if (current_opening_count >= 2)
-          and (current_closing_count >= 2) then
+        and (current_closing_count >= 2) then
         opening_delimiter.current_count = current_opening_count - 2
         t[current_position].current_count = current_closing_count - 2
         fill_strong(t, opener_position, current_position)
@@ -35347,7 +35347,7 @@ end
       |fi
       |markdownInfo{Including markdown document number
         "|the|markdownOptionFrozenCacheCounter" from frozen cache}%
-      |csname markdownFrozenCache
+      |csname markdownFrozenCache^^J
         |the|markdownOptionFrozenCacheCounter|endcsname
       |global|advance|markdownOptionFrozenCacheCounter by 1|relax
     }{%

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35272,6 +35272,13 @@ end
   \markdownInput
   #1
   {
+    \@@_if_option:nTF
+      { frozenCache }
+      {
+        \markdownInputRaw
+          { #1 }
+      }
+      {
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35281,19 +35288,23 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \file_get_full_name:nNTF
-      { #1 }
-      \l_tmpa_tl
-      {
-        \exp_args:NV
-          \markdownInputRaw
+        \tl_set:Nx
           \l_tmpa_tl
-      }
-      {
-        \msg_error:nnnV
-          { markdown }
-          { markdown-file-does-not-exist }
           { #1 }
+        \file_get_full_name:VNTF
+          \l_tmpa_tl
+          \l_tmpb_tl
+          {
+            \exp_args:NV
+              \markdownInputRaw
+              \l_tmpb_tl
+          }
+          {
+            \msg_error:nnV
+              { markdown }
+              { markdown-file-does-not-exist }
+              \l_tmpa_tl
+          }
       }
   }
 \msg_new:nnn

--- a/markdown.ins
+++ b/markdown.ins
@@ -14,7 +14,7 @@
     \file{markdownthemewitiko_tilde.tex}{\from{markdown.dtx}{themes-witiko-tilde}}
     \file{markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-tex}}
     \file{markdownthemewitiko_markdown_defaults.sty}{\from{markdown.dtx}{themes-witiko-markdown-defaults-latex}}
-    \file{t-markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-context}}
+    \file{t-markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-ctx}}
     \file{markdownthemewitiko_markdown_techdoc.sty}{\from{markdown.dtx}{themes-witiko-markdown-techdoc}}
   \usepreamble\empty
   \usepostamble\empty


### PR DESCRIPTION
This PR makes the following changes:

- Ensure that all code lines are shorter than 72 characters.
  This prevents overflows of the typeset code in the technical documentation.
- Add pseudo-target `check-line-length` to `Makefile`.
- Add checking of line length to continuous integration.
- Update `CHANGES.md`.

This PR also makes the following changes:

- Add pseudo-target `check-tabs-and-spaces` to `Makefile`.
- Fix the definition of `\markdownInput` with `frozenCache` enabled.