### PR TITLE
Prevent endless loop when setting deprecated `jekyllDataString` (renderer) prototype

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Fixes:
 
 - Properly load LaTeX themes when `theme` or `import` is used in
   `\usepackage[...]{markdown}`. (#471, #498)
+- Prevent endless loop when setting deprecated `jekyllDataString` (renderer)
+  prototype. (#500)
 
 ## 3.7.0 (2024-08-30)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20658,22 +20658,8 @@ following text:
     \seq_map_inline:Nn
       \g_@@_renderers_seq
       {
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% The \mref{markdownRendererJekyllDataString} has been deprecated and will be
-% removed in Markdown 4.0.0.
-%
-% \end{markdown}
-%  \begin{macrocode}
-        \str_if_eq:nnF
+        \@@_define_renderer:n
           { ##1 }
-          { jekyllDataString }
-          {
-            \@@_define_renderer:n
-              { ##1 }
-          }
       }
   }
 \cs_new:Nn \@@_define_renderer:n
@@ -21393,22 +21379,8 @@ following text:
     \seq_map_inline:Nn
       \g_@@_renderers_seq
       {
-%    \end{macrocode}
-% \par
-% \begin{markdown}
-%
-% The \mref{markdownRendererJekyllDataString} has been deprecated and will be
-% removed in Markdown 4.0.0.
-%
-% \end{markdown}
-%  \begin{macrocode}
-        \str_if_eq:nnF
+        \@@_define_renderer_prototype:n
           { ##1 }
-          { jekyllDataString }
-          {
-            \@@_define_renderer_prototype:n
-              { ##1 }
-          }
       }
   }
 \cs_new:Nn \@@_define_renderer_prototype:n

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -20724,6 +20724,24 @@ following text:
             \l_@@_renderer_definition_tl
         },
       }
+%    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% If the token renderer macro has been deprecated, we undefine it.
+%
+% The \mref{markdownRendererJekyllDataString} macro has been deprecated and
+% will be removed in Markdown 4.0.0.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \str_if_eq:nnT
+      { #1 }
+      { jekyllDataString }
+      {
+        \cs_undefine:N
+          #2
+      }
   }
 %    \end{macrocode}
 % \par
@@ -21447,21 +21465,30 @@ following text:
         },
       }
 %    \end{macrocode}
+% \par
 % \begin{markdown}
 %
-% Unless the token renderer prototype macro has already been defined,
-% we provide an empty definition.
+% Unless the token renderer prototype macro has already been defined or unless,
+% it has been deprecated, we provide an empty definition.
+%
+% The \mref{markdownRendererJekyllDataStringPrototype} macro has been
+% deprecated and will be removed in Markdown 4.0.0.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \cs_if_free:NT
-      #2
+    \str_if_eq:nnF
+      { #1 }
+      { jekyllDataString }
       {
-        \cs_generate_from_arg_count:NNnn
+        \cs_if_free:NT
           #2
-          \cs_set:Npn
-          { #3 }
-          { }
+          {
+            \cs_generate_from_arg_count:NNnn
+              #2
+              \cs_set:Npn
+              { #3 }
+              { }
+          }
       }
   }
 \cs_generate_variant:Nn

--- a/tests/support/keyval-setup.tex
+++ b/tests/support/keyval-setup.tex
@@ -147,11 +147,16 @@ renderers = {%
     \TYPE{#0: \NORMALIZEPATH{#1}}},
   (ticked|halfTicked|unticked)Box = {%
     \TYPE{#0}},
-  jekyllData(Boolean|Number|(Programmatic|Typographic)String) = {%
+  jekyllData(Boolean|Number|ProgrammaticString) = {%
     \TYPE{BEGIN #0}%
     \TYPE{- key:   #1}%
     \TYPE{- value: #2}%
     \TYPE{END #0}},
+  jekyllDataString = {%
+    \TYPE{BEGIN jekyllDataTypographicString}%
+    \TYPE{- key:   #1}%
+    \TYPE{- value: #2}%
+    \TYPE{END jekyllDataTypographicString}},
   jekyllDataEmpty = {%
     \TYPE{#0: #1}},%
   jekyllData(Begin|End) = {%


### PR DESCRIPTION
Since #451 from Markdown 3.7.0, the `jekyllDataString` (renderer) prototype has been deprecated in favor of the `jekyllDataTypographicString` alias. While the `jekyllDataString` (renderer) prototype is still produced by globbing, we no longer allow users to set it directly by an error in #451. Therefore, setting `jekyllDataString` (renderer) prototype or any glob that includes `jekyllDataString` will produce an endless loop, since any (renderer) prototype that cannot be set is considered a glob and will be expanded ad infinitum.

### Tasks

- [x] Allow renderer (prototype) `jekyllDataString` to be set.
- [x] Do not provide default `jekyllDataString` renderer (prototype).
- [x] Test that `jekyllDataString` renderer (prototype) can be set.
- [x] Update `CHANGES.md`