### PR TITLE
Implement versioned themes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ Development:
 - Add support for versioned themes and add new Lua option `experimental`.
   (#466, #512, #514, [matrix.org][matrix-514] reviewed by @TeXhackse, #521)
 
+  The option `experimental` enables experimental features that are planned to
+  be the new default in the next major release of the Markdown package.
+
+  At the moment, this just means that the version `experimental` of the theme
+  `witiko/markdown/defaults` will be loaded and warnings for hard-deprecated
+  features will become errors. However, the effects may extend to other areas
+  in the future as well.
+
  [matrix-514]: https://matrix.to/#/!UeAwznpYwwsinVTetR:matrix.org/$TTc-m7B5NSdsLBNNyIuFWQ-u2nOZ03lJ5js88hnyFiU?via=matrix.org&via=im.f3l.de
 
 Documentation:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,10 @@
 
 Development:
 
-- Add support for versioned themes. (#514, reviewed by @TeXhackse, #521)
-- Add new Lua option `experimental`. (#512, #514, #521)
+- Add support for versioned themes and add new Lua option `experimental`.
+  (#466, #512, #514, [matrix.org][matrix-514] reviewed by @TeXhackse, #521)
+
+ [matrix-514]: https://matrix.to/#/!UeAwznpYwwsinVTetR:matrix.org/$TTc-m7B5NSdsLBNNyIuFWQ-u2nOZ03lJ5js88hnyFiU?via=matrix.org&via=im.f3l.de
 
 Documentation:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 3.8.0
 
+Development:
+
+- Add support for versioned themes. (#514, reviewed by @TeXhackse, #521)
+- Add new Lua option `experimental`. (#512, #514, #521)
+
 Documentation:
 
 - Document LaTeX hooks. (#464, #507)
@@ -9,7 +14,7 @@ Documentation:
 Defaults:
 
 - Improve the compatibility of the default LaTeX packages with PDF tagging:
-  (#466, #512, reported and consulted by @u-fischer)
+  (#466, #512, #514, #521, reported and consulted by @u-fischer)
 
   - In TeX engines other than LuaTeX, use the package soul instead of the
     package soulutf8 in TeX Live ≥ 2023.
@@ -18,8 +23,14 @@ Defaults:
     prototypes instead of the package soul.
 
   - Use the package enumitem for tight and fancy lists instead of the package
-    paralist. If you wish to keep using the package paralist, load it before
-    the Markdown package to force the old behavior.
+    paralist.
+
+    This is a breaking change that is marked as experimental. To enable it,
+    either use the package option `experimental` or specify any test phase in
+    the document metadata:
+
+    1. `\usepackage[experimental]{markdown}`
+    2. `\DocumentMetadata{testphase=phase-III}`
 
 Continuous Integration:
 

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ EXAMPLES_SOURCES=examples/context-mkiv.tex \
   examples/optex.tex
 EXAMPLES=examples/context-mkiv.pdf \
   examples/latex-pdftex.pdf examples/latex-xetex.pdf examples/latex-luatex.pdf \
-  examples/latex-tex4ht.html examples/latex-tex4ht.css \
   examples/optex.pdf
+# examples/latex-tex4ht.html examples/latex-tex4ht.css
 TESTS=tests/test.sh tests/test.py tests/requirements.txt tests/support/*.tex \
   tests/templates/*/*/head.tex.m4 tests/templates/*/*/body.tex.m4 \
   tests/templates/*/*/foot.tex.m4 tests/templates/*/COMMANDS.m4 tests/testfiles/*/*/*.test

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -30,8 +30,8 @@ LUACLI_OPTIONS=\
 OUTPUT=\
   context-mkiv.pdf \
   latex-pdftex.pdf latex-xetex.pdf latex-luatex.pdf \
-  latex-tex4ht.html latex-tex4ht.css \
   optex.pdf
+# latex-tex4ht.html latex-tex4ht.css
 
 # This is the default pseudo-target.
 all: $(OUTPUT)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -803,8 +803,13 @@ abbr {
   titleaddon = {Markdown Enhancement Proposal},
   date       = {2024-10-13},
   urldate    = {2024-10-21},
-  url        = {https://github.com/Witiko/markdown/discussions/514},
-}
+  url        = {https://github.com/Witiko/markdown/discussions/514}}
+@book{latex24,
+  author     = {Frank Mittelbach and Ulrike Fischer and {\LaTeX{} Project}},
+  title      = {The \texttt{documentmetadata-support} code},
+  date       = {2024-06-01},
+  url        = {https://mirrors.ctan.org/macros/latex/required/latex-lab/documentmetadata-support-code.pdf},
+  urldate    = {2024-10-21}}
 %</techdoc-bibliography>
 %<@@=markdown>
 %<*themes-witiko-markdown-techdoc>
@@ -1375,14 +1380,21 @@ soft graphics
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{enumitem}
+% \pkg{enumitem} and \pkg{paralist}
 %
-%:    A package that provides macros for the default renderer prototypes for
+%:    Packages that provide macros for the default renderer prototypes for
 %     tight and fancy lists.
+%
+%     The package \pkg{paralist} will be used unless the option
+%     \Opt{experimental} has been enabled, in which case, the package
+%     \pkg{enumitem} will be used. Furthermore, enabling any test phase
+%     [@latex24] will also cause \pkg{enumitem} to be used. In a future
+%     major version, \pkg{enumitem} will replace \pkg{paralist} altogether.
 %
 % \end{markdown}
 %  \begin{macrocode}
 soft enumitem
+soft paralist
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -12079,7 +12091,7 @@ you would include the following code in your plain \TeX{} document:
 %  \begin{macrocode}
 \prg_new_conditional:Nnn
   \@@_if_option:n
-  { TF, T, F }
+  { p, TF, T, F }
   {
     \@@_get_option_type:nN
       { #1 }
@@ -36853,18 +36865,65 @@ end
 %
 %#### Lists
 %
-% If either the \Opt{tightLists} or the \Opt{fancyLists} Lua option is enabled,
-% the current document class is not \pkg{beamer} and the package \pkg{paralist}
-% is not loaded, load the \pkg{enumitem} package.
+% If either the \Opt{tightLists} or the \Opt{fancyLists} Lua option is enabled
+% and the current document class is not \pkg{beamer}, use a package that
+% provides support for tight and fancy lists.
+%
+% If either the package \pkg{paralist} or the package \pkg{enumitem} have already
+% been loaded, use them. Otherwise, if the option \Opt{experimental} or any test
+% phase has been enabled, use the package \pkg{enumitem}. Otherwise, use the
+% package \pkg{paralist}.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\@ifclassloaded{beamer}{}{%
-  \@ifpackageloaded{paralist}{}{%
-    \markdownIfOption{tightLists}{\RequirePackage{enumitem}}{}%
-    \markdownIfOption{fancyLists}{\RequirePackage{enumitem}}{}%
-  }%
-}
+\ExplSyntaxOn
+\bool_if:nT
+  {
+    \@@_if_option_p:n
+      { tightLists } ||
+    \@@_if_option_p:n
+      { fancyLists }
+  }
+  { \@ifclassloaded { beamer } { } {
+    \@ifpackageloaded { paralist } { } {
+    \@ifpackageloaded { enumitem } { } {
+    \bool_if:nT
+      {
+        \@@_if_option_p:n
+          { experimental } ||
+        \prop_if_exist_p:N
+          \g__pdfmanagement_documentproperties_prop &&
+        (
+          \prop_if_in_p:Nn
+            \g__pdfmanagement_documentproperties_prop
+            { document / testphase / phase-I } ||
+          \prop_if_in_p:Nn
+            \g__pdfmanagement_documentproperties_prop
+            { document / testphase / phase-II } ||
+          \prop_if_in_p:Nn
+            \g__pdfmanagement_documentproperties_prop
+            { document / testphase / phase-III } ||
+          \prop_if_in_p:Nn
+            \g__pdfmanagement_documentproperties_prop
+            { document / testphase / phase-IV } ||
+          \prop_if_in_p:Nn
+            \g__pdfmanagement_documentproperties_prop
+            { document / testphase / phase-V } ||
+          \prop_if_in_p:Nn
+            \g__pdfmanagement_documentproperties_prop
+            { document / testphase / phase-VI }
+        )
+      }
+      {
+        \RequirePackage
+          { enumitem }
+      }
+      {
+        \RequirePackage
+          { paralist }
+      }
+  } } } }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \par
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -2733,7 +2733,8 @@ defaultOptions.eagerCache = true
         next major release of the Markdown package will be enabled.
 
         At the moment, this just means that the version `experimental` of the
-        theme `witiko/markdown/defaults` will be loaded but the effects may
+        theme `witiko/markdown/defaults` will be loaded and warnings for
+        hard-deprecated features will become errors. However, the effects may
         extend to other areas in the future as well.
 
 :    false
@@ -20716,24 +20717,47 @@ removed in Markdown 4.0.0.
     \cs_if_exist:NTF
       \markdownRendererJekyllDataString
       {
-        \markdownWarning
+        \@@_if_option:nTF
+          { experimental }
           {
-            The~jekyllDataString~renderer~has~been~deprecated,~
-            to~be~removed~in~Markdown~4.0.0
+            \markdownError
+              {
+                The~jekyllDataString~renderer~has~been~deprecated,~
+                to~be~removed~in~Markdown~4.0.0
+              }
           }
-        \markdownRendererJekyllDataString
+          {
+            \markdownWarning
+              {
+                The~jekyllDataString~renderer~has~been~deprecated,~
+                to~be~removed~in~Markdown~4.0.0
+              }
+            \markdownRendererJekyllDataString
+          }
       }
       {
         \cs_if_exist:NTF
           \markdownRendererJekyllDataStringPrototype
           {
-            \markdownWarning
+            \@@_if_option:nTF
+              { experimental }
               {
-                The~jekyllDataString~renderer~prototype~
-                has~been~deprecated,~
-                to~be~removed~in~Markdown~4.0.0
+                \markdownError
+                  {
+                    The~jekyllDataString~renderer~prototype~
+                    has~been~deprecated,~
+                    to~be~removed~in~Markdown~4.0.0
+                  }
               }
-            \markdownRendererJekyllDataStringPrototype
+              {
+                \markdownWarning
+                  {
+                    The~jekyllDataString~renderer~prototype~
+                    has~been~deprecated,~
+                    to~be~removed~in~Markdown~4.0.0
+                  }
+                \markdownRendererJekyllDataStringPrototype
+              }
           }
           {
             \markdownRendererJekyllDataTypographicStringPrototype
@@ -36426,10 +36450,20 @@ end
   { markdown* }
   [ 1 ]
   {
-    \msg_warning:nnn
-      { markdown }
-      { latex-markdown-star-deprecated }
-      { #1 }
+    \@@_if_option:nTF
+      { experimental }
+      {
+        \msg_error:nnn
+          { markdown }
+          { latex-markdown-star-deprecated }
+          { #1 }
+      }
+      {
+        \msg_warning:nnn
+          { markdown }
+          { latex-markdown-star-deprecated }
+          { #1 }
+      }
     \@@_setup:n
       { #1 }
     \markdownReadAndConvert@

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -78,10 +78,9 @@
 \usepackage[
   citations,
   definitionLists,
-  fencedCode,
+  experimental,
   notes,
   headerAttributes,
-  html,
   hybrid,
   inlineNotes,
   jekyllData,

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22794,7 +22794,7 @@ following image:
 %<*themes-witiko-markdown-defaults-latex>
 % \fi
 %  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_markdown_defaults}[2024/01/03]%
+\ProvidesPackage{markdownthemewitiko_markdown_defaults}[2024/10/22]%
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-markdown-defaults-latex>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34767,6 +34767,7 @@ end
 %  \begin{macrocode}
 \ExplSyntaxOn
 \prop_new:N \g_@@_plain_tex_loaded_themes_linenos_prop
+\prop_new:N \g_@@_plain_tex_loaded_themes_versions_prop
 \cs_new:Nn
   \@@_plain_tex_load_theme:nn
   {
@@ -34775,11 +34776,29 @@ end
       { #1 }
       \l_tmpa_tl
       {
-        \msg_warning:nnnV
-          { markdown }
-          { repeatedly-loaded-plain-tex-theme }
+        \prop_get:NnN
+          \g_@@_plain_tex_loaded_themes_versions_prop
           { #1 }
-          \l_tmpa_tl
+          \l_tmpb_tl
+        \str_if_eq:eVTF
+          { \markdownThemeVersion }
+          \l_tmpb_tl
+          {
+            \msg_warning:nnnV
+              { markdown }
+              { repeatedly-loaded-plain-tex-theme }
+              { #1 }
+              \l_tmpa_tl
+          }
+          {
+            \msg_error:nnneVV
+              { markdown }
+              { different-versions-of-plain-tex-theme }
+              { #1 }
+              { \markdownThemeVersion }
+              \l_tmpb_tl
+              \l_tmpa_tl
+          }
       }
       {
         \msg_info:nnn
@@ -34805,6 +34824,13 @@ end
     Plain~TeX~Markdown~theme~#1~was~previously~
     loaded~on~line~#2,~not~loading~it~again
   }
+\msg_new:nnn
+  { markdown }
+  { different-versions-of-plain-tex-theme }
+  {
+    Tried~to~load~version~#2~of~plain~TeX~Markdown~theme~#1~
+    but~version~#3~has~already~been~loaded~on~line~#4
+  }
 \cs_generate_variant:Nn
   \prop_gput:Nnn
   { Nnx }
@@ -34813,7 +34839,14 @@ end
   \@@_plain_tex_load_theme:nn
 \cs_generate_variant:Nn
   \@@_load_theme:nn
-  { nV }
+  { VV }
+\cs_generate_variant:Nn
+  \msg_error:nnnnnn
+  { nnneVV }
+\prg_generate_conditional_variant:Nnn
+  \str_if_eq:nn
+  { eV }
+  { TF }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -36387,6 +36420,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\prop_new:N \g_@@_latex_loaded_themes_linenos_prop
+\prop_new:N \g_@@_latex_loaded_themes_versions_prop
 \cs_gset:Nn
   \@@_load_theme:nn
   {
@@ -36437,12 +36472,43 @@ end
         \file_if_exist:nTF
           { markdown theme #2.sty }
           {
-            \msg_info:nnn
-              { markdown }
-              { loading-latex-theme }
+            \prop_get:NnNTF
+              \g_@@_latex_loaded_themes_linenos_prop
               { #1 }
-            \RequirePackage
-              { markdown theme #2 }
+              \l_tmpa_tl
+              {
+                \prop_get:NnN
+                  \g_@@_latex_loaded_themes_versions_prop
+                  { #1 }
+                  \l_tmpb_tl
+                \str_if_eq:eVTF
+                  { \markdownThemeVersion }
+                  \l_tmpb_tl
+                  {
+                    \msg_warning:nnnV
+                      { markdown }
+                      { repeatedly-loaded-latex-theme }
+                      { #1 }
+                      \l_tmpa_tl
+                  }
+                  {
+                    \msg_error:nnneVV
+                      { markdown }
+                      { different-versions-of-latex-theme }
+                      { #1 }
+                      { \markdownThemeVersion }
+                      \l_tmpb_tl
+                      \l_tmpa_tl
+                  }
+              }
+              {
+                \msg_info:nnn
+                  { markdown }
+                  { loading-latex-theme }
+                  { #1 }
+                \RequirePackage
+                  { markdown theme #2 }
+              }
           }
           {
             \@@_plain_tex_load_theme:nn
@@ -36481,6 +36547,20 @@ end
   { markdown }
   { loading-latex-theme }
   { Loading~LaTeX~Markdown~theme~#1 }
+\msg_new:nnn
+  { markdown }
+  { repeatedly-loaded-latex-theme }
+  {
+    LaTeX~Markdown~theme~#1~was~previously~
+    loaded~on~line~#2,~not~loading~it~again
+  }
+\msg_new:nnn
+  { markdown }
+  { different-versions-of-latex-theme }
+  {
+    Tried~to~load~version~#2~of~LaTeX~Markdown~theme~#1~
+    but~version~#3~has~already~been~loaded~on~line~#4
+  }
 \cs_generate_variant:Nn
   \msg_new:nnnn
   { nnVV }
@@ -38264,6 +38344,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\prop_new:N \g_@@_context_loaded_themes_linenos_prop
+\prop_new:N \g_@@_context_loaded_themes_versions_prop
 \cs_gset:Nn
   \@@_load_theme:nn
   {
@@ -38280,13 +38362,44 @@ end
     \file_if_exist:nTF
       { t - markdown theme #2.tex }
       {
-        \msg_info:nnn
-          { markdown }
-          { loading-context-theme }
+        \prop_get:NnNTF
+          \g_@@_context_loaded_themes_linenos_prop
           { #1 }
-        \usemodule
-          [ t ]
-          [ markdown theme #2 ]
+          \l_tmpa_tl
+          {
+            \prop_get:NnN
+              \g_@@_context_loaded_themes_versions_prop
+              { #1 }
+              \l_tmpb_tl
+            \str_if_eq:eVTF
+              { \markdownThemeVersion }
+              \l_tmpb_tl
+              {
+                \msg_warning:nnnV
+                  { markdown }
+                  { repeatedly-loaded-context-theme }
+                  { #1 }
+                  \l_tmpa_tl
+              }
+              {
+                \msg_error:nnneVV
+                  { markdown }
+                  { different-versions-of-context-theme }
+                  { #1 }
+                  { \markdownThemeVersion }
+                  \l_tmpb_tl
+                  \l_tmpa_tl
+              }
+          }
+          {
+            \msg_info:nnn
+              { markdown }
+              { loading-context-theme }
+              { #1 }
+            \usemodule
+              [ t ]
+              [ markdown theme #2 ]
+          }
       }
       {
         \@@_plain_tex_load_theme:nn
@@ -38298,6 +38411,20 @@ end
   { markdown }
   { loading-context-theme }
   { Loading~ConTeXt~Markdown~theme~#1 }
+\msg_new:nnn
+  { markdown }
+  { repeatedly-loaded-context-theme }
+  {
+    ConTeXt~Markdown~theme~#1~was~previously~
+    loaded~on~line~#2,~not~loading~it~again
+  }
+\msg_new:nnn
+  { markdown }
+  { different-versions-of-context-theme }
+  {
+    Tried~to~load~version~#2~of~ConTeXt~Markdown~theme~#1~
+    but~version~#3~has~already~been~loaded~on~line~#4
+  }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12957,15 +12957,27 @@ a specific look and other high-level goals without low-level programming.
       { #1 }
       { @ }
       {
-        \regex_replace_once:nnF
+        \regex_extract_once:nnN
           { (.*) @ (.*) }
+          { #1 }
+          \l_tmpa_seq
+        \seq_gpop_right:NN
+          \l_tmpa_seq
+          \l_tmpa_tl
+        \seq_get_right:NN
+          \l_tmpa_seq
+          \l_tmpa_tl
+        \tl_gset:NV
+          \g_@@_current_theme_tl
+          \l_tmpa_tl
+        \seq_get_right:NN
+          \l_tmpa_seq
+          \l_tmpa_tl
+        \cs_gset:Npe
+          \markdownThemeVersion
           {
-            \c { tl_gset:Nn }
-              \c { g_@@_current_theme_tl }
-              \cB { \1 \cE }
-            \c { cs_gset:Npn }
-              \c { markdownThemeVersion }
-              \cB { \2 \cE }
+            \tl_use:N
+              \l_tmpa_tl
           }
       }
       {

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34836,10 +34836,11 @@ end
           }
       }
       {
-        \msg_info:nnn
+        \msg_info:nnne
           { markdown }
           { loading-plain-tex-theme }
           { #1 }
+          { \markdownThemeVersion }
         \prop_gput:Nnx
           \g_@@_plain_tex_loaded_themes_linenos_prop
           { #1 }
@@ -34851,7 +34852,7 @@ end
 \msg_new:nnn
   { markdown }
   { loading-plain-tex-theme }
-  { Loading~plain~TeX~Markdown~theme~#1 }
+  { Loading~version~#2~of~plain~TeX~Markdown~theme~#1 }
 \msg_new:nnn
   { markdown }
   { repeatedly-loaded-plain-tex-theme }
@@ -36545,10 +36546,11 @@ end
                   }
               }
               {
-                \msg_info:nnn
+                \msg_info:nnne
                   { markdown }
                   { loading-latex-theme }
                   { #1 }
+                  { \markdownThemeVersion }
                 \RequirePackage
                   { markdown theme #2 }
               }
@@ -36589,7 +36591,7 @@ end
 \msg_new:nnn
   { markdown }
   { loading-latex-theme }
-  { Loading~LaTeX~Markdown~theme~#1 }
+  { Loading~version~#2~of~LaTeX~Markdown~theme~#1 }
 \msg_new:nnn
   { markdown }
   { repeatedly-loaded-latex-theme }
@@ -38518,10 +38520,11 @@ end
               }
           }
           {
-            \msg_info:nnn
+            \msg_info:nnne
               { markdown }
               { loading-context-theme }
               { #1 }
+              { \markdownThemeVersion }
             \usemodule
               [ t ]
               [ markdown theme #2 ]
@@ -38536,7 +38539,7 @@ end
 \msg_new:nnn
   { markdown }
   { loading-context-theme }
-  { Loading~ConTeXt~Markdown~theme~#1 }
+  { Loading~version~#2~of~ConTeXt~Markdown~theme~#1 }
 \msg_new:nnn
   { markdown }
   { repeatedly-loaded-context-theme }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -22716,6 +22716,7 @@ following image:
 %  \begin{macrocode}
 \AtEndOfPackage{
   \markdownLaTeXLoadedtrue
+}
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -22726,10 +22727,32 @@ following image:
 %
 % \end{markdown}
 %  \begin{macrocode}
-  \markdownIfOption{noDefaults}{}{
-    \markdownSetup{theme=witiko/markdown/defaults}
+\ExplSyntaxOn
+\bool_if:nT
+  {
+    \str_if_eq_p:VV
+      \c_@@_top_layer_tl
+      \c_@@_option_layer_latex_tl &&
+    ! \@@_if_option_p:n
+      { noDefaults }
   }
-}
+  {
+    \AtEndOfPackage
+      {
+        \@@_if_option:nTF
+          { experimental }
+          {
+            \@@_setup:n
+              { theme = witiko/markdown/defaults@experimental }
+          }
+          {
+            \@@_setup:n
+              { theme = witiko/markdown/defaults }
+          }
+      }
+    \ExplSyntaxOn
+  }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</latex>
@@ -35416,16 +35439,25 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\str_if_eq:VVT
-  \c_@@_top_layer_tl
-  \c_@@_option_layer_plain_tex_tl
+\bool_if:nT
+  {
+    \str_if_eq_p:VV
+      \c_@@_top_layer_tl
+      \c_@@_option_layer_plain_tex_tl &&
+    ! \@@_if_option_p:n
+      { noDefaults }
+  }
   {
     \ExplSyntaxOff
-    \@@_if_option:nF
-      { noDefaults }
+    \@@_if_option:nTF
+      { experimental }
       {
         \@@_setup:n
-          {theme = witiko/markdown/defaults}
+          { theme = witiko/markdown/defaults@experimental }
+      }
+      {
+        \@@_setup:n
+          { theme = witiko/markdown/defaults }
       }
     \ExplSyntaxOn
   }
@@ -36889,7 +36921,8 @@ end
     \@ifpackageloaded { enumitem } { } {
     \bool_if:nT
       {
-        \@@_if_option_p:n
+        \str_if_eq_p:en
+          { \markdownThemeVersion }
           { experimental } ||
         \prop_if_exist_p:N
           \g__pdfmanagement_documentproperties_prop &&
@@ -38822,9 +38855,30 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\markdownIfOption{noDefaults}{}{
-  \setupmarkdown[theme=witiko/markdown/defaults]
-}
+\ExplSyntaxOn
+\bool_if:nT
+  {
+    \str_if_eq_p:VV
+      \c_@@_top_layer_tl
+      \c_@@_option_layer_context_tl &&
+    ! \@@_if_option_p:n
+      { noDefaults }
+  }
+  {
+    \ExplSyntaxOff
+    \@@_if_option:nTF
+      { experimental }
+      {
+        \@@_setup:n
+          { theme = witiko/markdown/defaults@experimental }
+      }
+      {
+        \@@_setup:n
+          { theme = witiko/markdown/defaults }
+      }
+    \ExplSyntaxOn
+  }
+\ExplSyntaxOff
 \stopmodule
 \protect
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12986,6 +12986,9 @@ a specific look and other high-level goals without low-level programming.
 %
 % \end{markdown}
 %  \begin{macrocode}
+    \tl_set:NV
+      \l_tmpa_tl
+      \g_@@_current_theme_tl
     \tl_put_right:Nn
       \g_@@_current_theme_tl
       { / }
@@ -12995,8 +12998,8 @@ a specific look and other high-level goals without low-level programming.
     \seq_gput_right:NV
       \g_@@_theme_versions_seq
       \markdownThemeVersion
-    \@@_load_theme:nV
-      { #1 }
+    \@@_load_theme:VV
+      \l_tmpa_tl
       \l_tmpa_str
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -2706,6 +2706,51 @@ defaultOptions.eagerCache = true
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
 
+#### Option `experimental`
+
+`experimental` (default value: `false`)
+
+% \fi
+% \begin{markdown}
+%
+% \Optitem[false]{experimental}{\opt{true}, \opt{false}}
+%
+:    true
+
+     :  Experimental features that are planned to be the new default in the
+        next major release of the Markdown package will be enabled.
+
+        At the moment, this just means that the version `experimental` of the
+        theme `witiko/markdown/defaults` will be loaded but the effects may
+        extend to other areas in the future as well.
+
+:    false
+
+     :  Experimental features will be disabled.
+
+% \end{markdown}
+% \iffalse
+%</manual-options>
+%<*tex>
+% \fi
+%  \begin{macrocode}
+\@@_add_lua_option:nnn
+  { experimental }
+  { boolean }
+  { false }
+%    \end{macrocode}
+% \iffalse
+%</tex>
+%<*lua,lua-cli,lua-loader>
+% \fi
+%  \begin{macrocode}
+defaultOptions.experimental = false
+%    \end{macrocode}
+% \par
+% \iffalse
+%</lua,lua-cli,lua-loader>
+%<*manual-options>
+
 #### Option `singletonCache`
 
 `singletonCache` (default value: `true`)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -684,119 +684,127 @@ abbr {
 %</techdoc-block-diagram>
 %<*techdoc-bibliography>
 @online{starynovotny24,
-  author    = {Starý Novotný, Vít and Enrico Gregorio and Max Chernoff and P. Spratte, Jonathan},
-  title     = {Convert control sequence with a variable number of undelimited parameters into a token list},
-  url       = {https://tex.stackexchange.com/q/716362/70941},
-  urldate   = {2024-04-28},
+  author     = {Starý Novotný, Vít and Enrico Gregorio and Max Chernoff and P. Spratte, Jonathan},
+  title      = {Convert control sequence with a variable number of undelimited parameters into a token list},
+  url        = {https://tex.stackexchange.com/q/716362/70941},
+  urldate    = {2024-04-28},
 }
 @book{tantau21,
-  author    = {Till Tantau and Joseph Wright and Vedran Miletić},
-  title     = {The Beamer class},
-  date      = {2021-02-10},
-  url       = {https://mirrors.ctan.org/macros/latex/contrib/beamer/doc/beameruserguide.pdf},
-  urldate   = {2021-02-11}}
+  author     = {Till Tantau and Joseph Wright and Vedran Miletić},
+  title      = {The Beamer class},
+  date       = {2021-02-10},
+  url        = {https://mirrors.ctan.org/macros/latex/contrib/beamer/doc/beameruserguide.pdf},
+  urldate    = {2021-02-11}}
 @online{sotkov17,
-  author    = {Sotkov, Anton},
-  title     = {File transclusion syntax for Markdown},
-  date      = {2017-01-19},
-  url       = {https://github.com/iainc/Markdown-Content-Blocks},
-  urldate   = {2018-01-08}}
+  author     = {Sotkov, Anton},
+  title      = {File transclusion syntax for Markdown},
+  date       = {2017-01-19},
+  url        = {https://github.com/iainc/Markdown-Content-Blocks},
+  urldate    = {2018-01-08}}
 @book{luatex21,
-  author    = {{Lua\TeX{} development team}},
-  title     = {Lua\TeX{} reference manual},
-  date      = {2021-07-23},
-  note      = {Version 1.10 (stable)},
-  url       = {https://www.pragma-ade.com/general/manuals/luatex.pdf},
-  urldate   = {2022-09-30}}
+  author     = {{Lua\TeX{} development team}},
+  title      = {Lua\TeX{} reference manual},
+  date       = {2021-07-23},
+  note       = {Version 1.10 (stable)},
+  url        = {https://www.pragma-ade.com/general/manuals/luatex.pdf},
+  urldate    = {2022-09-30}}
 @book{latex17,
-  author    = {Braams, Johannes and Carlisle, David and Jeffrey, Alan and
+  author     = {Braams, Johannes and Carlisle, David and Jeffrey, Alan and
                Lamport, Leslie and Mittelbach, Frank and Rowley, Chris and
                Schöpf, Rainer},
-  title     = {The \Hologo{LaTeX2e} Sources},
-  date      = {2017-04-15},
-  url       = {https://mirrors.ctan.org/macros/latex/base/source2e.pdf},
-  urldate   = {2018-01-08}}
+  title      = {The \Hologo{LaTeX2e} Sources},
+  date       = {2017-04-15},
+  url        = {https://mirrors.ctan.org/macros/latex/base/source2e.pdf},
+  urldate    = {2018-01-08}}
 @book{mittelbach17,
-  author    = {Mittelbach, Frank},
-  title     = {The \texttt{doc} and \texttt{shortvrb} Packages},
-  date      = {2017-04-15},
-  url       = {https://mirrors.ctan.org/macros/latex/base/doc.pdf},
-  urldate   = {2018-02-19}}
+  author     = {Mittelbach, Frank},
+  title      = {The \texttt{doc} and \texttt{shortvrb} Packages},
+  date       = {2017-04-15},
+  url        = {https://mirrors.ctan.org/macros/latex/base/doc.pdf},
+  urldate    = {2018-02-19}}
 @book{mittelbach24,
-  author    = {Mittelbach, Frank},
-  title     = {\LaTeX's hook management},
-  date      = {2024-06-26},
-  url       = {https://mirrors.ctan.org/macros/latex/base/lthooks-code.pdf},
-  urldate   = {2024-10-02}}
+  author     = {Mittelbach, Frank},
+  title      = {\LaTeX's hook management},
+  date       = {2024-06-26},
+  url        = {https://mirrors.ctan.org/macros/latex/base/lthooks-code.pdf},
+  urldate    = {2024-10-02}}
 @book{poore17,
-  author    = {Poore, Geoffrey M.},
-  title     = {The \texttt{minted} Package},
-  subtitle  = {Highlighted source code in \LaTeX},
-  date      = {2017-07-19},
-  version   = {v2.5},
-  url       = {https://mirrors.ctan.org/macros/latex/contrib/minted/minted.pdf},
-  urldate   = {2020-09-01}}
+  author     = {Poore, Geoffrey M.},
+  title      = {The \texttt{minted} Package},
+  subtitle   = {Highlighted source code in \LaTeX},
+  date       = {2017-07-19},
+  version    = {v2.5},
+  url        = {https://mirrors.ctan.org/macros/latex/contrib/minted/minted.pdf},
+  urldate    = {2020-09-01}}
 @online{macfarlane22,
-  title     = {Pandoc},
-  subtitle  = {a universal document converter},
-  author    = {John MacFarlane},
-  year      = {2022},
-  url       = {https://pandoc.org/},
-  urldate   = {2022-10-05}}
+  title      = {Pandoc},
+  subtitle   = {a universal document converter},
+  author     = {John MacFarlane},
+  year       = {2022},
+  url        = {https://pandoc.org/},
+  urldate    = {2022-10-05}}
 @online{novotny15,
-  author    = {Novotný, Vít},
-  year      = {2015},
-  title     = {TeXový interpret jazyka Markdown (markdown.sty)},
-  location  = {Brno, Czech Republic},
-  publisher = {Masaryk University},
-  url       = {https://www.muni.cz/en/research/projects/32984},
-  urldate   = {2018-02-19}}
+  author     = {Novotný, Vít},
+  year       = {2015},
+  title      = {TeXový interpret jazyka Markdown (markdown.sty)},
+  location   = {Brno, Czech Republic},
+  publisher  = {Masaryk University},
+  url        = {https://www.muni.cz/en/research/projects/32984},
+  urldate    = {2018-02-19}}
 @book{ierusalimschy13,
-  author    = {Ierusalimschy, Roberto},
-  year      = {2013},
-  title     = {Programming in Lua},
-  edition   = {3},
-  isbn      = {978-85-903798-5-0},
-  pagetotal = {xviii, 347},
-  location  = {Rio de Janeiro},
-  publisher = {PUC-Rio}}
+  author     = {Ierusalimschy, Roberto},
+  year       = {2013},
+  title      = {Programming in Lua},
+  edition    = {3},
+  isbn       = {978-85-903798-5-0},
+  pagetotal  = {xviii, 347},
+  location   = {Rio de Janeiro},
+  publisher  = {PUC-Rio}}
 @book{knuth86a,
-  author    = {Knuth, Donald Ervin},
-  year      = {1986},
-  title     = {The \TeX{}book},
-  edition   = {3},
-  isbn      = {0-201-13447-0},
-  pagetotal = {ix, 479},
-  series    = {Computers \& Typesetting},
-  volume    = {A},
-  location  = {Reading, MA},
-  publisher = {Addison-Wesley}}
+  author     = {Knuth, Donald Ervin},
+  year       = {1986},
+  title      = {The \TeX{}book},
+  edition    = {3},
+  isbn       = {0-201-13447-0},
+  pagetotal  = {ix, 479},
+  series     = {Computers \& Typesetting},
+  volume     = {A},
+  location   = {Reading, MA},
+  publisher  = {Addison-Wesley}}
 @book{knuth86b,
-  author    = {Knuth, Donald Ervin},
-  year      = {1986},
-  title     = {\TeX: The Program},
-  isbn      = {978-0-201-13437-7},
-  pagetotal = {xvi, 594},
-  series    = {Computers \& Typesetting},
-  volume    = {B},
-  location  = {Reading, MA},
-  publisher = {Addison-Wesley}}
+  author     = {Knuth, Donald Ervin},
+  year       = {1986},
+  title      = {\TeX: The Program},
+  isbn       = {978-0-201-13437-7},
+  pagetotal  = {xvi, 594},
+  series     = {Computers \& Typesetting},
+  volume     = {B},
+  location   = {Reading, MA},
+  publisher  = {Addison-Wesley}}
 @book{eijkhout92,
-  author    = {Victor Eijkhout},
-  title     = {\TeX{} by Topic},
-  subtitle  = {A \TeX nician's Reference},
-  isbn      = {978-0-201-56882-0},
-  pagetotal = {307},
-  date      = {1992-02-01},
-  location  = {Wokingham, England},
-  publisher = {Addison-Wesley}}
+  author     = {Victor Eijkhout},
+  title      = {\TeX{} by Topic},
+  subtitle   = {A \TeX nician's Reference},
+  isbn       = {978-0-201-56882-0},
+  pagetotal  = {307},
+  date       = {1992-02-01},
+  location   = {Wokingham, England},
+  publisher  = {Addison-Wesley}}
 @inproceedings{sharif10,
-  author    = {Sharif, Bonita and Maletic, Jonathan I.},
-  booktitle = {2010 IEEE 18th International Conference on Program Comprehension},
-  title     = {An Eye Tracking Study on camelCase and under\_score Identifier Styles},
-  year      = {2010},
-  pages     = {196-205},
-  doi       = {10.1109/ICPC.2010.41}}
+  author     = {Sharif, Bonita and Maletic, Jonathan I.},
+  booktitle  = {2010 IEEE 18th International Conference on Program Comprehension},
+  title      = {An Eye Tracking Study on camelCase and under\_score Identifier Styles},
+  year       = {2010},
+  pages      = {196-205},
+  doi        = {10.1109/ICPC.2010.41}}
+@online{novotny24,
+  author     = {Starý Novotný, Vít},
+  title      = {Versioned Themes},
+  titleaddon = {Markdown Enhancement Proposal},
+  date       = {2024-10-13},
+  urldate    = {2024-10-21},
+  url        = {https://github.com/Witiko/markdown/discussions/514},
+}
 %</techdoc-bibliography>
 %<@@=markdown>
 %<*themes-witiko-markdown-techdoc>
@@ -12757,27 +12765,33 @@ User-defined themes for the Markdown package provide a domain-specific
 interpretation of Markdown tokens. Themes allow the authors to achieve
 a specific look and other high-level goals without low-level programming.
 
-% The key-values `theme`=\meta{theme name} and `import`=\meta{theme name} load
-% a \TeX{} document (further referred to as *a theme*) named
-% `markdowntheme`\meta{munged theme name}`.tex`, where the *munged theme name*
-% is the *theme name* after the substitution of all forward slashes (`/`) for
-% an underscore (`_`). The theme name is *qualified* and contains no
-% underscores. A theme name is qualified if and only if it contains at least
-% one forward slash. Themes are inspired by the Beamer \LaTeX{} package, which
-% provides similar functionality with its `\usetheme` macro [@tantau21, Section
-% 15.1].
+% The key-values `theme`=\meta{theme name} and `import`=\meta{theme name},
+% optionally followed by `@`\meta{theme version}, load a \TeX{} document
+% (further referred to as *a theme*) named `markdowntheme`\meta{munged theme
+% name}`.tex`, where the *munged theme name* is the *theme name* after the
+% substitution of all forward slashes (`/`) for an underscore (`_`).
+% The theme name must be *qualified* and contain no underscores or at signs
+% (`@`). Themes are inspired by the Beamer \LaTeX{} package, which provides
+% similar functionality with its `\usetheme` macro [@tantau21, Section 15.1].
 %
-% Theme names must be qualified to minimize naming conflicts between different
-% themes with a similar purpose. The preferred format of a theme name is
-% \meta{theme author}`/`\meta{theme purpose}`/`\meta{private naming
-% scheme}, where the *private naming scheme* may contain additional forward
-% slashes. For example, a theme by a user `witiko` for the MU theme of the
-% Beamer document class may have the name `witiko/beamer/MU`.
+% A theme name is qualified if and only if it contains at least one forward
+% slash. Theme names must be qualified to minimize naming conflicts between
+% different themes with a similar purpose. The preferred format of a theme name
+% is \meta{theme author}`/`\meta{theme purpose}`/`\meta{private naming scheme},
+% where the *private naming scheme* may contain additional forward slashes. For
+% example, a theme by a user `witiko` for the MU theme of the Beamer document
+% class may have the name `witiko/beamer/MU`.
 %
 % Theme names are munged to allow structure inside theme names without
 % dictating where the themes should be located inside the \TeX{} directory
 % structure. For example, loading a theme named `witiko/beamer/MU` would
 % load a \TeX{} document package named `markdownthemewitiko_beamer_MU.tex`.
+%
+% If `@`\meta{theme version} is specified after \meta{theme name}, then the
+% text *theme version* will be available in the macro
+% \mdef{markdownThemeVersion} when the theme is loaded. If `@`\meta{theme
+% version} is not specified, the macro \mref{markdownThemeVersion} will
+% contain the text `latest` [@novotny24].
 %
 % \end{markdown}
 % \iffalse
@@ -12821,21 +12835,31 @@ a specific look and other high-level goals without low-level programming.
 % \begin{markdown}
 %
 % To keep track of the current theme when themes are nested, we will
-% maintain the \mdef{g_\@\@_themes_seq} stack of theme names.
-% For convenience, the name of the current theme is also available in the
-% \mdef{g_@@_current_theme_tl} macro.
+% maintain the stacks \mdef{g_\@\@_theme_names_seq} and
+% \mdef{g_\@\@_theme_versions_seq} stack of theme names and versions,
+% respectively. For convenience, the name of the current theme and version is
+% also available in the macros \mdef{g_@@_current_theme_tl} and
+% \mref{markdownThemeVersion}, respectively.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \seq_new:N
-  \g_@@_themes_seq
+  \g_@@_theme_names_seq
+\seq_new:N
+  \g_@@_theme_versions_seq
 \tl_new:N
   \g_@@_current_theme_tl
 \tl_gset:Nn
   \g_@@_current_theme_tl
   { }
 \seq_gput_right:NV
-  \g_@@_themes_seq
+  \g_@@_theme_names_seq
+  \g_@@_current_theme_tl
+\cs_new:Npn
+  \markdownThemeVersion
+  { }
+\seq_gput_right:NV
+  \g_@@_theme_versions_seq
   \g_@@_current_theme_tl
 \cs_new:Nn
   \@@_set_theme:n
@@ -12868,13 +12892,43 @@ a specific look and other high-level goals without low-level programming.
 %    \end{macrocode}
 % \begin{markdown}
 %
+% Next, we extract the theme version.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \str_if_in:nnTF
+      { #1 }
+      { @ }
+      {
+        \regex_replace_once:nnF
+          { (.*) @ (.*) }
+          {
+            \c { tl_gset:Nn }
+              \c { g_@@_current_theme_tl }
+              \cB { \1 \cE }
+            \c { cs_gset:Npn }
+              \c { markdownThemeVersion }
+              \cB { \2 \cE }
+          }
+      }
+      {
+        \tl_gset:Nn
+          \g_@@_current_theme_tl
+          { #1 }
+        \cs_gset:Npn
+          \markdownThemeVersion
+          { latest }
+      }
+%    \end{macrocode}
+% \begin{markdown}
+%
 % Next, we munge the theme name.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \str_set:Nn
+    \str_set:NV
       \l_tmpa_str
-      { #1 }
+      \g_@@_current_theme_tl
     \str_replace_all:Nnn
       \l_tmpa_str
       { / }
@@ -12882,28 +12936,52 @@ a specific look and other high-level goals without low-level programming.
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Finally, we load the theme.
+% Finally, we load the theme. Before loading the theme, we push down the
+% current name and version of the theme on the stack.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \tl_gset:Nn
+    \tl_put_right:Nn
       \g_@@_current_theme_tl
-      { #1 / }
+      { / }
     \seq_gput_right:NV
-      \g_@@_themes_seq
+      \g_@@_theme_names_seq
       \g_@@_current_theme_tl
+    \seq_gput_right:NV
+      \g_@@_theme_versions_seq
+      \markdownThemeVersion
     \@@_load_theme:nV
       { #1 }
       \l_tmpa_str
+%    \end{macrocode}
+% \begin{markdown}
+%
+% After the theme has been loaded, we recover the name and version of the
+% previous theme from the stack.
+%
+% \end{markdown}
+%  \begin{macrocode}
     \seq_gpop_right:NN
-      \g_@@_themes_seq
+      \g_@@_theme_names_seq
       \l_tmpa_tl
     \seq_get_right:NN
-      \g_@@_themes_seq
+      \g_@@_theme_names_seq
       \l_tmpa_tl
     \tl_gset:NV
       \g_@@_current_theme_tl
       \l_tmpa_tl
+    \seq_gpop_right:NN
+      \g_@@_theme_versions_seq
+      \l_tmpa_tl
+    \seq_get_right:NN
+      \g_@@_theme_versions_seq
+      \l_tmpa_tl
+    \cs_gset:Npe
+      \markdownThemeVersion
+      {
+        \tl_use:N
+          \l_tmpa_tl
+      }
   }
 \msg_new:nnnn
   { markdown }
@@ -13061,20 +13139,21 @@ options locally.
 %
 % \end{markdown}
 %  \begin{macrocode}
+\tl_new:N
+  \l_@@_current_snippet_tl
 \prg_new_conditional:Nnn
   \@@_if_snippet_exists:n
   { TF, T, F }
   {
     \tl_set:NV
-      \l_tmpa_tl
+      \l_@@_current_snippet_tl
       \g_@@_current_theme_tl
     \tl_put_right:Nn
-      \l_tmpa_tl
+      \l_@@_current_snippet_tl
       { #1 }
-    \prop_get:NVNTF
+    \prop_if_in:NVTF
       \g_@@_snippets_prop
-      \l_tmpa_tl
-      \l_tmpb_tl
+      \l_@@_current_snippet_tl
       { \prg_return_true: }
       { \prg_return_false: }
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12785,7 +12785,7 @@ A PDF document named `document.pdf` should be produced and contain the text
 \prg_generate_conditional_variant:Nnn
   \str_if_eq:nn
   { en }
-  { F }
+  { p, F }
 \msg_new:nnn
   { markdown }
   { malformed-name-for-clist-option }
@@ -12961,16 +12961,16 @@ a specific look and other high-level goals without low-level programming.
           { (.*) @ (.*) }
           { #1 }
           \l_tmpa_seq
-        \seq_gpop_right:NN
+        \seq_gpop_left:NN
           \l_tmpa_seq
           \l_tmpa_tl
-        \seq_get_right:NN
+        \seq_gpop_left:NN
           \l_tmpa_seq
           \l_tmpa_tl
         \tl_gset:NV
           \g_@@_current_theme_tl
           \l_tmpa_tl
-        \seq_get_right:NN
+        \seq_gpop_left:NN
           \l_tmpa_seq
           \l_tmpa_tl
         \cs_gset:Npe
@@ -13022,8 +13022,9 @@ a specific look and other high-level goals without low-level programming.
     \seq_gput_right:NV
       \g_@@_theme_versions_seq
       \markdownThemeVersion
-    \@@_load_theme:VV
+    \@@_load_theme:VeV
       \l_tmpa_tl
+      { \markdownThemeVersion }
       \l_tmpa_str
 %    \end{macrocode}
 % \begin{markdown}
@@ -22768,10 +22769,10 @@ following image:
   \c_@@_option_layer_latex_tl
   {
     \ExplSyntaxOff
-    \@@_if_option:nF
-      { noDefaults }
+    \AtEndOfPackage
       {
-        \AtEndOfPackage
+        \@@_if_option:nF
+          { noDefaults }
           {
             \@@_if_option:nTF
               { experimental }
@@ -34839,7 +34840,7 @@ end
 \prop_new:N \g_@@_plain_tex_loaded_themes_linenos_prop
 \prop_new:N \g_@@_plain_tex_loaded_themes_versions_prop
 \cs_new:Nn
-  \@@_plain_tex_load_theme:nn
+  \@@_plain_tex_load_theme:nnn
   {
     \prop_get:NnNTF
       \g_@@_plain_tex_loaded_themes_linenos_prop
@@ -34850,38 +34851,43 @@ end
           \g_@@_plain_tex_loaded_themes_versions_prop
           { #1 }
           \l_tmpb_tl
-        \str_if_eq:eVTF
-          { \markdownThemeVersion }
+        \str_if_eq:nVTF
+          { #2 }
           \l_tmpb_tl
           {
-            \msg_warning:nnnV
+            \msg_warning:nnnVn
               { markdown }
               { repeatedly-loaded-plain-tex-theme }
               { #1 }
               \l_tmpa_tl
+              { #2 }
           }
           {
-            \msg_error:nnneVV
+            \msg_error:nnnnVV
               { markdown }
               { different-versions-of-plain-tex-theme }
               { #1 }
-              { \markdownThemeVersion }
+              { #2 }
               \l_tmpb_tl
               \l_tmpa_tl
           }
       }
       {
-        \msg_info:nnne
+        \msg_info:nnnn
           { markdown }
           { loading-plain-tex-theme }
           { #1 }
-          { \markdownThemeVersion }
+          { #2 }
         \prop_gput:Nnx
           \g_@@_plain_tex_loaded_themes_linenos_prop
           { #1 }
           { \tex_the:D \tex_inputlineno:D }
+        \prop_gput:Nnn
+          \g_@@_plain_tex_loaded_themes_versions_prop
+          { #1 }
+          { #2 }
         \file_input:n
-          { markdown theme #2 }
+          { markdown theme #3 }
       }
   }
 \msg_new:nnn
@@ -34892,7 +34898,7 @@ end
   { markdown }
   { repeatedly-loaded-plain-tex-theme }
   {
-    Plain~TeX~Markdown~theme~#1~was~previously~
+    Version~#3~of~plain~TeX~Markdown~theme~#1~was~previously~
     loaded~on~line~#2,~not~loading~it~again
   }
 \msg_new:nnn
@@ -34906,18 +34912,17 @@ end
   \prop_gput:Nnn
   { Nnx }
 \cs_gset_eq:NN
-  \@@_load_theme:nn
-  \@@_plain_tex_load_theme:nn
+  \@@_load_theme:nnn
+  \@@_plain_tex_load_theme:nnn
 \cs_generate_variant:Nn
-  \@@_load_theme:nn
-  { VV }
+  \@@_load_theme:nnn
+  { VeV }
 \cs_generate_variant:Nn
   \msg_error:nnnnnn
-  { nnneVV }
-\prg_generate_conditional_variant:Nnn
-  \str_if_eq:nn
-  { eV }
-  { TF }
+  { nnnnVV }
+\cs_generate_variant:Nn
+  \msg_warning:nnnnn
+  { nnnVn }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -34972,16 +34977,17 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \@@_plain_tex_load_theme:VV
+    \@@_plain_tex_load_theme:VeV
       \l_tmpb_tl
+      { \markdownThemeVersion }
       \l_tmpa_str
   }
 \cs_generate_variant:Nn
   \tl_set:Nn
   { Ne }
 \cs_generate_variant:Nn
-  \@@_plain_tex_load_theme:nn
-  { VV }
+  \@@_plain_tex_load_theme:nnn
+  { VeV }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
@@ -36512,7 +36518,7 @@ end
 \prop_new:N \g_@@_latex_loaded_themes_linenos_prop
 \prop_new:N \g_@@_latex_loaded_themes_versions_prop
 \cs_gset:Nn
-  \@@_load_theme:nn
+  \@@_load_theme:nnn
   {
 %    \end{macrocode}
 % \par
@@ -36536,7 +36542,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
         \file_if_exist:nTF
-          { markdown theme #2.sty }
+          { markdown theme #3.sty }
           {
             \msg_error:nnn
               { markdown }
@@ -36544,9 +36550,10 @@ end
               { #1 }
           }
           {
-            \@@_plain_tex_load_theme:nn
+            \@@_plain_tex_load_theme:nnn
               { #1 }
               { #2 }
+              { #3 }
           }
       \else
 %    \end{macrocode}
@@ -36559,7 +36566,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
         \file_if_exist:nTF
-          { markdown theme #2.sty }
+          { markdown theme #3.sty }
           {
             \prop_get:NnNTF
               \g_@@_latex_loaded_themes_linenos_prop
@@ -36570,40 +36577,50 @@ end
                   \g_@@_latex_loaded_themes_versions_prop
                   { #1 }
                   \l_tmpb_tl
-                \str_if_eq:eVTF
-                  { \markdownThemeVersion }
+                \str_if_eq:nVTF
+                  { #2 }
                   \l_tmpb_tl
                   {
-                    \msg_warning:nnnV
+                    \msg_warning:nnnVn
                       { markdown }
                       { repeatedly-loaded-latex-theme }
                       { #1 }
                       \l_tmpa_tl
+                      { #2 }
                   }
                   {
-                    \msg_error:nnneVV
+                    \msg_error:nnnnVV
                       { markdown }
                       { different-versions-of-latex-theme }
                       { #1 }
-                      { \markdownThemeVersion }
+                      { #2 }
                       \l_tmpb_tl
                       \l_tmpa_tl
                   }
               }
               {
-                \msg_info:nnne
+                \msg_info:nnnn
                   { markdown }
                   { loading-latex-theme }
                   { #1 }
-                  { \markdownThemeVersion }
+                  { #2 }
+                \prop_gput:Nnx
+                  \g_@@_latex_loaded_themes_linenos_prop
+                  { #1 }
+                  { \tex_the:D \tex_inputlineno:D }
+                \prop_gput:Nnn
+                  \g_@@_latex_loaded_themes_versions_prop
+                  { #1 }
+                  { #2 }
                 \RequirePackage
-                  { markdown theme #2 }
+                  { markdown theme #3 }
               }
           }
           {
-            \@@_plain_tex_load_theme:nn
+            \@@_plain_tex_load_theme:nnn
               { #1 }
               { #2 }
+              { #3 }
           }
       \fi
     \else
@@ -36615,14 +36632,15 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-      \msg_info:nnn
+      \msg_info:nnnn
         { markdown }
         { theme-loading-postponed }
         { #1 }
+        { #2 }
       \AtEndOfPackage
         {
           \@@_set_theme:n
-            { #1 }
+            { #1 @ #2 }
         }
     \fi
   }
@@ -36630,7 +36648,7 @@ end
   { markdown }
   { theme-loading-postponed }
   {
-    Postponing~loading~Markdown~theme~#1~until~
+    Postponing~loading~version~#2~of~Markdown~theme~#1~until~
     Markdown~package~has~finished~loading
   }
 \msg_new:nnn
@@ -36641,7 +36659,7 @@ end
   { markdown }
   { repeatedly-loaded-latex-theme }
   {
-    LaTeX~Markdown~theme~#1~was~previously~
+    Version~#3~of~LaTeX~Markdown~theme~#1~was~previously~
     loaded~on~line~#2,~not~loading~it~again
   }
 \msg_new:nnn
@@ -37000,33 +37018,56 @@ end
     ! \g_@@_beamer_paralist_or_enumitem_bool
   }
   {
-    \bool_if:nT
+    \bool_if:nTF
       {
-        \str_if_eq_p:en
-          { \markdownThemeVersion }
-          { experimental } ||
-        \prop_if_exist_p:N
-          \g__pdfmanagement_documentproperties_prop &&
-        (
-          \prop_if_in_p:Nn
-            \g__pdfmanagement_documentproperties_prop
-            { document / testphase / phase-I } ||
-          \prop_if_in_p:Nn
-            \g__pdfmanagement_documentproperties_prop
-            { document / testphase / phase-II } ||
-          \prop_if_in_p:Nn
-            \g__pdfmanagement_documentproperties_prop
-            { document / testphase / phase-III } ||
-          \prop_if_in_p:Nn
-            \g__pdfmanagement_documentproperties_prop
-            { document / testphase / phase-IV } ||
-          \prop_if_in_p:Nn
-            \g__pdfmanagement_documentproperties_prop
-            { document / testphase / phase-V } ||
-          \prop_if_in_p:Nn
-            \g__pdfmanagement_documentproperties_prop
-            { document / testphase / phase-VI }
-        )
+        \bool_lazy_or_p:nn
+          {
+            \str_if_eq_p:en
+              { \markdownThemeVersion }
+              { experimental }
+          }
+          {
+            \bool_lazy_and_p:nn
+              {
+                \prop_if_exist_p:N
+                  \g__pdfmanagement_documentproperties_prop
+              }
+              {
+                \bool_lazy_any_p:n
+                  {
+                    {
+                      \prop_if_in_p:Nn
+                        \g__pdfmanagement_documentproperties_prop
+                        { document / testphase / phase-I }
+                    }
+                    {
+                      \prop_if_in_p:Nn
+                        \g__pdfmanagement_documentproperties_prop
+                        { document / testphase / phase-II }
+                    }
+                    {
+                      \prop_if_in_p:Nn
+                        \g__pdfmanagement_documentproperties_prop
+                        { document / testphase / phase-III }
+                    }
+                    {
+                      \prop_if_in_p:Nn
+                        \g__pdfmanagement_documentproperties_prop
+                        { document / testphase / phase-IV }
+                    }
+                    {
+                      \prop_if_in_p:Nn
+                        \g__pdfmanagement_documentproperties_prop
+                        { document / testphase / phase-V }
+                    }
+                    {
+                      \prop_if_in_p:Nn
+                        \g__pdfmanagement_documentproperties_prop
+                        { document / testphase / phase-VI }
+                    }
+                  }
+              }
+          }
       }
       {
         \RequirePackage
@@ -38520,7 +38561,7 @@ end
 \prop_new:N \g_@@_context_loaded_themes_linenos_prop
 \prop_new:N \g_@@_context_loaded_themes_versions_prop
 \cs_gset:Nn
-  \@@_load_theme:nn
+  \@@_load_theme:nnn
   {
 %    \end{macrocode}
 % \par
@@ -38533,7 +38574,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
     \file_if_exist:nTF
-      { t - markdown theme #2.tex }
+      { t - markdown theme #3.tex }
       {
         \prop_get:NnNTF
           \g_@@_context_loaded_themes_linenos_prop
@@ -38544,41 +38585,51 @@ end
               \g_@@_context_loaded_themes_versions_prop
               { #1 }
               \l_tmpb_tl
-            \str_if_eq:eVTF
-              { \markdownThemeVersion }
+            \str_if_eq:nVTF
+              { #2 }
               \l_tmpb_tl
               {
-                \msg_warning:nnnV
+                \msg_warning:nnnVn
                   { markdown }
                   { repeatedly-loaded-context-theme }
                   { #1 }
                   \l_tmpa_tl
+                  { #2 }
               }
               {
-                \msg_error:nnneVV
+                \msg_error:nnnnVV
                   { markdown }
                   { different-versions-of-context-theme }
                   { #1 }
-                  { \markdownThemeVersion }
+                  { #2 }
                   \l_tmpb_tl
                   \l_tmpa_tl
               }
           }
           {
-            \msg_info:nnne
+            \msg_info:nnn
               { markdown }
               { loading-context-theme }
               { #1 }
-              { \markdownThemeVersion }
+              { #2 }
+            \prop_gput:Nnx
+              \g_@@_context_loaded_themes_linenos_prop
+              { #1 }
+              { \tex_the:D \tex_inputlineno:D }
+            \prop_gput:Nnn
+              \g_@@_context_loaded_themes_versions_prop
+              { #1 }
+              { #2 }
             \usemodule
               [ t ]
-              [ markdown theme #2 ]
+              [ markdown theme #3 ]
           }
       }
       {
-        \@@_plain_tex_load_theme:nn
+        \@@_plain_tex_load_theme:nnn
           { #1 }
           { #2 }
+          { #3 }
       }
   }
 \msg_new:nnn
@@ -38589,7 +38640,7 @@ end
   { markdown }
   { repeatedly-loaded-context-theme }
   {
-    ConTeXt~Markdown~theme~#1~was~previously~
+    Version~#3~of~ConTeXt~Markdown~theme~#1~was~previously~
     loaded~on~line~#2,~not~loading~it~again
   }
 \msg_new:nnn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12091,7 +12091,7 @@ you would include the following code in your plain \TeX{} document:
 %  \begin{macrocode}
 \prg_new_conditional:Nnn
   \@@_if_option:n
-  { p, TF, T, F }
+  { TF, T, F }
   {
     \@@_get_option_type:nN
       { #1 }
@@ -22728,26 +22728,26 @@ following image:
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\bool_if:nT
+\str_if_eq:VVT
+  \c_@@_top_layer_tl
+  \c_@@_option_layer_latex_tl
   {
-    \str_if_eq_p:VV
-      \c_@@_top_layer_tl
-      \c_@@_option_layer_latex_tl &&
-    ! \@@_if_option_p:n
+    \ExplSyntaxOff
+    \@@_if_option:nF
       { noDefaults }
-  }
-  {
-    \AtEndOfPackage
       {
-        \@@_if_option:nTF
-          { experimental }
+        \AtEndOfPackage
           {
-            \@@_setup:n
-              { theme = witiko/markdown/defaults@experimental }
-          }
-          {
-            \@@_setup:n
-              { theme = witiko/markdown/defaults }
+            \@@_if_option:nTF
+              { experimental }
+              {
+                \@@_setup:n
+                  { theme = witiko/markdown/defaults@experimental }
+              }
+              {
+                \@@_setup:n
+                  { theme = witiko/markdown/defaults }
+              }
           }
       }
     \ExplSyntaxOn
@@ -35439,25 +35439,24 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\bool_if:nT
-  {
-    \str_if_eq_p:VV
-      \c_@@_top_layer_tl
-      \c_@@_option_layer_plain_tex_tl &&
-    ! \@@_if_option_p:n
-      { noDefaults }
-  }
+\str_if_eq:VVT
+  \c_@@_top_layer_tl
+  \c_@@_option_layer_plain_tex_tl
   {
     \ExplSyntaxOff
-    \@@_if_option:nTF
-      { experimental }
+    \@@_if_option:nF
+      { noDefaults }
       {
-        \@@_setup:n
-          { theme = witiko/markdown/defaults@experimental }
-      }
-      {
-        \@@_setup:n
-          { theme = witiko/markdown/defaults }
+        \@@_if_option:nTF
+          { experimental }
+          {
+            \@@_setup:n
+              { theme = witiko/markdown/defaults@experimental }
+          }
+          {
+            \@@_setup:n
+              { theme = witiko/markdown/defaults }
+          }
       }
     \ExplSyntaxOn
   }
@@ -36909,16 +36908,51 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\bool_new:N
+  \g_@@_tight_or_fancy_lists_bool
+\bool_gset_false:N
+  \g_@@_tight_or_fancy_lists_bool
+\@@_if_option:nTF
+  { tightLists }
+  {
+    \bool_gset_true:N
+      \g_@@_tight_or_fancy_lists_bool
+  }
+  {
+    \@@_if_option:nT
+      { fancyLists }
+      {
+        \bool_gset_true:N
+          \g_@@_tight_or_fancy_lists_bool
+      }
+  }
+\bool_new:N
+  \g_@@_beamer_paralist_or_enumitem_bool
+\bool_gset_true:N
+  \g_@@_beamer_paralist_or_enumitem_bool
+\@ifclassloaded
+  { beamer }
+  { }
+  {
+    \@ifpackageloaded
+      { paralist }
+      { }
+      {
+        \@ifpackageloaded
+        { enumitem }
+        { }
+        {
+          \bool_gset_false:N
+            \g_@@_beamer_paralist_or_enumitem_bool
+        }
+      }
+  }
 \bool_if:nT
   {
-    \@@_if_option_p:n
-      { tightLists } ||
-    \@@_if_option_p:n
-      { fancyLists }
+    \g_@@_tight_or_fancy_lists_bool &&
+    ! \g_@@_beamer_paralist_or_enumitem_bool
   }
-  { \@ifclassloaded { beamer } { } {
-    \@ifpackageloaded { paralist } { } {
-    \@ifpackageloaded { enumitem } { } {
+  {
     \bool_if:nT
       {
         \str_if_eq_p:en
@@ -36955,7 +36989,7 @@ end
         \RequirePackage
           { paralist }
       }
-  } } } }
+  }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \par
@@ -38856,25 +38890,24 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\bool_if:nT
-  {
-    \str_if_eq_p:VV
-      \c_@@_top_layer_tl
-      \c_@@_option_layer_context_tl &&
-    ! \@@_if_option_p:n
-      { noDefaults }
-  }
+\str_if_eq:VVT
+  \c_@@_top_layer_tl
+  \c_@@_option_layer_context_tl
   {
     \ExplSyntaxOff
-    \@@_if_option:nTF
-      { experimental }
+    \@@_if_option:nF
+      { noDefaults }
       {
-        \@@_setup:n
-          { theme = witiko/markdown/defaults@experimental }
-      }
-      {
-        \@@_setup:n
-          { theme = witiko/markdown/defaults }
+        \@@_if_option:nTF
+          { experimental }
+          {
+            \@@_setup:n
+              { theme = witiko/markdown/defaults@experimental }
+          }
+          {
+            \@@_setup:n
+              { theme = witiko/markdown/defaults }
+          }
       }
     \ExplSyntaxOn
   }


### PR DESCRIPTION
This PR implements MEP #514 and marks the changes from https://github.com/Witiko/markdown/pull/512 as _experimental_, as discussed in https://github.com/Witiko/markdown/issues/466#issuecomment-2410364433.

### Tasks
- [x] Implement the syntax `@`_⟨version⟩_ for themes, according to MEP [\#514](https://github.com/Witiko/markdown/discussions/514).
- [x] Add the Lua option `experimental` that causes theme `witiko/markdown/defaults@experimental` to be loaded.
- [x] Only apply the changes from [\#512](https://github.com/Witiko/markdown/issues/512) in the LaTeX theme `witiko/markdown/defaults` if the option `experimental` has been enabled or if any LaTeX test phase has been enabled.
- [x] Raise errors when deprecated features are used after the option `experimental` has been enabled.
- [x] Update `CHANGES.md`.

<details>

### Manual tests
- [x] Try loading the default themes with/without the version `experimental` and check that the correct package is used to render tight and fancy lists.
- [x] Try loading the markdown package with/without the option `experimental` enabled and check that the correct package is used to render tight and fancy lists.
- [x] Try loading the markdown package with/without a LaTeX test phase enabled and check that the correct package is used to render tight and fancy lists.
- [x] Try loading the markdown package with the packages `enumitem`/`paralist` preloaded and check that tight and fancy lists are correctly rendered.
- [x] Test that (not) using the syntax `@`⟨version⟩ correctly sets the macro `\markdownThemeVersion`, even in nested themes.
- [x] Test that repeatedly loading the same plain TeX/LaTeX/ConTeXt themes with the same/different versions produces the correct logs/error.

</details>

Closes #466 and #514.