### PR TITLE
Fix backslashes at the ends of hybrid documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # Changes
 
-## 3.9.0
+## 3.8.1
+
+Fixes:
+
+- Fix backslashes at the ends of hybrid documents.
+  (#502, #503, contributed by @lostenderman)
 
 ## 3.8.0 (2024-10-31)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27772,9 +27772,11 @@ parsers.commented_line = Cg(Cc(""), "backslashes")
                           * Cs(parsers.commented_line_letter
                             - parsers.newline)^1  -- initial
                           * Cg(Cc(""), "backslashes"))
-                         + #(parsers.backslash * (parsers.backslash + parsers.newline))
+                         + #( parsers.backslash
+                            * (parsers.backslash + parsers.newline))
                          * Cg((parsers.backslash  -- even backslash
-                              * (parsers.backslash + #parsers.newline))^1, "backslashes")
+                              * ( parsers.backslash
+                                + #parsers.newline))^1, "backslashes")
                          + (parsers.backslash
                            * (#parsers.percent
                              * Cb("backslashes")

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27772,9 +27772,9 @@ parsers.commented_line = Cg(Cc(""), "backslashes")
                           * Cs(parsers.commented_line_letter
                             - parsers.newline)^1  -- initial
                           * Cg(Cc(""), "backslashes"))
-                         + #(parsers.backslash * parsers.backslash)
+                         + #(parsers.backslash * (parsers.backslash + parsers.newline))
                          * Cg((parsers.backslash  -- even backslash
-                              * parsers.backslash)^1, "backslashes")
+                              * (parsers.backslash + #parsers.newline))^1, "backslashes")
                          + (parsers.backslash
                            * (#parsers.percent
                              * Cb("backslashes")

--- a/tests/testfiles/regression/github/issue-502-one-paragraph.test
+++ b/tests/testfiles/regression/github/issue-502-one-paragraph.test
@@ -5,6 +5,10 @@
 *bar* \
 >>>
 BEGIN document
+BEGIN warning
+- text: The `hybrid` option has been soft-deprecated.
+- more: Consider using one of the following better options for mixing TeX and markdown: `contentBlocks`, `rawAttribute`, `texComments`, `texMathDollars`, `texMathSingleBackslash`, and `texMathDoubleBackslash`. For more information, see the user manual at <https://witiko.github.io/markdown/>.
+END warning
 emphasis: foo
 hardLineBreak
 emphasis: bar

--- a/tests/testfiles/regression/github/issue-502-one-paragraph.test
+++ b/tests/testfiles/regression/github/issue-502-one-paragraph.test
@@ -1,0 +1,11 @@
+\markdownSetup{hybrid=true}
+\def\\markdownRendererDocumentEnd{\markdownRendererDocumentEnd}
+<<<
+*foo* \
+*bar* \
+>>>
+BEGIN document
+emphasis: foo
+hardLineBreak
+emphasis: bar
+END document

--- a/tests/testfiles/regression/github/issue-502-two-paragraphs.test
+++ b/tests/testfiles/regression/github/issue-502-two-paragraphs.test
@@ -6,6 +6,10 @@
 *bar* \
 >>>
 BEGIN document
+BEGIN warning
+- text: The `hybrid` option has been soft-deprecated.
+- more: Consider using one of the following better options for mixing TeX and markdown: `contentBlocks`, `rawAttribute`, `texComments`, `texMathDollars`, `texMathSingleBackslash`, and `texMathDoubleBackslash`. For more information, see the user manual at <https://witiko.github.io/markdown/>.
+END warning
 emphasis: foo
 paragraphSeparator
 emphasis: bar

--- a/tests/testfiles/regression/github/issue-502-two-paragraphs.test
+++ b/tests/testfiles/regression/github/issue-502-two-paragraphs.test
@@ -1,0 +1,12 @@
+\markdownSetup{hybrid=true}
+\def\\markdownRendererDocumentEnd{\markdownRendererDocumentEnd}
+<<<
+*foo*
+
+*bar* \
+>>>
+BEGIN document
+emphasis: foo
+paragraphSeparator
+emphasis: bar
+END document


### PR DESCRIPTION
This PR makes the following changes:

- [x] Add regression tests for [\#502](https://github.com/Witiko/markdown/issues/502).
- [x] Fix the regression tests.
- [x] Update `CHANGES.md`.

Closes #502.