### PR TITLE
Properly load LaTeX themes when `theme` or `import` is used in `\usepackage[...]{markdown}`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 3.7.1
 
+Fixes:
+
+- Properly load LaTeX themes when `theme` or `import` is used in
+  `\usepackage[...]{markdown}`. (#471, #498)
+
 ## 3.7.0 (2024-08-30)
 
 Development:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35880,17 +35880,6 @@ end
 % \par
 % \begin{markdown}
 %
-%### Options
-% The supplied package options are processed using the \mref{markdownSetup} macro.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\DeclareOption*{%
-  \expandafter\markdownSetup\expandafter{\CurrentOption}}%
-\ProcessOptions\relax
-%    \end{macrocode}
-% \begin{markdown}
-%
 %### Themes {#latex-themes-implementation}
 %
 % This section overrides the plain \TeX{} implementation of the theme-loading
@@ -36253,6 +36242,25 @@ end
 % Next, the \LaTeX{} theme overrides some of the plain \TeX{} definitions.
 % See Section <#sec:latex-token-renderer-prototypes> for the actual
 % definitions.
+%
+%### Options
+% The supplied package options are processed using the \mref{markdownSetup} macro.
+%
+% \end{markdown}
+% \iffalse
+%</themes-witiko-markdown-defaults-latex>
+%<*latex>
+% \fi
+%  \begin{macrocode}
+\DeclareOption*{%
+  \expandafter\markdownSetup\expandafter{\CurrentOption}}%
+\ProcessOptions\relax
+%    \end{macrocode}
+% \iffalse
+%</latex>
+%<*themes-witiko-markdown-defaults-latex>
+% \fi
+% \begin{markdown}
 %
 %### Token Renderer Prototypes {#latex-token-renderer-prototypes}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35967,9 +35967,8 @@ end
         { #1 }
       \AtEndOfPackage
         {
-          \@@_load_theme:nn
+          \@@_set_theme:n
             { #1 }
-            { #2 }
         }
     \fi
   }

--- a/tests/support/markdownthemewitiko_markdown_test_latex.sty
+++ b/tests/support/markdownthemewitiko_markdown_test_latex.sty
@@ -1,5 +1,9 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage
-  {markdownthemewitiko_markdown_test}%
+  {markdownthemewitiko_markdown_test_latex}%
   [2024/09/09 A LaTeX theme for the Markdown package that writes used renderers to the log for testing]
-\markdownLoadPlainTeXTheme
+\markdownSetup {
+  import = {
+    witiko/markdown/text = snippet
+  }
+}

--- a/tests/support/markdownthemewitiko_markdown_test_latex.sty
+++ b/tests/support/markdownthemewitiko_markdown_test_latex.sty
@@ -4,6 +4,6 @@
   [2024/09/09 A LaTeX theme for the Markdown package that writes used renderers to the log for testing]
 \markdownSetup {
   import = {
-    witiko/markdown/text = snippet
+    witiko/markdown/test = snippet
   }
 }

--- a/tests/templates/latex/input/head.tex.m4
+++ b/tests/templates/latex/input/head.tex.m4
@@ -2,12 +2,10 @@
 \csname UseRawInputEncoding\endcsname
 
 % Load the package.
-\usepackage[
-  plain,
-  import = {
-    witiko/markdown/test/latex = snippet as testSnippet,
-  },
-]{markdown}
+\usepackage[plain, import=witiko/markdown/test/latex]{markdown}
+\markdownSetupSnippet{testSnippet}{
+  snippet = witiko/markdown/test/latex/snippet,
+}
 
 % Load the support files.
 \markdownSetup {

--- a/tests/templates/latex/input/head.tex.m4
+++ b/tests/templates/latex/input/head.tex.m4
@@ -2,15 +2,17 @@
 \csname UseRawInputEncoding\endcsname
 
 % Load the package.
-\usepackage[plain]{markdown}
+\usepackage[
+  plain,
+  import = {
+    witiko/markdown/test/latex = snippet as testSnippet,
+  },
+]{markdown}
 
 % Load the support files.
 \markdownSetup {
   eagerCache = false,
   outputDir = OUTPUT_DIRECTORY,
-  import = {
-    witiko/markdown/test = snippet as testSnippet,
-  }
 }
 
 \begin{document}

--- a/tests/templates/latex/verbatim/head.tex.m4
+++ b/tests/templates/latex/verbatim/head.tex.m4
@@ -2,15 +2,15 @@
 \csname UseRawInputEncoding\endcsname
 
 % Load the package.
-\usepackage[plain]{markdown}
+\usepackage[plain, theme=witiko/markdown/test/latex]{markdown}
+\markdownSetupSnippet{testSnippet}{
+  snippet = witiko/markdown/test/latex/snippet,
+}
 
 % Load the support files.
 \markdownSetup {
   eagerCache = false,
   outputDir = OUTPUT_DIRECTORY,
-  import = {
-    witiko/markdown/test = snippet as testSnippet,
-  }
 }
 
 \begin{document}


### PR DESCRIPTION
Closes #471.