### PR TITLE
Soft-deprecate the `hybrid` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,12 +20,37 @@ Fixes:
 
 - Properly load LaTeX themes when `theme` or `import` is used in
   `\usepackage[...]{markdown}`. (#471, #498)
+
 - Prevent endless loop when setting deprecated `jekyllDataString` (renderer)
   prototype. (#500)
+
 - Correctly handle backslashes in `\markdownOptionOutputDir` on Windows.
   (#492, #500, reported by @l0th3r)
+
 - Fix hard line breaks in blockquotes.
   (#494, #495, reported by @l0th3r, #496, contributed by @lostenderman)
+
+Deprecation:
+
+- Soft-deprecate the `hybrid` option. (#470, #504)
+
+  Soft-deprecated features will never be removed but using them prints a
+  warning and is discouraged. Instead of the `hybrid` option, consider one of
+  the following better alternatives for mixing TeX and markdown:
+
+  - With the `contentBlocks` option, authors can move large blocks of TeX
+    code to separate files and include them in their markdown documents as
+    external resources.
+
+  - With the `rawAttribute` option, authors can denote raw text spans and
+    code blocks that will be interpreted as TeX code.
+
+  - With options `texMathDollars`, `texMathSingleBackslash`, and
+    `texMathDoubleBackslash`, authors can freely type TeX commands between
+    dollar signs or backslash-escaped brackets.
+
+  For more information, see the user manual at
+  <https://witiko.github.io/markdown/>.
 
 ## 3.7.0 (2024-08-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ Fixes:
 
 Deprecation:
 
-- Soft-deprecate the `hybrid` option. (#470, #504)
+- Soft-deprecate the `hybrid` option. (#470, #504, 546faa87)
 
   Soft-deprecated features will never be removed but using them prints a
   warning and is discouraged. Instead of the `hybrid` option, consider one of

--- a/README.md
+++ b/README.md
@@ -115,52 +115,6 @@ In fact, this is how we automatically produce
 
  [github-actions]: https://docs.github.com/actions "GitHub Actions Documentation"
 
-Peek under the hood
--------------------
-
-Remember how we said that the Markdown package converts markdown markup to
-TeX commands? Let's see what that means and what we can do with this knowledge.
-
-Using a text editor, create an empty text document named `document.md` with
-the following markdown content:
-
-``` markdown
-Hello *Markdown*! $a_x + b_x = c_x$
-```
-
-Next, run [the Lua command-line interface (CLI)][lua-cli] from
-[our official Docker image][docker-witiko/markdown] on `document.md`:
-
-    docker run --rm -i witiko/markdown markdown-cli hybrid=true < document.md
-
-We will receive the following output, where the markdown markup has been
-replaced by TeX commands:
-
-``` tex
-\markdownDocumentBegin
-Hello \markdownRendererEmphasis{Markdown}!
-$a\markdownRendererEmphasis{x + b}x = c_x$
-\markdownDocumentEnd
-```
-
-We can see right away that the Markdown package has incorrectly interpreted
-`_x + b_` as an emphasized text. We can fix this by passing in the
-`underscores=false` option:
-
-    docker run --rm -i witiko/markdown markdown-cli hybrid=true underscores=false < document.md
-
-``` tex
-\markdownDocumentBegin
-Hello \markdownRendererEmphasis{Markdown}!
-$a_x + b_x = c_x$
-\markdownDocumentEnd
-```
-
-Much better! If the Markdown package ever surprises you, use the Lua CLI to
-peek under the hood and inspect the results of the conversion.
-
- [lua-cli]: https://mirrors.ctan.org/macros/generic/markdown/markdown.html#lua-command-line-interface "Markdown Package User Manual"
-
 Further information
 -------------------
 

--- a/examples/optex.tex
+++ b/examples/optex.tex
@@ -230,6 +230,10 @@
 \_def  \markdownRendererJekyllDataTypographicString #1#2{}
 \_def  \markdownRendererJekyllDataEmpty #1{}
 
+%% Warning and Error Renderers
+\_def  \markdownRendererWarning #1#2#3#4{}
+\_def  \markdownRendererError #1#2#3#4{}
+
 % Load the Markdown module and set TeX macros for the Markdown module
 \_directlua{
   kpse = require("kpse")

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26938,7 +26938,8 @@ local unicode_data = require("markdown-unicode-data")
 if metadata.version ~= unicode_data.metadata.version then
   util.warning(
     "markdown.lua " .. metadata.version .. " used with " ..
-    "markdown-unicode-data.lua " .. unicode_data.metadata.version .. ".")
+    "markdown-unicode-data.lua " .. unicode_data.metadata.version .. "."
+  )
 end
 parsers.punctuation = unicode_data.punctuation
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26146,7 +26146,23 @@ function M.writer.new(options)
 % \end{markdown}
 %  \begin{macrocode}
   function self.document(d)
-    local buf = {"\\markdownRendererDocumentBegin\n", d}
+    local buf = {"\\markdownRendererDocumentBegin\n"}
+
+    -- warn against the `hybrid` option
+    if options.hybrid then
+      local text = "The `hybrid` option has been soft-deprecated."
+      local more = "Consider using one of the following better options "
+                .. "for mixing TeX and markdown: `contentBlocks`, "
+                .. "`rawAttribute`, `texComments`, `texMathDollars`, "
+                .. "`texMathSingleBackslash`, and "
+                .. "`texMathDoubleBackslash`. "
+                .. "For more information, see the user manual at "
+                .. "<https://witiko.github.io/markdown/>."
+      table.insert(buf, self.warning(text, more))
+    end
+
+    -- insert the text of the document
+    table.insert(buf, d)
 
     -- pop all attributes
     table.insert(buf, self.pop_attributes())

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23240,6 +23240,19 @@ function util.salt(options)
   return salt
 end
 %    \end{macrocode}
+% \par
+% \begin{markdown}
+%
+% The \luamdef{util.warning} method produces a warning `s` that is unrelated to
+% any specific markdown text being processed. For warnings that are specific to
+% a markdown text, use \luamref{writer->warning} function.
+%
+% \end{markdown}
+%  \begin{macrocode}
+function util.warning(s)
+  io.stderr:write("Warning: " .. s .. "\n")
+end
+%    \end{macrocode}
 % \iffalse
 %</lua,lua-loader>
 %<*lua>
@@ -26923,9 +26936,9 @@ print("return M")
 %  \begin{macrocode}
 local unicode_data = require("markdown-unicode-data")
 if metadata.version ~= unicode_data.metadata.version then
-  warn("markdown.lua " .. metadata.version .. " used with " ..
-       "markdown-unicode-data.lua " .. unicode_data.metadata.version ..
-       ".")
+  util.warning(
+    "markdown.lua " .. metadata.version .. " used with " ..
+    "markdown-unicode-data.lua " .. unicode_data.metadata.version .. ".")
 end
 parsers.punctuation = unicode_data.punctuation
 
@@ -33938,10 +33951,6 @@ end
 %<*lua-loader>
 % \fi
 %  \begin{macrocode}
-local function warn(s)
-  io.stderr:write("Warning: " .. s .. "\n")
-end
-
 function M.new(options)
 %    \end{macrocode}
 % \par

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -7484,6 +7484,58 @@ defaultOptions.html = true
         encouraged when typesetting automatically generated content or
         markdown documents that were not prepared with this package in mind.
 
+The \Opt{hybrid} option makes it difficult to untangle \TeX{} input from
+markdown text, which makes documents written with the \Opt{hybrid} option
+less interoperable and more difficult to read for authors. Therefore, the
+option has been soft-deprecated in version 3.7.1 of the Markdown package:
+It will never be removed but using it prints a warning and is discouraged.
+
+Consider one of the following better alternatives for mixing \TeX{} and
+markdown:
+
+- With the \Opt{contentBlocks} option, authors can move large blocks of TeX
+  code to separate files and include them in their markdown documents as
+  external resources:
+
+  ``` md
+  Here is a mathematical formula:
+
+   /math-formula.tex
+  ```
+
+- With the \Opt{rawAttribute} option, authors can denote raw text spans and
+  code blocks that will be interpreted as \TeX{} code:
+
+  `````` md
+  `$H_2 O$`{=tex} is a liquid.
+
+  Here is a mathematical formula:
+  ``` {=tex}
+  \[distance[i] =
+      \begin{dcases}
+          a & b \\
+          c & d
+      \end{dcases}
+  \]
+  ```
+  ``````
+
+- With options \Opt{texMathDollars}, \Opt{texMathSingleBackslash}, and
+  \Opt{texMathDoubleBackslash}, authors can freely type \TeX{} commands between
+  dollar signs or backslash-escaped brackets:
+
+  ``` md
+  $H_2 O$ is a liquid.
+
+  Here is a mathematical formula:
+  \[distance[i] =
+      \begin{dcases}
+          a & b \\
+          c & d
+      \end{dcases}
+  \]
+  ```
+
 % \end{markdown}
 % \iffalse
 

--- a/tests/testfiles/unit/lunamark-markdown/autolinks-hybrid.test
+++ b/tests/testfiles/unit/lunamark-markdown/autolinks-hybrid.test
@@ -10,6 +10,10 @@ commands, where both the labels and the URLs are escaped even though the
 <Value_of_life@Valueoflife.com>
 >>>
 BEGIN document
+BEGIN warning
+- text: The `hybrid` option has been soft-deprecated.
+- more: Consider using one of the following better options for mixing TeX and markdown: `contentBlocks`, `rawAttribute`, `texComments`, `texMathDollars`, `texMathSingleBackslash`, and `texMathDoubleBackslash`. For more information, see the user manual at <https://witiko.github.io/markdown/>.
+END warning
 codeSpan: hybrid
 softLineBreak
 softLineBreak

--- a/tests/testfiles/unit/lunamark-markdown/hybrid.test
+++ b/tests/testfiles/unit/lunamark-markdown/hybrid.test
@@ -17,6 +17,10 @@ processed by lunamark in any way.
  * \char`|
 >>>
 BEGIN document
+BEGIN warning
+- text: The `hybrid` option has been soft-deprecated.
+- more: Consider using one of the following better options for mixing TeX and markdown: `contentBlocks`, `rawAttribute`, `texComments`, `texMathDollars`, `texMathSingleBackslash`, and `texMathDoubleBackslash`. For more information, see the user manual at <https://witiko.github.io/markdown/>.
+END warning
 codeSpan: hybrid
 softLineBreak
 softLineBreak


### PR DESCRIPTION
Closes #470.

### Tasks
- [x] Soft-deprecate the `hybrid` option.
    - [x] Produce a warning when the `hybrid` option is used.
    - [x] Remove section "Peek under the hood" from `README.md`.
- [x] Update testfiles.
- [x] Update `CHANGES.md`.