### PR TITLE
Restore TeX4ht examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ EXAMPLES_SOURCES=examples/context-mkiv.tex \
   examples/optex.tex
 EXAMPLES=examples/context-mkiv.pdf \
   examples/latex-pdftex.pdf examples/latex-xetex.pdf examples/latex-luatex.pdf \
+  examples/latex-tex4ht.html examples/latex-tex4ht.css \
   examples/optex.pdf
-# examples/latex-tex4ht.html examples/latex-tex4ht.css
 TESTS=tests/test.sh tests/test.py tests/requirements.txt tests/support/*.tex \
   tests/templates/*/*/head.tex.m4 tests/templates/*/*/body.tex.m4 \
   tests/templates/*/*/foot.tex.m4 tests/templates/*/COMMANDS.m4 tests/testfiles/*/*/*.test

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -30,8 +30,8 @@ LUACLI_OPTIONS=\
 OUTPUT=\
   context-mkiv.pdf \
   latex-pdftex.pdf latex-xetex.pdf latex-luatex.pdf \
+  latex-tex4ht.html latex-tex4ht.css \
   optex.pdf
-# latex-tex4ht.html latex-tex4ht.css
 
 # This is the default pseudo-target.
 all: $(OUTPUT)


### PR DESCRIPTION
This PR reverts commit https://github.com/Witiko/markdown/commit/0e5c4ccd7b3d22fbdb5d31e8695546d625ad3434, which removed TeX4ht examples from the release due to https://github.com/michal-h21/make4ht/issues/154.