### PR TITLE
Clean up and update built-in themes and make them part of `markdown.tex` and `markdown.sty`

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -18,4 +18,5 @@ MD041: false
 MD046: false
 MD049: false
 MD050: false
+MD051: false
 MD053: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,33 @@
 
 ## 3.9.0
 
+Development:
+
+- Convert built-in LaTeX themes `witiko/dot` and `witiko/graphicx/http` into
+  plain TeX themes. (#514, #522, #529)
+
+  This allows these themes to be used in formats such as plain TeX and ConTeXt
+  as well.
+
+Refactoring:
+
+- Remove dependencies on `ifthen`, `gobble`, and `catchfile`. (#514, #522, #529)
+
+- Store small built-in LaTeX themes `witiko/dot`, `witiko/graphicx/http`, and
+  `witiko/tilde` in expl3 props in files `markdown.tex` and `markdown.sty`.
+  (#514, #522, #529)
+
+  This simplifies the distribution and installation of these themes, which were
+  previously located in individual `.tex` and `.sty` files.
+
+  The built-in plain TeX, LaTeX, and ConTeXt themes `witiko/markdown/defaults`
+  are still distributed in individual files. This is because inlining these
+  themes in files `markdown.tex`, `markdown.sty`, and `t-markdown.tex` would
+  make it more difficult for users to copy and modify these themes without
+  delaying updates to the Markdown package itself. Furthermore, these themes
+  are large and storing/executing them from an expl3 prop would make it more
+  difficult to determine the line numbers when errors occur.
+
 Fixes:
 
 - Protect renderers and renderer prototypes. (#465, #506)

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,8 @@ mkdir -p                                                     ${INSTALL_DIR}/tex/
 cp ${BUILD_DIR}/markdown.tex                                 ${INSTALL_DIR}/tex/generic/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_tilde.tex                ${INSTALL_DIR}/tex/generic/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_markdown_defaults.tex    ${INSTALL_DIR}/tex/generic/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_dot.tex                  ${INSTALL_DIR}/tex/generic/markdown/
+cp ${BUILD_DIR}/markdownthemewitiko_graphicx_http.tex        ${INSTALL_DIR}/tex/generic/markdown/
 mkdir -p                                                     ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdown.sty                                 ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_dot.sty                  ${INSTALL_DIR}/tex/latex/markdown/

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,14 +114,9 @@ mkdir -p                                                     ${INSTALL_DIR}/scri
 cp ${BUILD_DIR}/markdown-cli.lua                             ${INSTALL_DIR}/scripts/markdown/
 mkdir -p                                                     ${INSTALL_DIR}/tex/generic/markdown/
 cp ${BUILD_DIR}/markdown.tex                                 ${INSTALL_DIR}/tex/generic/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_tilde.tex                ${INSTALL_DIR}/tex/generic/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_markdown_defaults.tex    ${INSTALL_DIR}/tex/generic/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_dot.tex                  ${INSTALL_DIR}/tex/generic/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_graphicx_http.tex        ${INSTALL_DIR}/tex/generic/markdown/
 mkdir -p                                                     ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdown.sty                                 ${INSTALL_DIR}/tex/latex/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_dot.sty                  ${INSTALL_DIR}/tex/latex/markdown/
-cp ${BUILD_DIR}/markdownthemewitiko_graphicx_http.sty        ${INSTALL_DIR}/tex/latex/markdown/
 cp ${BUILD_DIR}/markdownthemewitiko_markdown_defaults.sty    ${INSTALL_DIR}/tex/latex/markdown/
 mkdir -p                                                     ${INSTALL_DIR}/tex/context/third/markdown/
 cp ${BUILD_DIR}/t-markdown.tex                               ${INSTALL_DIR}/tex/context/third/markdown/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 SHELL=/bin/bash
 
 AUXFILES=markdown.bbl markdown.cb markdown.cb2 markdown.glo markdown.bbl \
-  markdown.run.xml markdown.markdown.in markdown.markdown.lua \
+  markdown.hd markdown.run.xml markdown.markdown.in markdown.markdown.lua \
   markdown.markdown.out markdown-interfaces.md markdown-miscellanea.md \
   markdown-options.md markdown-tokens.md $(TECHNICAL_DOCUMENTATION_RESOURCES) \
   $(VERSION_FILE) $(RAW_DEPENDENCIES) markdown-unicode-data-generator.lua \
@@ -47,9 +47,9 @@ DOCUMENTATION=$(TECHNICAL_DOCUMENTATION) $(HTML_USER_MANUAL) $(ROOT_README) $(VE
   $(CHANGES_FILE) $(DEPENDENCIES)
 LIBRARIES=libraries/markdown-tinyyaml.lua
 INSTALLABLES=markdown.lua markdown-parser.lua markdown-cli.lua markdown-unicode-data.lua \
-  markdown.tex markdown.sty t-markdown.tex markdownthemewitiko_dot.sty \
-  markdownthemewitiko_graphicx_http.sty markdownthemewitiko_tilde.tex \
-  markdownthemewitiko_markdown_defaults.tex markdownthemewitiko_markdown_defaults.sty \
+  markdown.tex markdown.sty t-markdown.tex \
+  markdownthemewitiko_markdown_defaults.tex \
+  markdownthemewitiko_markdown_defaults.sty \
   t-markdownthemewitiko_markdown_defaults.tex
 EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES) \
   $(RAW_DEPENDENCIES)
@@ -231,12 +231,9 @@ $(TDSARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(INSTALLABLES) $(DOCUMENTATION) $(EXA
 	cp markdown.lua markdown-parser.lua markdown-unicode-data.lua $(LIBRARIES) \
 	  tex/luatex/markdown/
 	cp markdown-cli.lua scripts/markdown/
-	cp markdown.tex markdownthemewitiko_tilde.tex \
-	  markdownthemewitiko_markdown_defaults.tex tex/generic/markdown/
-	cp markdown.sty markdownthemewitiko_graphicx_http.sty markdownthemewitiko_dot.sty \
-	  markdownthemewitiko_markdown_defaults.sty tex/latex/markdown/
-	cp t-markdown.tex t-markdownthemewitiko_markdown_defaults.tex \
-	  tex/context/third/markdown/
+	cp markdown.tex markdownthemewitiko_markdown_defaults.tex tex/generic/markdown/
+	cp markdown.sty markdownthemewitiko_markdown_defaults.sty tex/latex/markdown/
+	cp t-markdown.tex t-markdownthemewitiko_markdown_defaults.tex tex/context/third/markdown/
 	@# Installing the documentation.
 	mkdir -p doc/generic/markdown doc/latex/markdown/examples \
 	  doc/context/third/markdown/examples doc/optex/markdown/examples

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34909,7 +34909,7 @@ function M.new(options)
       local salt = util.salt(options)
       local name = util.cache(options.cacheDir, input, salt, convert,
                               ".md.tex")
-      output = [[\input{]] .. name .. [[}\relax]]
+      output = [[\noexpand\input{]] .. name .. [[}\relax]]
 %    \end{macrocode}
 % \begin{markdown}
 % Otherwise, return the result of the conversion directly.

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23241,8 +23241,10 @@ beginning of a \LaTeX{} document.
 %</manual-options>
 %<*latex>
 %  \begin{macrocode}
+\ExplSyntaxOn
 \prop_new:N
   \g_@@_latex_built_in_themes_prop
+\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</latex>
@@ -23265,9 +23267,7 @@ Built-in \LaTeX{} themes provided with the Markdown package include:
 %<*latex>
 % \fi
 %  \begin{macrocode}
-\AtEndOfPackage{
-  \markdownLaTeXLoadedtrue
-}
+\AtEndOfPackage{\markdownLaTeXLoadedtrue}
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -23647,7 +23647,6 @@ following text:
     \@@_define_renderers:
     \@@_define_renderer_prototypes:
   }
-\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</context>
@@ -23696,6 +23695,7 @@ For example, to load a theme named `witiko/tilde` in your document:
 %  \begin{macrocode}
 \prop_new:N
   \g_@@_context_built_in_themes_prop
+\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</context>
@@ -37694,14 +37694,21 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\prop_gput:Nnn
-  \g_@@_latex_built_in_themes_prop
-  { witiko / dot }
+\tl_set:Nn
+  \l_tmpa_tl
   {
     \RequirePackage
       { graphicx }
     \markdownLoadPlainTeXTheme
   }
+\prop_gput:NnV
+  \g_@@_latex_built_in_themes_prop
+  { witiko / dot }
+  \l_tmpa_tl
+\prop_gput:NnV
+  \g_@@_latex_built_in_themes_prop
+  { witiko / graphicx / http }
+  \l_tmpa_tl
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -905,7 +905,6 @@ date:   \markdownVersion{} \markdownLastModified{}
 <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet" />
 
 % \fi
-% \par
 % \begin{markdown}
 
 Introduction
@@ -1072,7 +1071,6 @@ The file `markdown.tex` *must* be placed in a directory named `markdown`.
 %</manual>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 % Requirements
@@ -1102,7 +1100,6 @@ The file `markdown.tex` *must* be placed in a directory named `markdown`.
 %  \begin{macrocode}
 local lpeg = require("lpeg")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % \pkg{Selene Unicode}
@@ -1120,7 +1117,6 @@ local lpeg = require("lpeg")
 %  \begin{macrocode}
 local unicode = require("unicode")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % \pkg{MD5}
@@ -1172,7 +1168,6 @@ local md5 = require("md5")
   end
 end)()
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % All the abovelisted modules are statically linked into the current version of
@@ -1198,7 +1193,6 @@ hard lua-uni-algos
 %  \begin{macrocode}
 local uni_algos = require("lua-uni-algos")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % \pkg{api7/lua-tinyyaml}
@@ -1222,7 +1216,6 @@ local uni_algos = require("lua-uni-algos")
 %</depends>
 %<*tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### Plain \TeX{} Requirements {#tex-prerequisites}
@@ -1320,7 +1313,6 @@ hard lt3luabridge
 %</tex>
 %<*latex>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### \LaTeX{} Requirements {#latex-prerequisites}
@@ -1493,7 +1485,6 @@ soft verse
 %</depends>
 %<*context>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### \Hologo{ConTeXt} Prerequisites
@@ -1840,7 +1831,6 @@ Each part will be shown by example, leaving the implementation details to the
 %</manual>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 % Lua Interface {#luainterface}
@@ -1890,7 +1880,6 @@ local M = {metadata = metadata}
 %</lua,lua-loader,lua-unicode-data>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### Conversion from Markdown to Plain \TeX{} {#lua-conversion}
@@ -1959,7 +1948,6 @@ local walkable_syntax = {
   },
 }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamref{reader->insert_pattern} method inserts a \acro{peg} pattern into
@@ -2173,7 +2161,6 @@ local defaultOptions = {}
 %    \end{macrocode}
 % \begingroup
 % \markdownSetup{snippet=lua-options}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -2463,7 +2450,6 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
       }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % To make it easier to support different coding styles in the interface,
@@ -2494,7 +2480,6 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
       { #2 }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % To interrupt the \mref{\@\@_with_various_cases:nn} function
@@ -2548,7 +2533,6 @@ interfaces and all the way up to the \LaTeX{} and \Hologo{ConTeXt} interfaces.
 %### General Behavior
 %
 % \end{markdown}
-% \par
 % \iffalse
 
 #### Option `eagerCache`
@@ -2653,7 +2637,6 @@ Hello \markdownRendererEmphasis{world}!\relax
 %  \begin{macrocode}
 defaultOptions.eagerCache = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -2699,7 +2682,6 @@ defaultOptions.eagerCache = true
 %  \begin{macrocode}
 defaultOptions.experimental = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -2797,7 +2779,6 @@ local singletonCache = {
   options = nil,
 }
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua>
 %<*manual-options>
@@ -2842,7 +2823,6 @@ local singletonCache = {
 %  \begin{macrocode}
 defaultOptions.unicodeNormalization = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -2898,7 +2878,6 @@ defaultOptions.unicodeNormalization = true
 %  \begin{macrocode}
 defaultOptions.unicodeNormalizationForm = "nfc"
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -2908,7 +2887,6 @@ defaultOptions.unicodeNormalizationForm = "nfc"
 %### File and Directory Names
 %
 % \end{markdown}
-% \par
 % \iffalse
 
 #### Option `cacheDir`
@@ -3074,7 +3052,6 @@ option.
 %  \begin{macrocode}
 defaultOptions.cacheDir = "."
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -3238,7 +3215,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.contentBlocksLanguageMap = "markdown-languages.json"
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -3287,7 +3263,6 @@ defaultOptions.contentBlocksLanguageMap = "markdown-languages.json"
 %  \begin{macrocode}
 defaultOptions.debugExtensionsFileName = "debug-extensions.json"
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -3529,7 +3504,6 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 %  \begin{macrocode}
 defaultOptions.frozenCacheFileName = "frozenCache.tex"
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -3539,7 +3513,6 @@ defaultOptions.frozenCacheFileName = "frozenCache.tex"
 %### Parser Options
 %
 % \end{markdown}
-% \par
 % \iffalse
 
 #### Option `autoIdentifiers`
@@ -3586,7 +3559,6 @@ See also the option \Opt{gfmAutoIdentifiers}.
 %  \begin{macrocode}
 defaultOptions.autoIdentifiers = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -3810,7 +3782,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.blankBeforeBlockquote = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -4067,7 +4038,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.blankBeforeCodeFence = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -4150,7 +4120,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.blankBeforeDivFence = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -4390,7 +4359,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.blankBeforeHeading = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -4616,7 +4584,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.blankBeforeList = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -4712,7 +4679,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.bracketedSpans = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -4946,7 +4912,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.breakableBlockquotes = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5040,7 +5005,6 @@ following text, where the middot (`·`) denotes a non-breaking space:
 %  \begin{macrocode}
 defaultOptions.citationNbsps = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5143,7 +5107,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.citations = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5369,7 +5332,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.codeSpans = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5543,7 +5505,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.contentBlocks = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5680,7 +5641,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.contentLevel = "block"
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5835,7 +5795,6 @@ inserted to the grammar of markdown.
 %  \begin{macrocode}
 defaultOptions.debugExtensions = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -5974,7 +5933,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.definitionLists = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6020,7 +5978,6 @@ defaultOptions.definitionLists = false
 %  \begin{macrocode}
 defaultOptions.ensureJekyllData = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6144,7 +6101,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.expectJekyllData = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6295,7 +6251,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.extensions = {}
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6397,7 +6352,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.fancyLists = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6564,7 +6518,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.fencedCode = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6664,7 +6617,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.fencedCodeAttributes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6743,7 +6695,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.fencedDivs = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6907,7 +6858,6 @@ the markdown document from “Hello *world*!” to “Hi *world*!” was not ref
 %  \begin{macrocode}
 defaultOptions.finalizeCache = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -6976,7 +6926,6 @@ requested using the `frozenCacheCounter` option.
 %  \begin{macrocode}
 defaultOptions.frozenCacheCounter = 0
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7025,7 +6974,6 @@ See also the option \Opt{autoIdentifiers}.
 %  \begin{macrocode}
 defaultOptions.gfmAutoIdentifiers = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7156,7 +7104,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.hashEnumerators = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7205,7 +7152,6 @@ defaultOptions.hashEnumerators = false
 %  \begin{macrocode}
 defaultOptions.headerAttributes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7477,7 +7423,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.html = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7755,7 +7700,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.hybrid = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7851,7 +7795,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.inlineCodeAttributes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -7952,7 +7895,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.inlineNotes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8119,7 +8061,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.jekyllData = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8216,7 +8157,6 @@ image (from [Martin Scharrer's mwe package][mwe]) displayed at size 5cm × 4cm.
 %  \begin{macrocode}
 defaultOptions.linkAttributes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8351,7 +8291,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.lineBlocks = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8422,7 +8361,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.mark = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8585,7 +8523,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.notes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8694,7 +8631,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.pipeTables = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8734,7 +8670,6 @@ defaultOptions.pipeTables = false
 %  \begin{macrocode}
 defaultOptions.preserveTabs = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8829,7 +8764,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.rawAttribute = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -8918,7 +8852,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.relativeReferences = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9058,7 +8991,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.shiftHeadings = 0
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9276,7 +9208,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.slice = "^ $"
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9491,7 +9422,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.smartEllipses = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9627,7 +9557,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.startNumber = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9749,7 +9678,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.strikeThrough = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9862,7 +9790,6 @@ text “Hello *world*!”
 %  \begin{macrocode}
 defaultOptions.stripIndent = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -9954,7 +9881,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.subscripts = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10046,7 +9972,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.superscripts = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10171,7 +10096,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.tableAttributes = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10301,7 +10225,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.tableCaptions = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10414,7 +10337,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.taskLists = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10530,7 +10452,6 @@ text “Hello *world*!”
 %  \begin{macrocode}
 defaultOptions.texComments = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10741,7 +10662,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.texMathDollars = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -10952,7 +10872,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.texMathDoubleBackslash = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -11163,7 +11082,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.texMathSingleBackslash = false
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -11284,7 +11202,6 @@ following text:
 %  \begin{macrocode}
 defaultOptions.tightLists = true
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua,lua-cli,lua-loader>
 %<*manual-options>
@@ -11432,7 +11349,6 @@ defaultOptions.underscores = true
 %</lua,lua-cli,lua-loader>
 %<*lua-cli>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### Command-Line Interface {#lua-cli-interface}
@@ -11662,7 +11578,6 @@ for i = 1, #arg do
   ::continue::
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The command-line Lua interface is implemented by the `markdown-cli.lua`
@@ -11682,7 +11597,6 @@ end
 %</lua-cli>
 %<*tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % Plain \TeX{} Interface {#texinterface}
@@ -11755,7 +11669,6 @@ pdftex --shell-escape document.tex
 \def\markdownLastModified{(((LASTMODIFIED)))}%
 \def\markdownVersion{(((VERSION)))}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The plain \TeX{} interface is implemented by the `markdown.tex` file that can
@@ -11782,7 +11695,6 @@ pdftex --shell-escape document.tex
 \let\markdownBegin\relax
 \let\markdownEnd\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % You may prepend your own code to the \mref{markdownBegin} macro and redefine the
@@ -11838,7 +11750,6 @@ pdftex --shell-escape document.tex
 \let\yamlBegin\relax
 \def\yamlEnd{\markdownEnd\endgroup}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mref{yamlBegin} and \mref{yamlEnd} macros are subject to the same
@@ -11874,7 +11785,6 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \let\markinline\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The following example plain \TeX{} code showcases the usage of the
@@ -11912,7 +11822,6 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \let\markdownInput\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The macro \mref{markdownInput} is not subject to the limitations of the
@@ -11942,7 +11851,6 @@ pdftex --shell-escape document.tex
   \endgroup
 }%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The macro \mref{yamlInput} is also not subject to the limitations of the
@@ -11978,7 +11886,6 @@ pdftex --shell-escape document.tex
 %  \begin{macrocode}
 \let\markdownEscape\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Options {#tex-options}
@@ -12064,7 +11971,6 @@ following code in your plain \TeX{} document:
 %</manual-options>
 %<*tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The plain \TeX{} options may be also be specified via the \mdef{markdownSetup}
@@ -12115,7 +12021,6 @@ you would include the following code in your plain \TeX{} document:
 %</manual-options>
 %<*tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The
@@ -12250,7 +12155,6 @@ For more information, see the examples for the \Opt{finalizeCache} option.
   { path }
   { \jobname.markdown.in }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownOptionOutputDir} macro sets the path to the directory that
@@ -13128,7 +13032,6 @@ a specific look and other high-level goals without low-level programming.
 %</tex>
 %<*manual-options>
 % \fi
-% \par
 % \markdownBegin
 
 Built-in plain \TeX{} themes provided with the Markdown package include:
@@ -13262,7 +13165,6 @@ conference article:
 > <http://ceur-ws.org/Vol-2696/paper_235.pdf>
 
 % \fi
-% \par
 % \markdownBegin
 
 \pkg{witiko/graphicx/http}
@@ -13316,7 +13218,6 @@ following image:
                                                   "Figure 1: The banner of the Markdown package")
 
 % \fi
-% \par
 % \begin{markdown}
 
 \pkg{witiko/tilde}
@@ -13359,7 +13260,6 @@ following text, where the middot (`·`) denotes a non-breaking space:
 > Bartel·Leendert van·der·Waerden
 
 % \fi
-% \par
 % \begin{markdown}
 
 \pkg{witiko/markdown/defaults}
@@ -13387,7 +13287,6 @@ options locally.
 %</manual-options>
 %<*tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % We may set up options as *snippets* using the
@@ -13519,7 +13418,6 @@ options locally.
 %</tex>
 %<*manual-options>
 % \fi
-% \par
 % \markdownBegin
 
 Here is how we can use snippets to store options and invoke them later
@@ -13789,7 +13687,6 @@ In this section, I will describe the individual token renderers.
 \prop_new:N \g_@@_renderer_arities_prop
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -13929,7 +13826,6 @@ following text:
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -13965,7 +13861,6 @@ a block quote. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14113,7 +14008,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14197,7 +14091,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14234,7 +14127,6 @@ list is not tight). The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14271,7 +14163,6 @@ is disabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14306,7 +14197,6 @@ list. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14341,7 +14231,6 @@ bulleted list. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14377,7 +14266,6 @@ tight). The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14616,7 +14504,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14716,7 +14603,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14810,7 +14696,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14847,7 +14732,6 @@ filename of a file containing the code block contents.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -14968,7 +14852,6 @@ following text except for the filename, which may differ:
   { 3 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15121,7 +15004,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15206,7 +15088,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15246,7 +15127,6 @@ and the title of the content block.
   { 4 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15282,7 +15162,6 @@ as \mref{markdownRendererContentBlock}.
   { 4 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15480,7 +15359,6 @@ following text:
   { 5 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15520,7 +15398,6 @@ list is not tight). The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15557,7 +15434,6 @@ list is tight). This macro will only be produced, when the
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15593,7 +15469,6 @@ being defined.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15628,7 +15503,6 @@ definitions for a single term.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15664,7 +15538,6 @@ a single term.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15700,7 +15573,6 @@ single term.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -15736,7 +15608,6 @@ tight). The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16108,7 +15979,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16222,7 +16092,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16259,7 +16128,6 @@ span of text.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16381,7 +16249,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16484,7 +16351,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16608,7 +16474,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16715,7 +16580,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16751,7 +16615,6 @@ The macro receives a single argument that corresponds to the heading text.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16787,7 +16650,6 @@ text.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16823,7 +16685,6 @@ text.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16859,7 +16720,6 @@ text.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -16895,7 +16755,6 @@ text.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17032,7 +16891,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17108,7 +16966,6 @@ The horizontal margins should contain the following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17200,7 +17057,6 @@ following body text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17293,7 +17149,6 @@ that the \TeX{} engine has shell access.
   { 4 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17378,7 +17233,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17516,7 +17370,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17594,7 +17447,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17729,7 +17581,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17840,7 +17691,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -17951,7 +17801,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18078,7 +17927,6 @@ following text:
   { 4 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18163,7 +18011,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18233,7 +18080,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18390,7 +18236,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18478,7 +18323,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18599,7 +18443,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18637,7 +18480,6 @@ option is disabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18675,7 +18517,6 @@ receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18715,7 +18556,6 @@ and the style of delimiters between list item labels and texts (`Default`,
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18755,7 +18595,6 @@ the valid style values.
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18792,7 +18631,6 @@ arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18828,7 +18666,6 @@ option is disabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18865,7 +18702,6 @@ receives a single numeric argument that corresponds to the item number.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18902,7 +18738,6 @@ no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18938,7 +18773,6 @@ option is enabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -18975,7 +18809,6 @@ argument that corresponds to the item number.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19012,7 +18845,6 @@ disabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19050,7 +18882,6 @@ arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19087,7 +18918,6 @@ option is enabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19381,7 +19211,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19420,7 +19249,6 @@ option is enabled.
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19505,7 +19333,6 @@ following text:
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19553,7 +19380,6 @@ macros represent the beginning and the end of a section based on headings.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19589,7 +19415,6 @@ and U+FFFD Unicode characters. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19837,7 +19662,6 @@ following text, where the middot (`·`) denotes a non-breaking space:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -19950,7 +19774,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20060,7 +19883,6 @@ following text:
   { subscript }
   { 1 }
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20171,7 +19993,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20295,7 +20116,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20425,7 +20245,6 @@ following text:
   { 3 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20561,7 +20380,6 @@ following text:
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20691,7 +20509,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20812,7 +20629,6 @@ following text:
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20871,7 +20687,6 @@ receive four parameters:
   { 4 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20909,7 +20724,6 @@ option is enabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20945,7 +20759,6 @@ The \mdef{markdownRendererJekyllDataEnd} macro represents the end of a
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -20983,7 +20796,6 @@ arguments: the scalar key in the parent structure, cast to a string following
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21019,7 +20831,6 @@ when the \Opt{jekyllData} option is enabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21057,7 +20868,6 @@ arguments: the scalar key in the parent structure, cast to a string following
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21093,7 +20903,6 @@ when the \Opt{jekyllData} option is enabled. The macro receives no arguments.
   { 0 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21131,7 +20940,6 @@ following \acro{yaml} serialization rules.
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21169,7 +20977,6 @@ following \acro{yaml} serialization rules.
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21231,7 +21038,6 @@ for identifiers and other programmatic text that won't be typeset by \TeX{}.
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21317,7 +21123,6 @@ removed in Markdown 4.0.0.
   { 2 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21359,7 +21164,6 @@ serialization rules.
   { 1 }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 %
 % \iffalse
 %</tex>
@@ -21565,7 +21369,6 @@ following text:
         },
       }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the token renderer macro has been deprecated, we undefine it.
@@ -21584,7 +21387,6 @@ following text:
       }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % We define the function \mdef{@@_tl_set_from_cs:NNn}
@@ -21657,7 +21459,6 @@ following text:
     },
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The following example code showcases a possible configuration of the
@@ -21686,7 +21487,6 @@ following text:
   {
     unknown .code:n = {
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Besides defining renderers at once, we can also define them incrementally
@@ -21748,7 +21548,6 @@ following text:
             \g_@@_appending_renderer_bool
         }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % In addition to exact token renderer names, we also support wildcards (`*`)
@@ -22335,7 +22134,6 @@ following text:
         },
       }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Unless the token renderer prototype macro has already been defined or unless,
@@ -22365,7 +22163,6 @@ following text:
   \@@_define_renderer_prototype:nNn
   { ncV }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The following example code showcases a possible configuration of the
@@ -22387,7 +22184,6 @@ following text:
   {
     unknown .code:n = {
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Besides defining renderer prototypes at once, we can also define them
@@ -22449,7 +22245,6 @@ following text:
             \g_@@_appending_renderer_prototype_bool
         }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % In addition to exact token renderer prototype names, we also support
@@ -22601,7 +22396,6 @@ following text:
 %  \begin{macrocode}
 \let\markdownMakeOther\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownReadAndConvert} macro implements the \mref{markdownBegin}
@@ -22660,7 +22454,6 @@ following text:
 % \iffalse
 %</tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % \LaTeX{} Interface {#latexinterface}
@@ -22772,7 +22565,6 @@ pdflatex --shell-escape document.tex
 % \Hologo{LaTeX2e} parses package options.
 %
 % \end{markdown}
-% \par
 % \begin{markdown}
 %
 %### Typesetting Markdown
@@ -23150,7 +22942,6 @@ document:
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The following example \LaTeX{} code showcases a possible configuration of
@@ -23212,7 +23003,6 @@ For example, to load themes named `witiko/beamer/MU` and `witiko/dot`, you
 would use the following code in the preamble of your document:
 
 % \fi
-% \par
 % \begin{markdown}
 
 ``` tex
@@ -23235,7 +23025,6 @@ would use the following code in the preamble of your document:
 %</latex>
 %<*manual-options>
 % \fi
-% \par
 % \begin{markdown}
 
 Due to limitations of \LaTeX{}, themes may not be loaded after the
@@ -23260,7 +23049,6 @@ beginning of a \LaTeX{} document.
 %</latex>
 %<*manual-options>
 % \fi
-% \par
 % \begin{markdown}
 
 Built-in \LaTeX{} themes provided with the Markdown package include:
@@ -23319,7 +23107,6 @@ Built-in \LaTeX{} themes provided with the Markdown package include:
 %</latex>
 %<*context>
 % \fi
-% \par
 % \begin{markdown}
 %
 % Please, see Section <#sec:latex-themes-implementation> for implementation
@@ -23415,7 +23202,6 @@ following text:
   \do\#\do\^\do\_\do\%\do\~}%
 \input markdown/markdown
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \Hologo{ConTeXt} interface is implemented by the
@@ -23443,7 +23229,6 @@ following text:
 \let\startmarkdown\relax
 \let\stopmarkdown\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % You may prepend your own code to the \mref{startmarkdown} macro and redefine the
@@ -23473,7 +23258,6 @@ following text:
 \let\startyaml\relax
 \let\stopyaml\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % You may prepend your own code to the \mref{startyaml} macro and append your
@@ -23518,7 +23302,6 @@ following text:
 %  \begin{macrocode}
 \let\inputmarkdown\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Furthermore, the \mref{inputmarkdown} macro also accepts \Hologo{ConTeXt}
@@ -23552,7 +23335,6 @@ following text:
 %  \begin{macrocode}
 \let\inputyaml\relax
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Furthermore, the \mref{inputyaml} macro also accepts \Hologo{ConTeXt}
@@ -23786,7 +23568,6 @@ local P, R, S, V, C, Cg, Cb, Cmt, Cc, Ct, B, Cs, Cp, any =
   lpeg.P, lpeg.R, lpeg.S, lpeg.V, lpeg.C, lpeg.Cg, lpeg.Cb,
   lpeg.Cmt, lpeg.Cc, lpeg.Ct, lpeg.B, lpeg.Cs, lpeg.Cp, lpeg.P(1)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Utility Functions
@@ -23807,7 +23588,6 @@ local util = {}
 %</lua,lua-loader>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.err} method prints an error message `msg` and exits.
@@ -23825,7 +23605,6 @@ end
 %</lua>
 %<*lua,lua-loader>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.cache} method used `dir`, `string`, `salt`, and `suffix`
@@ -23856,7 +23635,6 @@ end
 %</lua,lua-loader>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.cache_verbatim} method strips whitespaces from the
@@ -23870,7 +23648,6 @@ function util.cache_verbatim(dir, string)
   return name
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.table_copy} method creates a shallow copy of a table `t`
@@ -23884,7 +23661,6 @@ function util.table_copy(t)
   return setmetatable(u, getmetatable(t))
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.encode_json_string} method encodes a string `s` in
@@ -23898,7 +23674,6 @@ function util.encode_json_string(s)
   return [["]] .. s .. [["]]
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.expand_tabs_in_line} expands tabs in string `s`. If
@@ -23918,7 +23693,6 @@ function util.expand_tabs_in_line(s, tabstop)
           end))
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.walk} method walks a rope `t`, applying a function `f`
@@ -23951,7 +23725,6 @@ function util.walk(t, f)
   end
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.flatten} method flattens an array `ary` that does not
@@ -23973,7 +23746,6 @@ function util.flatten(ary)
   return new
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.rope_to_string} method converts a rope `rope` to a
@@ -23988,7 +23760,6 @@ function util.rope_to_string(rope)
   return table.concat(buffer)
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.rope_last} method retrieves the last item in a rope. For
@@ -24009,7 +23780,6 @@ function util.rope_last(rope)
   end
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given an array `ary` and a string `x`, the \luamdef{util.intersperse}
@@ -24031,7 +23801,6 @@ function util.intersperse(ary, x)
   return new
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given an array `ary` and a function `f`, the \luamdef{util.map} method
@@ -24048,7 +23817,6 @@ function util.map(ary, f)
   return new
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given a table `char_escapes` mapping escapable characters to escaped
@@ -24118,7 +23886,6 @@ end
 %</lua>
 %<*lua,lua-loader>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.pathname} method produces a pathname out of a directory
@@ -24134,7 +23901,6 @@ function util.pathname(dir, file)
   end
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.salt} method produces cryptographic salt out of a table of
@@ -24167,7 +23933,6 @@ function util.salt(options)
   return salt
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{util.warning} method produces a warning `s` that is unrelated to
@@ -24184,7 +23949,6 @@ end
 %</lua,lua-loader>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### HTML Entities
@@ -26325,7 +26089,6 @@ local character_entities = {
   ["zopf"] = 120171,
 }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given a string `s` of decimal digits, the \luamdef{entities.dec_entity}
@@ -26341,7 +26104,6 @@ function entities.dec_entity(s)
   return unicode.utf8.char(n)
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given a string `s` of hexadecimal digits, the
@@ -26358,7 +26120,6 @@ function entities.hex_entity(s)
   return unicode.utf8.char(n)
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given a captured character `x` and a string `s` of hexadecimal digits, the
@@ -26375,7 +26136,6 @@ function entities.hex_entity_with_x_char(x, s)
   return unicode.utf8.char(n)
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Given a character entity name `s` (like `ouml`), the
@@ -26399,7 +26159,6 @@ function entities.char_entity(s)
   return table.concat(char_table)
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Plain \TeX{} Writer {#tex-writer}
@@ -26420,7 +26179,6 @@ end
 %  \begin{macrocode}
 M.writer = {}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{writer.new} method creates and returns a new \TeX{} writer
@@ -26438,7 +26196,6 @@ M.writer = {}
 function M.writer.new(options)
   local self = {}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Make `options` available as \luamdef{writer->options}, so that it is
@@ -26448,7 +26205,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   self.options = options
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->flatten\_inlines}, which indicates whether or not the
@@ -26460,7 +26216,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   self.flatten_inlines = false
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Parse the \Opt{slice} option and define \luamdef{writer->slice\_begin},
@@ -26500,7 +26255,6 @@ function M.writer.new(options)
     self.is_writing = false
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->space} as the output format of a space character.
@@ -26509,7 +26263,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   self.space = " "
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->nbsp} as the output format of a non-breaking space
@@ -26519,7 +26272,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   self.nbsp = "\\markdownRendererNbsp{}"
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->plain} as a function that will transform an input
@@ -26531,7 +26283,6 @@ function M.writer.new(options)
     return s
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->paragraph} as a function that will transform an
@@ -26544,7 +26295,6 @@ function M.writer.new(options)
     return s
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->interblocksep} as the output format of a block
@@ -26558,7 +26308,6 @@ function M.writer.new(options)
     return self.interblocksep_text
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->paragraphsep} as the output format of a paragraph
@@ -26574,7 +26323,6 @@ function M.writer.new(options)
     return self.paragraphsep_text
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->undosep} as a function that will remove the output
@@ -26588,7 +26336,6 @@ function M.writer.new(options)
     return self.undosep_text
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->soft_line_break} as the output format of a soft
@@ -26601,7 +26348,6 @@ function M.writer.new(options)
     return "\\markdownRendererSoftLineBreak\n{}"
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->hard_line_break} as the output format of a hard
@@ -26614,7 +26360,6 @@ function M.writer.new(options)
     return "\\markdownRendererHardLineBreak\n{}"
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->ellipsis} as the output format of an ellipsis.
@@ -26623,7 +26368,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   self.ellipsis = "\\markdownRendererEllipsis{}"
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->thematic_break} as the output format of a thematic
@@ -26636,7 +26380,6 @@ function M.writer.new(options)
     return "\\markdownRendererThematicBreak{}"
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define tables \luamdef{writer->escaped_uri_chars} and
@@ -26663,7 +26406,6 @@ function M.writer.new(options)
       = "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define table \luamdef{writer->escaped_strings} containing the mapping from
@@ -26674,7 +26416,6 @@ function M.writer.new(options)
   self.escaped_strings = util.table_copy(self.escaped_minimal_strings)
   self.escaped_strings[entities.hex_entity('00A0')] = self.nbsp
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define a table \luamdef{writer->escaped_chars} containing the mapping from
@@ -26699,7 +26440,6 @@ function M.writer.new(options)
       = "\\markdownRendererReplacementCharacter{}",
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Use the \luamref{writer->escaped_chars}, \luamref{writer->escaped_uri_chars},
@@ -26724,7 +26464,6 @@ function M.writer.new(options)
   local escape_minimal = create_escaper(
     {}, self.escaped_minimal_strings)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define the following semantic aliases for the escaper functions:
@@ -26755,7 +26494,6 @@ function M.writer.new(options)
     self.infostring = escape_programmatic_text
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->warning} as a function that will transform an input
@@ -26769,7 +26507,6 @@ function M.writer.new(options)
             escape_minimal(m or ""), "}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->error} as a function that will transform an input
@@ -26783,7 +26520,6 @@ function M.writer.new(options)
             escape_minimal(m or ""), "}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->code} as a function that will transform an input
@@ -26809,7 +26545,6 @@ function M.writer.new(options)
     return buf
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->link} as a function that will transform an input
@@ -26838,7 +26573,6 @@ function M.writer.new(options)
     return buf
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->image} as a function that will transform an input
@@ -26867,7 +26601,6 @@ function M.writer.new(options)
     return buf
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->bulletlist} as a function that will transform an input
@@ -26907,7 +26640,6 @@ function M.writer.new(options)
             "\\markdownRendererUlItemEnd "}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->orderedlist} as a function that will transform an
@@ -26959,7 +26691,6 @@ function M.writer.new(options)
     end
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->inline_html_comment} as a function that will
@@ -26973,7 +26704,6 @@ function M.writer.new(options)
     return {"\\markdownRendererInlineHtmlComment{",contents,"}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->inline_html_tag} as a function that will
@@ -26989,7 +26719,6 @@ function M.writer.new(options)
             self.string(contents),"}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->block_html_element} as a function that will
@@ -27004,7 +26733,6 @@ function M.writer.new(options)
     return {"\\markdownRendererInputBlockHtmlElement{",name,"}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->emphasis} as a function that will transform an
@@ -27017,7 +26745,6 @@ function M.writer.new(options)
     return {"\\markdownRendererEmphasis{",s,"}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->tickbox} as a function that will transform a
@@ -27035,7 +26762,6 @@ function M.writer.new(options)
     end
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->strong} as a function that will transform a strongly
@@ -27048,7 +26774,6 @@ function M.writer.new(options)
     return {"\\markdownRendererStrongEmphasis{",s,"}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->blockquote} as a function that will transform an
@@ -27062,7 +26787,6 @@ function M.writer.new(options)
       "\\markdownRendererBlockQuoteEnd "}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->verbatim} as a function that will transform an
@@ -27077,7 +26801,6 @@ function M.writer.new(options)
     return {"\\markdownRendererInputVerbatim{",name,"}"}
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->document} as a function that will transform a
@@ -27112,7 +26835,6 @@ function M.writer.new(options)
     return buf
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->attributes} as a function that will transform
@@ -27222,7 +26944,6 @@ function M.writer.new(options)
     return buf
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->active\_attributes} as a stack of block-level
@@ -27233,7 +26954,6 @@ function M.writer.new(options)
 %  \begin{macrocode}
   self.active_attributes = {}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->attribute\_type\_levels} as a hash table that
@@ -27246,7 +26966,6 @@ function M.writer.new(options)
   setmetatable(self.attribute_type_levels,
                { __index = function() return 0 end })
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->push\_attributes} and
@@ -27504,7 +27223,6 @@ function M.writer.new(options)
     return identifier
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->heading} as a function that will transform an
@@ -27592,7 +27310,6 @@ function M.writer.new(options)
     return buf
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->get_state} as a function that returns the current
@@ -27609,7 +27326,6 @@ function M.writer.new(options)
     }
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->set_state} as a function that restores the input
@@ -27625,7 +27341,6 @@ function M.writer.new(options)
     return previous_state
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->defer_call} as a function that will encapsulate the
@@ -27647,7 +27362,6 @@ function M.writer.new(options)
   return self
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Parsers
@@ -27658,7 +27372,6 @@ end
 %  \begin{macrocode}
 local parsers                  = {}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Basic Parsers
@@ -27720,7 +27433,6 @@ parsers.internal_punctuation   = S(":;,.?")
 parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua>
 %<*lua-unicode-data-generator>
@@ -27749,7 +27461,6 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
   local file = assert(io.open(pathname, "r"),
     [[Could not open file "UnicodeData.txt"]])
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % In order to minimize the size and speed of the parser, we will first
@@ -27783,7 +27494,6 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
   assert(file:close())
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Next, we will construct a parser out of the prefix tree.
@@ -27849,7 +27559,6 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 end)()
 print("return M")
 %    \end{macrocode}
-% \par
 % \iffalse
 %</lua-unicode-data-generator>
 %<*lua>
@@ -27906,7 +27615,6 @@ parsers.spnl                   = parsers.optionalspace
 parsers.line                   = parsers.linechar^0 * parsers.newline
 parsers.nonemptyline           = parsers.line - parsers.blankline
 %    \end{macrocode}
-%   \par
 % \begin{markdown}
 %
 %#### Parsers Used for Indentation
@@ -28886,7 +28594,6 @@ parsers.indented_blocks = function(bl)
          * (parsers.blankline^1 + parsers.eof) )
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for HTML Entities
@@ -28911,7 +28618,6 @@ parsers.html_entities
   + parsers.decentity / entities.dec_entity
   + parsers.tagentity / entities.char_entity
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for Markdown Lists
@@ -28941,7 +28647,6 @@ parsers.halfticked_box = tickbox(S("./")) * Cc(0.5)
 parsers.unticked_box = tickbox(parsers.spacechar^1) * Cc(0.0)
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for Markdown Code Spans
@@ -28975,7 +28680,6 @@ parsers.inticks = parsers.openticks
                 * parsers.closeticks
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for HTML
@@ -29394,7 +29098,6 @@ parsers.html_inline_tags  = parsers.html_inline_comment_full
                           + parsers.html_any_close_tag
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for Markdown Tags and Links
@@ -29583,7 +29286,6 @@ parsers.optionaltitle
   = parsers.spnlc * parsers.title * parsers.spacechar^0 + Cc("")
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Helpers for Links and Link Reference Definitions
@@ -29598,7 +29300,6 @@ parsers.define_reference_parser = (parsers.check_trail / "")
                                   * parsers.only_blank
                                   + Cc("") * parsers.only_blank)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Inline Elements
@@ -29617,7 +29318,6 @@ parsers.between = function(p, starter, ender)
 end
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Block Elements
@@ -29634,7 +29334,6 @@ parsers.thematic_break_lines = parsers.lineof(parsers.asterisk)
                              + parsers.lineof(parsers.dash)
                              + parsers.lineof(parsers.underscore)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Headings
@@ -29665,7 +29364,6 @@ parsers.atx_heading = parsers.check_trail_no_rem
                       + parsers.spacechar^1
                       * C(parsers.line))
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Markdown Reader {#markdown-reader}
@@ -29691,7 +29389,6 @@ M.reader = {}
 function M.reader.new(writer, options)
   local self = {}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Make the `writer` and `options` parameters available as
@@ -29703,7 +29400,6 @@ function M.reader.new(writer, options)
   self.writer = writer
   self.options = options
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Create a \luamdef{reader->parsers} hash table that stores \acro{peg} patterns
@@ -29731,7 +29427,6 @@ function M.reader.new(writer, options)
 %  \begin{macrocode}
   local parsers = self.parsers
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Top-Level Helper Functions
@@ -29749,7 +29444,6 @@ function M.reader.new(writer, options)
     return tag
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{iterlines} as a function that iterates over the lines of
@@ -29763,7 +29457,6 @@ function M.reader.new(writer, options)
     return util.rope_to_string(rope)
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{expandtabs} either as an identity function, when the
@@ -29784,7 +29477,6 @@ function M.reader.new(writer, options)
                       end
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### High-Level Parser Functions
@@ -29802,7 +29494,6 @@ function M.reader.new(writer, options)
   self.create_parser = function(name, grammar, toplevel)
     self.parser_functions[name] = function(str)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the parser function is top-level and the \Opt{stripIndent} Lua option is
@@ -29833,7 +29524,6 @@ function M.reader.new(writer, options)
           str = str:gsub('^' .. min_prefix, '')
       end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the parser is top-level and the \Opt{texComments} or \Opt{hybrid} Lua
@@ -29893,7 +29583,6 @@ function M.reader.new(writer, options)
                       return parsers.inlines_no_link_or_emphasis
                     end, false)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for Indentation (local)
@@ -30037,7 +29726,6 @@ function M.reader.new(writer, options)
   end
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for Markdown Lists (local)
@@ -30074,7 +29762,6 @@ function M.reader.new(writer, options)
                   + parsers.enumerator(parsers.rparent)
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Parsers Used for Blockquotes (local)
@@ -30098,7 +29785,6 @@ function M.reader.new(writer, options)
       * remove_indent("bq")
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Helpers for Emphasis and Strong Emphasis (local)
@@ -30484,7 +30170,6 @@ function M.reader.new(writer, options)
                       + parsers.emph_capturing_close
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Helpers for Links and Link Reference Definitions (local)
@@ -30498,7 +30183,6 @@ function M.reader.new(writer, options)
   parsers.rawnotes = {}
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{reader->register_link} method registers
@@ -30522,7 +30206,6 @@ function M.reader.new(writer, options)
   end
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{reader->lookup_reference} method looks up a
@@ -30535,7 +30218,6 @@ function M.reader.new(writer, options)
   end
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{reader->lookup_note_reference} method looks up a
@@ -31178,7 +30860,6 @@ function M.reader.new(writer, options)
   end
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Inline Elements (local)
@@ -31322,7 +31003,6 @@ function M.reader.new(writer, options)
                                         / writer.nbsp
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{reader->auto_link_url} method produces an
@@ -31337,7 +31017,6 @@ function self.auto_link_url(url, attributes)
                      url, nil, attributes)
 end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{reader->auto_link_email} method produces an
@@ -31381,7 +31060,6 @@ end
 
   parsers.HtmlEntity = parsers.html_entities / writer.string
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Block Elements (local)
@@ -31429,7 +31107,6 @@ end
   parsers.Plain        = parsers.nonindentspace * Ct(parsers.Inline^1)
                        / writer.plain
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Lists (local)
@@ -31594,7 +31271,6 @@ end
   parsers.OrderedList = parsers.OrderedListOfType(parsers.period)
                       + parsers.OrderedListOfType(parsers.rparent)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Blank (local)
@@ -31604,7 +31280,6 @@ end
   parsers.Blank        = parsers.blankline / ""
                        + V("Reference")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Headings (local)
@@ -31660,7 +31335,6 @@ end
 
   parsers.Heading = parsers.AtxHeading + parsers.SetextHeading
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Syntax Specification
@@ -31693,7 +31367,6 @@ end
       return local_walkable_syntax
     end)(walkable_syntax)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamref{reader->insert_pattern} method adds a pattern to
@@ -31750,7 +31423,6 @@ end
       end
     end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Create a local \luamdef{syntax} hash table that stores those rules of the
@@ -31766,7 +31438,6 @@ end
                * V("ExpectedJekyllData")
                * V("Blank")^0
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Only create interblock separators between pairs of blocks that are not
@@ -31844,7 +31515,6 @@ end
         InitializeState    = parsers.succeed,
       }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamref{reader->update_rule} as a function that receives two
@@ -31876,7 +31546,6 @@ end
       end
       local pattern
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Instead of a function, a \acro{peg} pattern `pattern` may also be
@@ -31905,7 +31574,6 @@ end
       walkable_syntax[rule_name] = { accountable_pattern }
     end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define a hash table of all characters with special meaning and add method
@@ -31927,7 +31595,6 @@ end
     self.add_special_character("!")
     self.add_special_character("\\")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Add method \luamdef{reader->initialize_named_group} that defines named groups
@@ -31944,7 +31611,6 @@ end
                              * Cg(pattern, name)
     end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Add a named group for indentation.
@@ -31953,7 +31619,6 @@ end
 %  \begin{macrocode}
     self.initialize_named_group("indent_info")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Apply syntax extensions.
@@ -31967,7 +31632,6 @@ end
     end
     current_extension_name = nil
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the \Opt{debugExtensions} option is enabled, serialize
@@ -32027,7 +31691,6 @@ end
       assert(output_file:close())
     end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Materialize \luamref{walkable_syntax} and merge it into \luamref{syntax} to
@@ -32064,7 +31727,6 @@ end
       end
     end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Finalize the parser by reacting to options and by producing special parsers
@@ -32150,7 +31812,6 @@ end
     parsers.inlines_no_link_or_emphasis
       = Ct(inlines_no_link_or_emphasis_t)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Return a function that converts markdown string `input` into a plain \TeX{}
@@ -32284,7 +31945,6 @@ M.extensions.bracketed_spans = function()
     name = "built-in bracketed_spans syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->span} as a function that will transform an input
@@ -32346,7 +32006,6 @@ M.extensions.citations = function(citation_nbsps)
     name = "built-in citations syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->citations} as a function that will transform an
@@ -32556,7 +32215,6 @@ end
 %  \begin{macrocode}
 M.extensions.content_blocks = function(language_map)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \luamdef{languages_json} table maps programming language filename
@@ -32594,7 +32252,6 @@ M.extensions.content_blocks = function(language_map)
     name = "built-in content_blocks syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->contentblock} as a function that will transform an
@@ -32724,7 +32381,6 @@ M.extensions.definition_lists = function(tight_lists)
     name = "built-in definition_lists syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->definitionlist} as a function that will transform an
@@ -32843,7 +32499,6 @@ M.extensions.fancy_lists = function()
       local options = self.options
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->fancylist} as a function that will transform an
@@ -33144,7 +32799,6 @@ M.extensions.fenced_code = function(blank_before_code_fence,
       local options = self.options
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->fencedCode} as a function that will transform an
@@ -33174,7 +32828,6 @@ M.extensions.fenced_code = function(blank_before_code_fence,
       end
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->rawBlock} as a function that will transform an
@@ -33395,7 +33048,6 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
     name = "built-in fenced_divs syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->div_begin} as a function that will transform the
@@ -33414,7 +33066,6 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
           "div", attributes, start_output, end_output)
       end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->div_end} as a function that will produce the end of a
@@ -33429,7 +33080,6 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       local parsers = self.parsers
       local writer = self.writer
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define basic patterns for matching the opening and the closing tag of a div.
@@ -33455,7 +33105,6 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
                            * parsers.optionalspace
                            * (parsers.newline + parsers.eof)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Initialize a named group named `fenced_div_level` for tracking how deep
@@ -33568,7 +33217,6 @@ M.extensions.fenced_divs = function(blank_before_div_fence)
       self.add_special_character(":")
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the `blank_before_div_fence` parameter is `false`, we will have the
@@ -33744,7 +33392,6 @@ M.extensions.line_blocks = function()
     name = "built-in line_blocks syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->lineblock} as a function that will transform
@@ -33802,7 +33449,6 @@ M.extensions.mark = function()
     name = "built-in mark syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->mark} as a function that will transform an input
@@ -33949,7 +33595,6 @@ M.extensions.notes = function(notes, inline_notes)
     name = "built-in notes syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->note} as a function that will transform an
@@ -34118,7 +33763,6 @@ M.extensions.pipe_tables = function(table_captions, table_attributes)
     name = "built-in pipe_tables syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->table} as a function that will transform an input
@@ -34280,7 +33924,6 @@ M.extensions.raw_inline = function()
       local options = self.options
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->rawInline} as a function that will transform an
@@ -34322,7 +33965,6 @@ M.extensions.strike_through = function()
     name = "built-in strike_through syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->strike_through} as a function that will transform
@@ -34365,7 +34007,6 @@ M.extensions.subscripts = function()
     name = "built-in subscripts syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->subscript} as a function that will transform
@@ -34407,7 +34048,6 @@ M.extensions.superscripts = function()
     name = "built-in superscripts syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->superscript} as a function that will transform
@@ -34452,7 +34092,6 @@ M.extensions.tex_math = function(tex_math_dollars,
     name = "built-in tex_math syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->display_math} as a function that will transform
@@ -34675,7 +34314,6 @@ M.extensions.jekyll_data = function(expect_jekyll_data,
     name = "built-in jekyll_data syntax extension",
     extend_writer = function(self)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Define \luamdef{writer->jekyllData} as a function that will transform an
@@ -34881,7 +34519,6 @@ end
 %  \begin{macrocode}
 function M.new(options)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Make the `options` table inherit from the \luamref{defaultOptions} table.
@@ -34892,7 +34529,6 @@ function M.new(options)
   setmetatable(options, { __index = function (_, key)
     return defaultOptions[key] end })
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Return a conversion function that tries to produce a cached conversion output
@@ -34906,7 +34542,6 @@ function M.new(options)
     local function convert(input)
       if parser_convert == nil then
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Lazy-load `markdown-parser.lua` and check that it originates from the same
@@ -34978,7 +34613,6 @@ end
 %</lua-loader>
 %<*lua>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The \luamref{new} function from file `markdown-parser.lua` returns a
@@ -34989,7 +34623,6 @@ end
 %  \begin{macrocode}
 function M.new(options)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Make the `options` table inherit from the \luamref{defaultOptions} table.
@@ -35000,7 +34633,6 @@ function M.new(options)
   setmetatable(options, { __index = function (_, key)
     return defaultOptions[key] end })
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the singleton cache contains a conversion function for the same `options`,
@@ -35032,7 +34664,6 @@ function M.new(options)
   end
   ::miss::
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Apply built-in syntax extensions based on `options`.
@@ -35158,7 +34789,6 @@ function M.new(options)
     table.insert(extensions, fancy_lists_extension)
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Apply user-defined syntax extensions based on `options.extensions`.
@@ -35258,7 +34888,6 @@ function M.new(options)
     table.insert(extensions, user_extension)
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Produce a conversion function from markdown to plain \TeX.
@@ -35269,7 +34898,6 @@ function M.new(options)
   local reader = M.reader.new(writer, options)
   local convert = reader.finalize_grammar(extensions)
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Force garbage collection to reclaim memory for temporary
@@ -35280,7 +34908,6 @@ function M.new(options)
 %  \begin{macrocode}
   collectgarbage("collect")
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Update the singleton cache.
@@ -35299,7 +34926,6 @@ function M.new(options)
     singletonCache.convert = convert
   end
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Return the conversion function from markdown to plain \TeX.
@@ -35320,7 +34946,6 @@ return M
 %</lua,lua-loader>
 %<*lua-cli>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### Command-Line Implementation {#lua-cli-implementation}
@@ -35403,7 +35028,6 @@ end
 %</lua-cli>
 %<*tex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % Plain \TeX{} Implementation {#teximplementation}
@@ -35476,7 +35100,6 @@ end
   { nnee }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Themes {#themes-implementation}
@@ -36119,7 +35742,6 @@ end
 \def\markdownRendererErrorPrototype#1#2#3#4{%
   \markdownError{#2}{#4}}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Raw Attributes
@@ -36167,7 +35789,6 @@ end
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### YAML Metadata Renderer Prototypes
@@ -36200,7 +35821,6 @@ end
 \tl_const:Nn \c_@@_jekyll_data_mapping_tl    { mapping  }
 \tl_const:Nn \c_@@_jekyll_data_scalar_tl     { scalar   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % To keep track of our current place when we are traversing a \acro{yaml}
@@ -36246,7 +35866,6 @@ end
       }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Out of \mref{g_\@\@_jekyll_data_wildcard_absolute_address_seq}, we will
@@ -36301,7 +35920,6 @@ end
       \g_@@_jekyll_data_wildcard_relative_address_tl
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % To make sure that the stacks and token lists stay in sync, we will use the
@@ -36330,7 +35948,6 @@ end
     \markdown_jekyll_data_update_address_tls:
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % To set a single key--value, we will use the
@@ -36363,7 +35980,6 @@ end
     \markdown_jekyll_data_pop:
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Finally, we will register our macros as token renderer prototypes
@@ -36399,7 +36015,6 @@ end
     { #2 }
 }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % We will process all string scalar values assuming that they may contain
@@ -36612,7 +36227,6 @@ end
       { " \markdownInputFilename " }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownPrepare} macro contains the Lua code that is executed prior
@@ -36645,7 +36259,6 @@ end
     local~convert = md.new(options)
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownConvert} macro contains the Lua code that is executed
@@ -36666,7 +36279,6 @@ end
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownCleanup} macro contains the Lua code that is executed
@@ -36685,7 +36297,6 @@ end
   end
 }%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Buffering Block-Level Markdown Input {#buffering-block}
@@ -36699,7 +36310,6 @@ end
 \csname newread\endcsname\markdownInputFileStream
 \csname newwrite\endcsname\markdownOutputFileStream
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownReadAndConvertTab} macro contains the tab character literal.
@@ -36711,7 +36321,6 @@ end
   \gdef\markdownReadAndConvertTab{^^I}%
 \endgroup
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mref{markdownReadAndConvert} macro is largely a rewrite of the
@@ -36869,7 +36478,6 @@ end
 %  \begin{macrocode}
 |endgroup
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Use the \pkg{lt3luabridge} library to define the \mdef{markdownLuaExecute}
@@ -37186,7 +36794,6 @@ end
   }%
 |endgroup
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 % The \mref{markdownEscape} macro resets the category codes of the percent sign
 % and the hash sign back to comment and parameter, respectively, before using
@@ -37206,7 +36813,6 @@ end
 %</tex>
 %<*latex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % \LaTeX{} Implementation {#lateximplementation}
@@ -37223,7 +36829,6 @@ end
 \ProvidesPackage{markdown}[\markdownLastModified\markdownVersionSpace v%
   \markdownVersion\markdownVersionSpace markdown renderer]%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Typesetting Markdown
@@ -37245,7 +36850,6 @@ end
       { ( \[ (.*?) \] ) ? }
       {
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Apply the options locally.
@@ -37263,7 +36867,6 @@ end
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mdef{markdownInputPlainTeX} macro is used to store the original plain
@@ -37286,7 +36889,6 @@ end
     \markdownInputPlainTeX{#2}%
   \endgroup}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \envmref{markdown}, \envmref{markdown*}, and \envmref{yaml} \LaTeX{}
@@ -37465,7 +37067,6 @@ end
                            <|end<#1>>>%
 |endgroup
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Themes {#latex-themes-implementation}
@@ -37483,7 +37084,6 @@ end
   \@@_load_theme:nnn
   {
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the Markdown package has not yet been loaded, determine whether
@@ -37744,7 +37344,6 @@ end
 %</latex>
 %<*themes-witiko-markdown-defaults-latex>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The `witiko/markdown/defaults` \LaTeX{} theme also loads the corresponding
@@ -37754,7 +37353,6 @@ end
 %  \begin{macrocode}
 \markdownLoadPlainTeXTheme
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Next, the \LaTeX{} theme overrides some of the plain \TeX{} definitions.
@@ -37789,7 +37387,6 @@ end
 %  \begin{macrocode}
 \markdownIfOption{plain}{\iffalse}{\iftrue}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Lists
@@ -37913,7 +37510,6 @@ end
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If we loaded the \pkg{enumitem} package, define the tight and
@@ -38044,7 +37640,6 @@ end
     },
   }}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Otherwise, if we loaded the \pkg{paralist} package, define the
@@ -38151,7 +37746,6 @@ end
   }}
 }{
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Otherwise, if we loaded neither the \pkg{enumitem} package nor the
@@ -38180,7 +37774,6 @@ end
 \ExplSyntaxOff
 \RequirePackage{amsmath}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Unless the \pkg{unicode-math} package has been loaded, load the \pkg{amssymb}
@@ -38212,7 +37805,6 @@ end
   tilde = {\textasciitilde},
   pipe = {\textbar},
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % We can capitalize on the fact that the expansion of renderers is performed by
@@ -38275,7 +37867,6 @@ end
   tickedBox = {$\boxtimes$},
   halfTickedBox = {$\boxdot$}}}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If \acro{HTML} identifiers appear after a heading, we make them
@@ -38368,7 +37959,6 @@ end
   thematicBreak = {\noindent\rule[0.5ex]{\linewidth}{1pt}},
   note = {\footnote{#1}}}}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Fenced Code
@@ -38402,7 +37992,6 @@ end
           \l_tmpa_seq
           \l_tmpa_tl
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % When the \pkg{minted} package is loaded, use it for syntax highlighting.
@@ -38423,7 +38012,6 @@ end
           }
           {
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % When the \pkg{listings} package is loaded, use it for syntax highlighting.
@@ -38434,7 +38022,6 @@ end
               { listings }
               { \lstinputlisting[language=\l_tmpa_tl]{#1} }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % When neither the \pkg{listings} package nor the \pkg{minted} package is
@@ -38448,7 +38035,6 @@ end
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Support the nesting of strong emphasis.
@@ -38467,7 +38053,6 @@ end
 \markdownSetup{rendererPrototypes={strongEmphasis={%
   \protect\markdownLATEXStrongEmphasis{#1}}}}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Support \LaTeX{} document classes that do not provide chapters.
@@ -38491,7 +38076,6 @@ end
     headingSix = {\subparagraph{#1}}}}
 }%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Tickboxes
@@ -38527,7 +38111,6 @@ end
   \fi
 }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### HTML elements
@@ -38561,7 +38144,6 @@ end
   }
 }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Citations
@@ -38808,7 +38390,6 @@ end
       \expandafter{\expandafter}%
     }}}}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Links
@@ -38900,7 +38481,6 @@ end
 \def\markdownLaTeXRendererDirectOrIndirectLink#1#2#3#4{%
   #1\footnote{\ifx\empty#4\empty\else#4: \fi\url{#3}}}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Tables
@@ -38944,7 +38524,6 @@ end
   }
 }}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % If the \Opt{tableAttributes} option is enabled, we will register any
@@ -39041,7 +38620,6 @@ end
     \expandafter\@gobble
   \fi\markdownLaTeXRenderTableCell}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Line Blocks
@@ -39067,7 +38645,6 @@ end
 }{}
 
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### YAML Metadata {#latex-yaml-metadata}
@@ -39106,7 +38683,6 @@ end
   },
 }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Marked Text
@@ -39160,7 +38736,6 @@ end
       }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Strike-Through
@@ -39211,7 +38786,6 @@ end
       }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Images and their attributes
@@ -39281,7 +38855,6 @@ end
   }
 \ExplSyntaxOff
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Raw Attributes
@@ -39331,7 +38904,6 @@ end
       }
   }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Bracketed spans
@@ -39373,7 +38945,6 @@ end
 %</themes-witiko-markdown-defaults-latex>
 %<*latex>
 % \fi
-% \par
 % \begin{markdown}
 %
 %### Miscellanea
@@ -39395,7 +38966,6 @@ end
 %</latex>
 %<*context>
 % \fi
-% \par
 % \begin{markdown}
 %
 % \Hologo{ConTeXt} Implementation {#contextimplementation}
@@ -39423,7 +38993,6 @@ end
     \advance\count0 by 1\relax
   \ifnum\count0<256\repeat
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % On top of that, make the pipe character (`|`) inactive during the scanning.
@@ -39433,7 +39002,6 @@ end
 %  \begin{macrocode}
   \catcode`|=12}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Typesetting Markdown
@@ -39460,7 +39028,6 @@ end
   \doinputmarkdown
     [jekyllData, expectJekyllData, ensureJekyllData, #1]{#2}}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % The \mref{startmarkdown}, \mref{stopmarkdown}, \mref{startyaml}, and
@@ -39509,7 +39076,6 @@ end
     |yamlEnd}%
 |endgroup
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %### Themes {#context-themes-implementation}
@@ -39528,7 +39094,6 @@ end
   \@@_load_theme:nnn
   {
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Determine whether either this is a built-in theme according to the prop
@@ -39659,7 +39224,6 @@ end
 %</context>
 %<*themes-witiko-markdown-defaults-ctx>
 % \fi
-% \par
 % \begin{markdown}
 %
 % The `witiko/markdown/defaults` \Hologo{ConTeXt} theme provides default
@@ -39670,7 +39234,6 @@ end
 %  \begin{macrocode}
 \markdownLoadPlainTeXTheme
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Next, the \Hologo{ConTeXt} theme overrides some of the plain \TeX{} definitions.
@@ -39769,7 +39332,6 @@ end
 }%
 \def\markdownRendererInputVerbatimPrototype#1{\typefile{#1}}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Fenced Code
@@ -39786,7 +39348,6 @@ end
       { #2 }
       { \markdownRendererInputVerbatim{#1} }
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 % Otherwise, extract the first word of the infostring and treat it as the name
@@ -39842,7 +39403,6 @@ end
 \def\markdownRendererDisplayMathPrototype#1{%
   \startformula#1\stopformula}%
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Tables
@@ -39920,7 +39480,6 @@ end
     \expandafter\gobbleoneargument
   \fi\markdownConTeXtRenderTableCell}
 %    \end{macrocode}
-% \par
 % \begin{markdown}
 %
 %#### Raw Attributes
@@ -39981,7 +39540,6 @@ end
 %</themes-witiko-markdown-defaults-ctx>
 %<*context>
 % \fi
-% \par
 % \begin{markdown}
 %
 % At the end of the \Hologo{ConTeXt} module, we load the

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1439,18 +1439,15 @@ soft amsfonts
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{grffile}
+% \pkg{graphicx}
 %
-%:    A package that extends the name processing of the \pkg{graphics} package
-%     to support a larger range of file names in $2006\leq{}$\TeX{}
-%     Live${}\leq{}2019$.  Since \TeX{} Live${}\geq{}2020$, the functionality
-%     of the package has been integrated in the \LaTeXe{} kernel. It is used in
-%     the `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes, see Section
-%     <#sec:latexthemes>.
+%:    A package that provides extended support for graphics. It is used in
+%     the `witiko/dot` and `witiko/graphicx/http` plain \TeX{} themes, see
+%     Section <#sec:themes>.
 %
 % \end{markdown}
 %  \begin{macrocode}
-soft grffile
+soft graphics
 soft epstopdf  # required by `graphics` and `graphicx`, which load `epsopdf-base.sty`
 soft epstopdf-pkg  # required by `graphics` and `graphicx`, which load `epsopdf-base.sty`
 %    \end{macrocode}
@@ -35743,15 +35740,6 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% We load the \pkg{grffile} package, see also Section
-% <#sec:latex-prerequisites>:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\RequirePackage{grffile}
-%    \end{macrocode}
-% \begin{markdown}
-%
 % We define variables and functions to enumerate the images for caching and to
 % store the pathname of the file containing the pathname of the downloaded
 % image file.
@@ -37635,11 +37623,11 @@ end
 % \begin{markdown}
 %
 % The `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes load the package
-% \pkg{grffile}.
+% \pkg{graphicx}, see also Section <#sec:latex-prerequisites>.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\RequirePackage{grffile}
+\RequirePackage{graphicx}
 \markdownLoadPlainTeXTheme
 %    \end{macrocode}
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1451,19 +1451,6 @@ soft grffile
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{etoolbox}
-%
-%:    A package that is used to polyfill the general hook management system in
-%     the default renderer prototypes for \acro{yaml} metadata, see Section
-%     <#sec:latex-yaml-metadata>, and also in the default renderer prototype
-%     for identifier attributes.
-%
-% \end{markdown}
-%  \begin{macrocode}
-soft etoolbox
-%    \end{macrocode}
-% \begin{markdown}
-%
 % \pkg{soulutf8} and \pkg{xcolor}
 %
 %:    Packages that are used in the default renderer prototypes for

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34925,7 +34925,7 @@ function M.new(options)
       local salt = util.salt(options)
       local name = util.cache(options.cacheDir, input, salt, convert,
                               ".md.tex")
-      output = [[\noexpand\input{]] .. name .. [[}\relax]]
+      output = [[\input{]] .. name .. [[}\relax]]
 %    \end{macrocode}
 % \begin{markdown}
 % Otherwise, return the result of the conversion directly.

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23711,6 +23711,21 @@ Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
      prototypes for plain \TeX{}. This theme is loaded automatically together
      with the package and explicitly loading it has no effect.
 
+% \end{markdown}
+% \iffalse
+%</manual-options>
+%<*themes-witiko-markdown-defaults-ctx>
+% \fi
+%  \begin{macrocode}
+\startmodule[markdownthemewitiko_markdown_defaults]
+\unprotect
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-markdown-defaults-ctx>
+%<*manual-options>
+% \fi
+% \begin{markdown}
+%
 % Please, see Section <#sec:context-themes-implementation> for implementation
 % details of the built-in \Hologo{ConTeXt} themes.
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1399,19 +1399,6 @@ soft paralist
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{ifthen}
-%
-%:    A package that provides a concise syntax for the inspection of macro
-%     values. It is used in the `witiko/dot` \LaTeX{} theme (see Section
-%     <#sec:latexthemes>).
-%
-% \end{markdown}
-%  \begin{macrocode}
-soft latex
-soft epstopdf-pkg  # required by `latex`
-%    \end{macrocode}
-% \begin{markdown}
-%
 % \pkg{fancyvrb}
 %
 %:    A package that provides the `\VerbatimInput` macros for the verbatim
@@ -23236,7 +23223,7 @@ conference article:
 %<*themes-witiko-dot>
 % \fi
 %  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_dot}[2021/03/09]%
+\ProvidesPackage{markdownthemewitiko_dot}[2024/11/19]%
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-dot>
@@ -37404,12 +37391,12 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% We load the \pkg{ifthen} and \pkg{grffile} packages, see also
-% Section <#sec:latex-prerequisites>:
+% We load \pkg{grffile} package, see also Section
+% <#sec:latex-prerequisites>:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\RequirePackage{ifthen,grffile}
+\RequirePackage{grffile}
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37417,7 +37404,9 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\let\markdown@witiko@dot@oldRendererInputFencedCodePrototype
+\ExplSyntaxOn
+\cs_seq_eq:NN
+  \@@_dot_previous_definition:nnn
   \markdownRendererInputFencedCodePrototype
 %    \end{macrocode}
 % \begin{markdown}
@@ -37429,16 +37418,32 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\renewcommand\markdownRendererInputFencedCodePrototype[3]{%
-  \def\next##1 ##2\relax{%
-    \ifthenelse{\equal{##1}{dot}}{%
-      \markdownIfOption{frozenCache}{}{%
-        \immediate\write18{%
-          if ! test -e #1.pdf.source || ! diff #1 #1.pdf.source;
-          then
-            dot -Tpdf -o #1.pdf #1;
-            cp #1 #1.pdf.source;
-          fi}}%
+\regex_const:Nn
+  \c_@@_dot_infostring_regex
+  { ^dot(\s+(.+))? }
+\seq_new:N
+  \l_@@_dot_matches_seq
+\markdownSetup {
+  rendererPrototypes = {
+    inputFencedCodePrototype = {
+      \regex_extract_once:NnNTF
+        \c_@@_dot_infostring_regex
+        { #2 }
+        \l_@@_dot_matches_seq
+        {
+          \@@_if_option:nF
+            { frozenCache }
+            {
+              \sys_shell_now:n
+                {
+                  if ! test -e #1.pdf.source
+                  || ! diff #1 #1.pdf.source;
+                  then
+                    dot -Tpdf -o #1.pdf #1;
+                    cp #1 #1.pdf.source;
+                  fi
+                }
+            }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37446,7 +37451,20 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-      \markdownRendererImage{Graphviz image}{#1.pdf}{#1.pdf}{##2}%
+          \exp_args:NNne
+            \exp_last_unbraced:No
+            \markdownRendererImage
+              {
+                { Graphviz image }
+                { #1.pdf }
+                { #1.pdf }
+              }
+              {
+                \seq_item:Nn
+                  \l_@@_dot_matches_seq
+                  { 3 }
+              }
+        }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37455,12 +37473,17 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    }{%
-      \markdown@witiko@dot@oldRendererInputFencedCodePrototype
-        {#1}{#2}{#3}%
-    }%
-  }%
-  \next#2 \relax}%
+        {
+          \@@_dot_previous_definition:nnn
+            { #1 }
+            { #2 }
+            { #3 }
+
+        }
+    },
+  },
+}
+\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-dot>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1436,18 +1436,6 @@ soft amsfonts
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{catchfile}
-%
-%:    A package that catches the contents of a file and puts it in a macro. It
-%     is used in the `witiko/graphicx/http` \LaTeX{} theme, see Section
-%     <#sec:latexthemes>.
-%
-% \end{markdown}
-%  \begin{macrocode}
-soft catchfile
-%    \end{macrocode}
-% \begin{markdown}
-%
 % \pkg{grffile}
 %
 %:    A package that extends the name processing of the \pkg{graphics} package
@@ -37424,11 +37412,11 @@ end
             {
               \sys_shell_now:n
                 {
-                  if ! test -e #1.pdf.source
-                  || ! diff #1 #1.pdf.source;
+                  if~!~test~-e~#1.pdf.source~
+                  ||~!~diff~#1~#1.pdf.source;
                   then
-                    dot -Tpdf -o #1.pdf #1;
-                    cp #1 #1.pdf.source;
+                    dot~-Tpdf~-o~#1.pdf~#1;
+                    cp~#1~#1.pdf.source;
                   fi
                 }
             }
@@ -37443,7 +37431,7 @@ end
             \exp_last_unbraced:No
             \markdownRendererImage
               {
-                { Graphviz image }
+                { Graphviz~image }
                 { #1.pdf }
                 { #1.pdf }
               }
@@ -37466,7 +37454,6 @@ end
             { #1 }
             { #2 }
             { #3 }
-
         }
     },
   },
@@ -37485,56 +37472,69 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\let\markdown@witiko@graphicx@http@oldRendererImagePrototype
+\ExplSyntaxOn
+\cs_seq_eq:NN
+  \@@_graphicx_http_previous_definition:nnnn
+  \markdownRendererInputFencedCodePrototype
   \markdownRendererImagePrototype
 %    \end{macrocode}
 % \begin{markdown}
 %
-% We load the \pkg{catchfile} and \pkg{grffile} packages, see also
-% Section <#sec:latex-prerequisites>:
+% We load the \pkg{grffile} package, see also Section
+% <#sec:latex-prerequisites>:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\RequirePackage{catchfile,grffile}
+\RequirePackage{grffile}
 %    \end{macrocode}
 % \begin{markdown}
 %
-% We define the \mdef{markdown@witiko@graphicx@http@counter} counter to enumerate
-% the images for caching and the \mdef{markdown@witiko@graphicx@http@filename}
-% command, which will store the pathname of the file containing the pathname
-% of the downloaded image file.
+% We define variables and functions to enumerate the images for caching and to
+% store the pathname of the file containing the pathname of the downloaded
+% image file.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\newcount\markdown@witiko@graphicx@http@counter
-\markdown@witiko@graphicx@http@counter=0
-\newcommand\markdown@witiko@graphicx@http@filename{%
-  \markdownOptionCacheDir/witiko_graphicx_http%
-  .\the\markdown@witiko@graphicx@http@counter}%
+\int_new:N
+  \g_@@_graphicx_http_image_number_int
+\int_gset:Nn
+  \g_@@_graphicx_http_image_number_int
+  { 0 }
+\cs_new:Nn
+  \@@_graphicx_http_filename:
+  {
+    \markdownOptionCacheDir
+    / witiko_graphicx_http .
+    \int_use:N
+      \g_@@_graphicx_http_image_number_int
+  }
 %    \end{macrocode}
 % \begin{markdown}
 %
-% We define the \mdef{markdown@witiko@graphicx@http@download} command, which will
-% receive two arguments that correspond to the URL of the online image and to
-% the pathname, where the online image should be downloaded. The command will
-% produce a shell command that tries to downloads the online image to the
-% pathname.
+% We define a function that will receive two arguments that correspond to the
+% URL of the online image and to the pathname, where the online image should
+% be downloaded. The function produces a shell command that tries to
+% downloads the online image to the pathname.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\newcommand\markdown@witiko@graphicx@http@download[2]{%
-  wget -O #2 #1 || curl --location -o #2 #1 || rm -f #2}
+\cs_new:Nn
+  \@@_graphicx_http_download:nn
+  {
+    wget~-O~#2~#1~
+    ||~curl~--location~-o~#2~#1~
+    ||~rm~-f~#2
+  }
 %    \end{macrocode}
 % \begin{markdown}
 %
-% We locally swap the category code of the percentage sign with the line feed
-% control character, so that we can use percentage signs in the shell code:
+% We locally change the category code of percent signs, so that we
+% can use them in the shell code:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\begingroup
-\catcode`\%=12
-\catcode`\^^A=14
+\group_begin:
+\char_set_catcode_other:N \%
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37543,9 +37543,16 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\global\def\markdownRendererImagePrototype#1#2#3#4{^^A
-  \begingroup
-    \edef\filename{\markdown@witiko@graphicx@http@filename}^^A
+\str_new:N
+  \l_@@_graphicx_http_filename_str
+\ior_new:N
+  \g_@@_graphicx_http_filename_ior
+\markdownSetup {
+  rendererPrototypes = {
+    image = {
+      \@@_if_option:nF
+        { frozenCache }
+        {
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37554,11 +37561,11 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \markdownIfOption{frozenCache}{}{^^A
-      \immediate\write18{^^A
-        mkdir -p "\markdownOptionCacheDir";
-        if printf '%s' "#3" | grep -q -E '^https?:';
-        then
+          \sys_shell_now:e
+            {
+              mkdir~-p~" \markdownOptionCacheDir ";
+              if~printf~'%s'~"#3"~|~grep~-q~-E~'^https?:';
+              then
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37568,10 +37575,12 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-          OUTPUT_PREFIX="\markdownOptionCacheDir";
-          OUTPUT_BODY="$(printf '%s' '#3' | md5sum | cut -d' ' -f1)";
-          OUTPUT_SUFFIX="$(printf '%s' '#3' | sed 's/.*[.]//')";
-          OUTPUT="$OUTPUT_PREFIX/$OUTPUT_BODY.$OUTPUT_SUFFIX";
+                OUTPUT_PREFIX=" \markdownOptionCacheDir ";
+                OUTPUT_BODY="$(printf~'%s'~'#3'
+                              |~md5sum~|~cut~-d'~'~-f1)";
+                OUTPUT_SUFFIX="$(printf~'%s'~'#3'
+                              |~sed~'s/.*[.]//')";
+                OUTPUT="$OUTPUT_PREFIX/$OUTPUT_BODY.$OUTPUT_SUFFIX";
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37579,11 +37588,14 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-          if ! [ -e "$OUTPUT" ];
-          then
-            \markdown@witiko@graphicx@http@download{'#3'}{"$OUTPUT"};
-            printf '%s' "$OUTPUT" > "\filename";
-          fi;
+                if~!~[~-e~"$OUTPUT"~];
+                then
+                  \@@_graphicx_http_download:nn
+                    { '#3' }
+                    { "$OUTPUT" } ;
+                  printf~'%s'~"$OUTPUT"~
+                    >~" \@@_graphicx_http_filename: ";
+                fi;
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37592,9 +37604,46 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-        else
-          printf '%s' '#3' > "\filename";
-        fi}}^^A
+              else
+                printf~'%s'~'#3'~
+                  >~" \@@_graphicx_http_filename: ";
+              fi
+            }
+          }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We load the pathname of the downloaded image and we typeset the image using
+% the previous definition of the image renderer prototype:
+%
+% \end{markdown}
+%  \begin{macrocode}
+      \ior_open:Ne
+        \g_@@_graphicx_http_filename_ior
+        { \@@_graphicx_http_filename: }
+      \ior_str_get:NN
+        \g_@@_graphicx_http_filename_ior
+        \l_@@_graphicx_http_filename_str
+      \ior_close:N
+        \g_@@_graphicx_http_filename_ior
+      \@@_graphicx_http_previous_definition:nnVn
+        { #1 }
+        { #2 }
+        \l_@@_graphicx_http_filename_str
+        { #4 }
+      \int_gincr:N
+        \g_@@_graphicx_http_image_number_int
+    }
+  }
+}
+\group_end:
+\cs_generate_variant:Nn
+  \ior_open:Nn
+  { Ne }
+\cs_generate_variant:Nn
+  \@@_graphicx_http_previous_definition:nnnn
+  { nnVn }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1339,14 +1339,14 @@ hard lt3luabridge
 % prerequisites (see Section <#sec:tex-prerequisites>).
 % \end{markdown}
 % \iffalse
-%<*themes-witiko-dot,latex-themes-witiko-graphicx-http>
+%<*themes-witiko-dot,themes-witiko-graphicx-http>
 % \fi
 %  \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}
 \RequirePackage{expl3}
 %    \end{macrocode}
 % \iffalse
-%</themes-witiko-dot,latex-themes-witiko-graphicx-http>
+%</themes-witiko-dot,themes-witiko-graphicx-http>
 %</latex>
 %<*depends>
 % \fi

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -13214,8 +13214,7 @@ lualatex --shell-escape document.tex
 A PDF document named `document.pdf` should be produced and contain the
 following image:
 
-> ![Figure 1: The banner of the Markdown package](https://github.com/witiko/markdown/raw/main/markdown.png
-                                                  "Figure 1: The banner of the Markdown package")
+> ![Figure 1: The banner of the Markdown package](https://github.com/witiko/markdown/raw/main/markdown.png)
 
 % \fi
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23240,6 +23240,7 @@ beginning of a \LaTeX{} document.
 % \iffalse
 %</manual-options>
 %<*latex>
+% \fi
 %  \begin{macrocode}
 \ExplSyntaxOn
 \prop_new:N

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12853,7 +12853,10 @@ A PDF document named `document.pdf` should be produced and contain the text
 % \fi
 % \begin{markdown}
 
-### Themes {#themes}
+%### Themes {#themes}
+% \iffalse
+#### Themes {#themes}
+% \fi
 
 User-defined themes for the Markdown package provide a domain-specific
 interpretation of Markdown tokens. Themes allow the authors to achieve
@@ -13367,8 +13370,11 @@ following text, where the middot (`·`) denotes a non-breaking space:
 
 % Please, see Section <#sec:themes-implementation> for implementation
 % details of the built-in plain \TeX{} themes.
-
-### Snippets {#snippets}
+%
+%### Snippets {#snippets}
+% \iffalse
+#### Snippets {#snippets}
+% \fi
 
 % \end{markdown}
 % \iffalse
@@ -23165,7 +23171,10 @@ document:
 % \fi
 % \begin{markdown}
 
-### Themes {#latexthemes}
+%### Themes {#latexthemes}
+% \iffalse
+#### Themes {#latexthemes}
+% \fi
 
 % In Section~\ref{sec:themes}, we described the concept of themes.
 In \LaTeX{}, we expand on the concept of
@@ -23654,9 +23663,13 @@ following text:
 %<*manual-options>
 % \fi
 % \begin{markdown}
-
-### Themes
-
+%
+%### Themes {#contextthemes}
+% \iffalse
+### \Hologo{ConTeXt}
+#### Themes {#contextthemes}
+% \fi
+%
 % In Section~\ref{sec:themes}, we described the concept of themes.
 In \Hologo{ConTeXt}, we expand on the concept of
 % themes\iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1424,18 +1424,6 @@ soft tools  # required by `csvsimple`, which loads `shellesc.sty`
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{gobble}
-%
-%:    A package that provides the `\@gobblethree` \TeX{} command that
-%     is used in the default renderer prototype for citations. The package
-%     is included in \TeX Live${}\geq{}2016$.
-%
-% \end{markdown}
-%  \begin{macrocode}
-soft gobble
-%    \end{macrocode}
-% \begin{markdown}
-%
 % \pkg{amsmath} and \pkg{amssymb}
 %
 %:    Packages that provide symbols used for drawing ticked and unticked
@@ -38459,7 +38447,7 @@ end
 \newcount\markdownLaTeXCitationsCounter
 
 % Basic implementation
-\RequirePackage{gobble}
+\long\def\@gobblethree#1#2#3{}%
 \def\markdownLaTeXBasicCitations#1#2#3#4#5#6{%
   \advance\markdownLaTeXCitationsCounter by 1\relax
   \ifx\relax#4\relax

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1421,6 +1421,7 @@ soft fancyvrb
 soft csvsimple
 soft pgf  # required by `csvsimple`, which loads `pgfkeys.sty`
 soft tools  # required by `csvsimple`, which loads `shellesc.sty`
+soft etoolbox  # required by `csvsimple`, which loads `etoolbox.sty`
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -1448,6 +1449,8 @@ soft amsfonts
 % \end{markdown}
 %  \begin{macrocode}
 soft grffile
+soft epstopdf  # required by `graphics` and `graphicx`, which load `epsopdf-base.sty`
+soft epstopdf-pkg  # required by `graphics` and `graphicx`, which load `epsopdf-base.sty`
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -23170,7 +23173,7 @@ digraph tree {
 ````````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-lualatex document.tex
+lualatex --shell-escape document.tex
 ``````
 A PDF document named `document.pdf` should be produced and contain
 a drawing of a directed graph similar to Figure 1 from the following
@@ -23227,22 +23230,23 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ``` tex
 \documentclass{article}
-\usepackage[import=witiko/graphicx/http]{markdown}
+\usepackage[import=witiko/graphicx/http, link_attributes]{markdown}
 \begin{document}
 \begin{markdown}
 ![img](https://github.com/witiko/markdown/raw/main/markdown.png
-       "The banner of the Markdown package")
+       "The banner of the Markdown package"){width=5in}
 \end{markdown}
 \end{document}
 ```````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-lualatex document.tex
+lualatex --shell-escape document.tex
 ``````
 A PDF document named `document.pdf` should be produced and contain the
 following image:
 
-> ![img](https://github.com/witiko/markdown/raw/main/markdown.png "The banner of the Markdown package")
+> ![Figure 1: The banner of the Markdown package](https://github.com/witiko/markdown/raw/main/markdown.png
+                                                  "Figure 1: The banner of the Markdown package")
 
 %</manual-options>
 %<*themes-witiko-graphicx-http>
@@ -37368,7 +37372,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\cs_seq_eq:NN
+\cs_set_eq:NN
   \@@_dot_previous_definition:nnn
   \markdownRendererInputFencedCodePrototype
 %    \end{macrocode}
@@ -37388,7 +37392,7 @@ end
   \l_@@_dot_matches_seq
 \markdownSetup {
   rendererPrototypes = {
-    inputFencedCodePrototype = {
+    inputFencedCode = {
       \regex_extract_once:NnNTF
         \c_@@_dot_infostring_regex
         { #2 }
@@ -37401,7 +37405,7 @@ end
                 {
                   if~!~test~-e~#1.pdf.source~
                   ||~!~diff~#1~#1.pdf.source;
-                  then
+                  then~
                     dot~-Tpdf~-o~#1.pdf~#1;
                     cp~#1~#1.pdf.source;
                   fi
@@ -37460,9 +37464,8 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
-\cs_seq_eq:NN
+\cs_set_eq:NN
   \@@_graphicx_http_previous_definition:nnnn
-  \markdownRendererInputFencedCodePrototype
   \markdownRendererImagePrototype
 %    \end{macrocode}
 % \begin{markdown}
@@ -37520,7 +37523,6 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\group_begin:
 \char_set_catcode_other:N \%
 %    \end{macrocode}
 % \begin{markdown}
@@ -37552,7 +37554,7 @@ end
             {
               mkdir~-p~" \markdownOptionCacheDir ";
               if~printf~'%s'~"#3"~|~grep~-q~-E~'^https?:';
-              then
+              then~
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -37576,7 +37578,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
                 if~!~[~-e~"$OUTPUT"~];
-                then
+                then~
                   \@@_graphicx_http_download:nn
                     { '#3' }
                     { "$OUTPUT" } ;
@@ -37591,7 +37593,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-              else
+              else~
                 printf~'%s'~'#3'~
                   >~" \@@_graphicx_http_filename: ";
               fi
@@ -37623,7 +37625,7 @@ end
     }
   }
 }
-\group_end:
+\char_set_catcode_comment:N \%
 \cs_generate_variant:Nn
   \ior_open:Nn
   { Ne }
@@ -37631,20 +37633,6 @@ end
   \@@_graphicx_http_previous_definition:nnnn
   { nnVn }
 \ExplSyntaxOff
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We load the pathname of the downloaded image and we typeset the image using
-% the previous definition of the image renderer prototype:
-%
-% \end{markdown}
-%  \begin{macrocode}
-    \CatchFileDef{\filename}{\filename}{\endlinechar=-1}^^A
-    \markdown@witiko@graphicx@http@oldRendererImagePrototype^^A
-      {#1}{#2}{\filename}{#4}^^A
-  \endgroup
-  \global\advance\markdown@witiko@graphicx@http@counter by 1\relax}^^A
-\endgroup
 %    \end{macrocode}
 % \iffalse
 %</themes-witiko-graphicx-http>

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1018,8 +1018,8 @@ Either of the two abovelisted approaches should produce the following files:
 * `markdown-cli.lua`: The Lua command-line interface
 * `markdown.tex`: The plain \TeX{} macro package
 * `markdown.sty`: The \LaTeX{} package
-* `markdownthemewitiko_dot.sty`: The `witiko/dot` \LaTeX{} theme
-* `markdownthemewitiko_graphicx_http.sty`: The `witiko/graphicx/http` \LaTeX{} theme
+* `markdownthemewitiko_dot.tex` and `markdownthemewitiko_dot.sty`: The `witiko/dot` \LaTeX{} theme
+* `markdownthemewitiko_graphicx_http.tex` and `markdownthemewitiko_graphicx_http.sty`: The `witiko/graphicx/http` \LaTeX{} theme
 * `markdownthemewitiko_tilde.tex`: The `witiko/tilde` theme
 * `markdownthemewitiko_markdown_defaults.tex`,
   `markdownthemewitiko_markdown_defaults.sty`, and
@@ -1041,6 +1041,8 @@ placed:
 * `⟨TEXMF⟩/tex/generic/markdown/markdown.tex`
 * `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_tilde.tex`
 * `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_markdown_defaults.tex`
+* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_dot.tex`
+* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_graphicx_http.tex`
 * `⟨TEXMF⟩/tex/latex/markdown/markdown.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_dot.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_graphicx_http.sty`
@@ -1069,7 +1071,9 @@ This is where the individual files should be placed:
 * `./markdown/markdown.tex`
 * `./markdown.sty`
 * `./t-markdown.tex`
+* `./markdownthemewitiko_dot.tex`
 * `./markdownthemewitiko_dot.sty`
+* `./markdownthemewitiko_graphicx_http.tex`
 * `./markdownthemewitiko_graphicx_http.sty`
 * `./markdownthemewitiko_tilde.tex`
 * `./markdownthemewitiko_markdown_defaults.tex`
@@ -1339,14 +1343,12 @@ hard lt3luabridge
 % prerequisites (see Section <#sec:tex-prerequisites>).
 % \end{markdown}
 % \iffalse
-%<*themes-witiko-dot,themes-witiko-graphicx-http>
 % \fi
 %  \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}
 \RequirePackage{expl3}
 %    \end{macrocode}
 % \iffalse
-%</themes-witiko-dot,themes-witiko-graphicx-http>
 %</latex>
 %<*depends>
 % \fi
@@ -13130,9 +13132,213 @@ a specific look and other high-level goals without low-level programming.
 %<*manual-options>
 % \fi
 % \par
-% \begin{markdown}
+% \markdownBegin
 
 Built-in plain \TeX{} themes provided with the Markdown package include:
+
+\pkg{witiko/dot}
+
+:    A theme that typesets fenced code blocks with the `dot …` infostring
+     as images of directed graphs rendered by the Graphviz tools. The
+     right tail of the infostring is used as the image title.
+%    ```` tex
+%    \documentclass{article}
+%    \usepackage[import=witiko/dot]{markdown}
+%    \setkeys{Gin}{
+%      width = \columnwidth,
+%      height = 0.65\paperheight,
+%      keepaspectratio}
+%    \begin{document}
+%    \begin{markdown}
+%    ``` dot Various formats of mathemathical formulae
+%    digraph tree {
+%      margin = 0;
+%      rankdir = "LR";
+%
+%      latex -> pmml;
+%      latex -> cmml;
+%      pmml -> slt;
+%      cmml -> opt;
+%      cmml -> prefix;
+%      cmml -> infix;
+%      pmml -> mterms [style=dashed];
+%      cmml -> mterms;
+%
+%      latex [label = "LaTeX"];
+%      pmml [label = "Presentation MathML"];
+%      cmml [label = "Content MathML"];
+%      slt [label = "Symbol Layout Tree"];
+%      opt [label = "Operator Tree"];
+%      prefix [label = "Prefix"];
+%      infix [label = "Infix"];
+%      mterms [label = "M-Terms"];
+%    }
+%    ```
+%    \end{markdown}
+%    \end{document}
+%    ````````
+%    Typesetting the above document produces the output shown in
+%    Figure <#fig:witiko/dot>.
+%    ``` dot Various formats of mathemathical formulae \label{fig:witiko/dot}
+%    digraph tree {
+%      margin = 0;
+%      rankdir = "LR";
+%
+%      latex -> pmml;
+%      latex -> cmml;
+%      pmml -> slt;
+%      cmml -> opt;
+%      cmml -> prefix;
+%      cmml -> infix;
+%      pmml -> mterms [style=dashed];
+%      cmml -> mterms;
+%
+%      latex [label = "LaTeX"];
+%      pmml [label = "Presentation MathML"];
+%      cmml [label = "Content MathML"];
+%      slt [label = "Symbol Layout Tree"];
+%      opt [label = "Operator Tree"];
+%      prefix [label = "Prefix"];
+%      infix [label = "Infix"];
+%      mterms [label = "M-Terms"];
+%    }
+%    ```
+     The theme requires a Unix-like operating system with GNU Diffutils and
+     Graphviz installed. The theme also requires shell access unless the
+     \Opt{frozenCache} plain \TeX{} option is enabled.
+
+% \markdownEnd
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+```` tex
+\documentclass{article}
+\usepackage[import=witiko/dot]{markdown}
+\setkeys{Gin}{
+  width=\columnwidth,
+  height=0.65\paperheight,
+  keepaspectratio}
+\begin{document}
+\begin{markdown}
+``` dot Various formats of mathemathical formulae
+digraph tree {
+  margin = 0;
+  rankdir = "LR";
+
+  latex -> pmml;
+  latex -> cmml;
+  pmml -> slt;
+  cmml -> opt;
+  cmml -> prefix;
+  cmml -> infix;
+  pmml -> mterms [style=dashed];
+  cmml -> mterms;
+
+  latex [label = "LaTeX"];
+  pmml [label = "Presentation MathML"];
+  cmml [label = "Content MathML"];
+  slt [label = "Symbol Layout Tree"];
+  opt [label = "Operator Tree"];
+  prefix [label = "Prefix"];
+  infix [label = "Infix"];
+  mterms [label = "M-Terms"];
+}
+```
+\end{markdown}
+\end{document}
+````````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain
+a drawing of a directed graph similar to Figure 1 from the following
+conference article:
+
+> NOVOTNÝ, Vít, Petr SOJKA, Michal ŠTEFÁNIK and Dávid LUPTÁK. Three is Better
+> than One: Ensembling Math Information Retrieval Systems. *CEUR Workshop
+> Proceedings*. Thessaloniki, Greece: M. Jeusfeld c/o Redaktion Sun SITE,
+> Informatik V, RWTH Aachen., 2020, vol. 2020, No 2696, p. 1-30. ISSN 1613-0073.
+> <http://ceur-ws.org/Vol-2696/paper_235.pdf>
+
+%</manual-options>
+%<*themes-witiko-dot-latex>
+% \fi
+%  \begin{macrocode}
+\ProvidesPackage{markdownthemewitiko_dot}[2024/11/20]%
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-dot-latex>
+%<*manual-options>
+% \fi
+% \par
+% \markdownBegin
+
+\pkg{witiko/graphicx/http}
+
+:    A theme that adds support for downloading images whose URL has the
+     http or https protocol.
+%    ``` tex
+%    \documentclass{article}
+%    \usepackage[import=witiko/graphicx/http]{markdown}
+%    \begin{document}
+%    \begin{markdown}
+%    ![img](https://github.com/witiko/markdown/raw/main/markdown.png
+%           "The banner of the Markdown package")
+%    \end{markdown}
+%    \end{document}
+%    ```````
+%    Typesetting the above document produces the output shown in
+%    Figure <#fig:witiko/graphicx/http>.
+%    ![img](https://github.com/witiko/markdown/raw/main/markdown.png
+%           "The banner of the Markdown package \label{fig:witiko/graphicx/http}")
+     The theme requires the \pkg{catchfile} \LaTeX{} package and a Unix-like
+     operating system with GNU Coreutils `md5sum` and either GNU Wget or cURL
+     installed. The theme also requires shell access unless the
+     \Opt{frozenCache} plain \TeX{} option is enabled.
+
+% \markdownEnd
+% \iffalse
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage[import=witiko/graphicx/http, link_attributes]{markdown}
+\begin{document}
+\begin{markdown}
+![img](https://github.com/witiko/markdown/raw/main/markdown.png
+       "The banner of the Markdown package"){width=5in}
+\end{markdown}
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex --shell-escape document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following image:
+
+> ![Figure 1: The banner of the Markdown package](https://github.com/witiko/markdown/raw/main/markdown.png
+                                                  "Figure 1: The banner of the Markdown package")
+
+%</manual-options>
+%<*themes-witiko-graphicx-http-latex>
+% \fi
+%  \begin{macrocode}
+\ProvidesPackage{markdownthemewitiko_graphicx_http}[2024/11/20]%
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-graphicx-http-latex>
+%<*manual-options>
+% \fi
+% \par
+% \begin{markdown}
 
 \pkg{witiko/tilde}
 
@@ -23056,210 +23262,6 @@ beginning of a \LaTeX{} document.
 % \markdownBegin
 
 Built-in \LaTeX{} themes provided with the Markdown package include:
-
-\pkg{witiko/dot}
-
-:    A theme that typesets fenced code blocks with the `dot …` infostring
-     as images of directed graphs rendered by the Graphviz tools. The
-     right tail of the infostring is used as the image title.
-%    ```` tex
-%    \documentclass{article}
-%    \usepackage[import=witiko/dot]{markdown}
-%    \setkeys{Gin}{
-%      width = \columnwidth,
-%      height = 0.65\paperheight,
-%      keepaspectratio}
-%    \begin{document}
-%    \begin{markdown}
-%    ``` dot Various formats of mathemathical formulae
-%    digraph tree {
-%      margin = 0;
-%      rankdir = "LR";
-%
-%      latex -> pmml;
-%      latex -> cmml;
-%      pmml -> slt;
-%      cmml -> opt;
-%      cmml -> prefix;
-%      cmml -> infix;
-%      pmml -> mterms [style=dashed];
-%      cmml -> mterms;
-%
-%      latex [label = "LaTeX"];
-%      pmml [label = "Presentation MathML"];
-%      cmml [label = "Content MathML"];
-%      slt [label = "Symbol Layout Tree"];
-%      opt [label = "Operator Tree"];
-%      prefix [label = "Prefix"];
-%      infix [label = "Infix"];
-%      mterms [label = "M-Terms"];
-%    }
-%    ```
-%    \end{markdown}
-%    \end{document}
-%    ````````
-%    Typesetting the above document produces the output shown in
-%    Figure <#fig:witiko/dot>.
-%    ``` dot Various formats of mathemathical formulae \label{fig:witiko/dot}
-%    digraph tree {
-%      margin = 0;
-%      rankdir = "LR";
-%
-%      latex -> pmml;
-%      latex -> cmml;
-%      pmml -> slt;
-%      cmml -> opt;
-%      cmml -> prefix;
-%      cmml -> infix;
-%      pmml -> mterms [style=dashed];
-%      cmml -> mterms;
-%
-%      latex [label = "LaTeX"];
-%      pmml [label = "Presentation MathML"];
-%      cmml [label = "Content MathML"];
-%      slt [label = "Symbol Layout Tree"];
-%      opt [label = "Operator Tree"];
-%      prefix [label = "Prefix"];
-%      infix [label = "Infix"];
-%      mterms [label = "M-Terms"];
-%    }
-%    ```
-     The theme requires a Unix-like operating system with GNU Diffutils and
-     Graphviz installed. The theme also requires shell access unless the
-     \Opt{frozenCache} plain \TeX{} option is enabled.
-
-% \markdownEnd
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-```` tex
-\documentclass{article}
-\usepackage[import=witiko/dot]{markdown}
-\setkeys{Gin}{
-  width=\columnwidth,
-  height=0.65\paperheight,
-  keepaspectratio}
-\begin{document}
-\begin{markdown}
-``` dot Various formats of mathemathical formulae
-digraph tree {
-  margin = 0;
-  rankdir = "LR";
-
-  latex -> pmml;
-  latex -> cmml;
-  pmml -> slt;
-  cmml -> opt;
-  cmml -> prefix;
-  cmml -> infix;
-  pmml -> mterms [style=dashed];
-  cmml -> mterms;
-
-  latex [label = "LaTeX"];
-  pmml [label = "Presentation MathML"];
-  cmml [label = "Content MathML"];
-  slt [label = "Symbol Layout Tree"];
-  opt [label = "Operator Tree"];
-  prefix [label = "Prefix"];
-  infix [label = "Infix"];
-  mterms [label = "M-Terms"];
-}
-```
-\end{markdown}
-\end{document}
-````````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex --shell-escape document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain
-a drawing of a directed graph similar to Figure 1 from the following
-conference article:
-
-> NOVOTNÝ, Vít, Petr SOJKA, Michal ŠTEFÁNIK and Dávid LUPTÁK. Three is Better
-> than One: Ensembling Math Information Retrieval Systems. *CEUR Workshop
-> Proceedings*. Thessaloniki, Greece: M. Jeusfeld c/o Redaktion Sun SITE,
-> Informatik V, RWTH Aachen., 2020, vol. 2020, No 2696, p. 1-30. ISSN 1613-0073.
-> <http://ceur-ws.org/Vol-2696/paper_235.pdf>
-
-%</manual-options>
-%<*themes-witiko-dot>
-% \fi
-%  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_dot}[2024/11/19]%
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-dot>
-%<*manual-options>
-% \fi
-% \par
-% \markdownBegin
-
-\pkg{witiko/graphicx/http}
-
-:    A theme that adds support for downloading images whose URL has the
-     http or https protocol.
-%    ``` tex
-%    \documentclass{article}
-%    \usepackage[import=witiko/graphicx/http]{markdown}
-%    \begin{document}
-%    \begin{markdown}
-%    ![img](https://github.com/witiko/markdown/raw/main/markdown.png
-%           "The banner of the Markdown package")
-%    \end{markdown}
-%    \end{document}
-%    ```````
-%    Typesetting the above document produces the output shown in
-%    Figure <#fig:witiko/graphicx/http>.
-%    ![img](https://github.com/witiko/markdown/raw/main/markdown.png
-%           "The banner of the Markdown package \label{fig:witiko/graphicx/http}")
-     The theme requires the \pkg{catchfile} \LaTeX{} package and a Unix-like
-     operating system with GNU Coreutils `md5sum` and either GNU Wget or cURL
-     installed. The theme also requires shell access unless the
-     \Opt{frozenCache} plain \TeX{} option is enabled.
-
-% \markdownEnd
-% \iffalse
-
-##### \LaTeX{} Example {.unnumbered}
-
-Using a text editor, create a text document named `document.tex` with the
-following content:
-``` tex
-\documentclass{article}
-\usepackage[import=witiko/graphicx/http, link_attributes]{markdown}
-\begin{document}
-\begin{markdown}
-![img](https://github.com/witiko/markdown/raw/main/markdown.png
-       "The banner of the Markdown package"){width=5in}
-\end{markdown}
-\end{document}
-```````
-Next, invoke LuaTeX from the terminal:
-``` sh
-lualatex --shell-escape document.tex
-``````
-A PDF document named `document.pdf` should be produced and contain the
-following image:
-
-> ![Figure 1: The banner of the Markdown package](https://github.com/witiko/markdown/raw/main/markdown.png
-                                                  "Figure 1: The banner of the Markdown package")
-
-%</manual-options>
-%<*themes-witiko-graphicx-http>
-% \fi
-%  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_graphicx_http}[2021/03/22]%
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-graphicx-http>
-%<*manual-options>
-% \fi
-% \par
-% \begin{markdown}
 
 \pkg{witiko/markdown/defaults}
 
@@ -35625,6 +35627,288 @@ end
 %    \end{macrocode}
 % \iffalse
 %</tex>
+%<*themes-witiko-dot>
+% \fi
+% \par
+% \begin{markdown}
+%
+% The `witiko/dot` theme enables the \Opt{fencedCode} Lua option:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\markdownSetup{fencedCode}
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We store the previous definition of the fenced code token renderer prototype:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\cs_set_eq:NN
+  \@@_dot_previous_definition:nnn
+  \markdownRendererInputFencedCodePrototype
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the infostring starts with `dot …`, we redefine the fenced code block
+% token renderer prototype, so that it typesets the code block via Graphviz
+% tools if and only if the \Opt{frozenCache} plain \TeX{} option is
+% disabled and the code block has not been previously typeset:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\regex_const:Nn
+  \c_@@_dot_infostring_regex
+  { ^dot(\s+(.+))? }
+\seq_new:N
+  \l_@@_dot_matches_seq
+\markdownSetup {
+  rendererPrototypes = {
+    inputFencedCode = {
+      \regex_extract_once:NnNTF
+        \c_@@_dot_infostring_regex
+        { #2 }
+        \l_@@_dot_matches_seq
+        {
+          \@@_if_option:nF
+            { frozenCache }
+            {
+              \sys_shell_now:n
+                {
+                  if~!~test~-e~#1.pdf.source~
+                  ||~!~diff~#1~#1.pdf.source;
+                  then~
+                    dot~-Tpdf~-o~#1.pdf~#1;
+                    cp~#1~#1.pdf.source;
+                  fi
+                }
+            }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We include the typeset image using the image token renderer:
+%
+% \end{markdown}
+%  \begin{macrocode}
+          \exp_args:NNne
+            \exp_last_unbraced:No
+            \markdownRendererImage
+              {
+                { Graphviz~image }
+                { #1.pdf }
+                { #1.pdf }
+              }
+              {
+                \seq_item:Nn
+                  \l_@@_dot_matches_seq
+                  { 3 }
+              }
+        }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the infostring does not start with `dot …`, we use the previous definition
+% of the fenced code token renderer prototype:
+%
+% \end{markdown}
+%  \begin{macrocode}
+        {
+          \@@_dot_previous_definition:nnn
+            { #1 }
+            { #2 }
+            { #3 }
+        }
+    },
+  },
+}
+\ExplSyntaxOff
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-dot>
+%<*themes-witiko-graphicx-http>
+% \fi
+% \par
+% \begin{markdown}
+%
+% The `witiko/graphicx/http` theme stores the previous definition of the image
+% token renderer prototype:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\cs_set_eq:NN
+  \@@_graphicx_http_previous_definition:nnnn
+  \markdownRendererImagePrototype
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We load the \pkg{grffile} package, see also Section
+% <#sec:latex-prerequisites>:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\RequirePackage{grffile}
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We define variables and functions to enumerate the images for caching and to
+% store the pathname of the file containing the pathname of the downloaded
+% image file.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\int_new:N
+  \g_@@_graphicx_http_image_number_int
+\int_gset:Nn
+  \g_@@_graphicx_http_image_number_int
+  { 0 }
+\cs_new:Nn
+  \@@_graphicx_http_filename:
+  {
+    \markdownOptionCacheDir
+    / witiko_graphicx_http .
+    \int_use:N
+      \g_@@_graphicx_http_image_number_int
+  }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We define a function that will receive two arguments that correspond to the
+% URL of the online image and to the pathname, where the online image should
+% be downloaded. The function produces a shell command that tries to
+% downloads the online image to the pathname.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\cs_new:Nn
+  \@@_graphicx_http_download:nn
+  {
+    wget~-O~#2~#1~
+    ||~curl~--location~-o~#2~#1~
+    ||~rm~-f~#2
+  }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We locally change the category code of percent signs, so that we
+% can use them in the shell code:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\char_set_catcode_other:N \%
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We redefine the image token renderer prototype, so that it tries to download
+% an online image.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\str_new:N
+  \l_@@_graphicx_http_filename_str
+\ior_new:N
+  \g_@@_graphicx_http_filename_ior
+\markdownSetup {
+  rendererPrototypes = {
+    image = {
+      \@@_if_option:nF
+        { frozenCache }
+        {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The image will be downloaded only if the image URL has the http or https
+% protocols and the \Opt{frozenCache} plain \TeX{} option is disabled:
+%
+% \end{markdown}
+%  \begin{macrocode}
+          \sys_shell_now:e
+            {
+              mkdir~-p~" \markdownOptionCacheDir ";
+              if~printf~'%s'~"#3"~|~grep~-q~-E~'^https?:';
+              then~
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The image will be downloaded to the pathname \Opt{cacheDir}<!--
+% -->`/`\meta{the MD5 digest of the image URL}`.`\meta{the suffix of the
+% image URL}:
+%
+% \end{markdown}
+%  \begin{macrocode}
+                OUTPUT_PREFIX=" \markdownOptionCacheDir ";
+                OUTPUT_BODY="$(printf~'%s'~'#3'
+                              |~md5sum~|~cut~-d'~'~-f1)";
+                OUTPUT_SUFFIX="$(printf~'%s'~'#3'
+                              |~sed~'s/.*[.]//')";
+                OUTPUT="$OUTPUT_PREFIX/$OUTPUT_BODY.$OUTPUT_SUFFIX";
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The image will be downloaded only if it has not already been downloaded:
+%
+% \end{markdown}
+%  \begin{macrocode}
+                if~!~[~-e~"$OUTPUT"~];
+                then~
+                  \@@_graphicx_http_download:nn
+                    { '#3' }
+                    { "$OUTPUT" } ;
+                  printf~'%s'~"$OUTPUT"~
+                    >~" \@@_graphicx_http_filename: ";
+                fi;
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If the image does not have the http or https protocols or the image has
+% already been downloaded, the URL will be stored as-is:
+%
+% \end{markdown}
+%  \begin{macrocode}
+              else~
+                printf~'%s'~'#3'~
+                  >~" \@@_graphicx_http_filename: ";
+              fi
+            }
+          }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We load the pathname of the downloaded image and we typeset the image using
+% the previous definition of the image renderer prototype:
+%
+% \end{markdown}
+%  \begin{macrocode}
+      \ior_open:Ne
+        \g_@@_graphicx_http_filename_ior
+        { \@@_graphicx_http_filename: }
+      \ior_str_get:NN
+        \g_@@_graphicx_http_filename_ior
+        \l_@@_graphicx_http_filename_str
+      \ior_close:N
+        \g_@@_graphicx_http_filename_ior
+      \@@_graphicx_http_previous_definition:nnVn
+        { #1 }
+        { #2 }
+        \l_@@_graphicx_http_filename_str
+        { #4 }
+      \int_gincr:N
+        \g_@@_graphicx_http_image_number_int
+    }
+  }
+}
+\char_set_catcode_comment:N \%
+\cs_generate_variant:Nn
+  \ior_open:Nn
+  { Ne }
+\cs_generate_variant:Nn
+  \@@_graphicx_http_previous_definition:nnnn
+  { nnVn }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \iffalse
+%</themes-witiko-graphicx-http>
 %<*themes-witiko-tilde>
 % \fi
 % \par
@@ -37344,306 +37628,28 @@ end
   \l_tmpb_tl
 \ExplSyntaxOff
 %    \end{macrocode}
-% \begin{markdown}
-%
-% The `witiko/dot` theme enables the \Opt{fencedCode} Lua option:
-%
-% \end{markdown}
 % \iffalse
 %</latex>
-%<*themes-witiko-dot>
+%<*themes-witiko-dot-latex,themes-witiko-graphicx-http-latex>
 % \fi
-%  \begin{macrocode}
-\markdownSetup{fencedCode}%
-%    \end{macrocode}
 % \begin{markdown}
 %
-% We load \pkg{grffile} package, see also Section
-% <#sec:latex-prerequisites>:
+% The `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes load the package
+% \pkg{grffile}.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \RequirePackage{grffile}
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We store the previous definition of the fenced code token renderer prototype:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\cs_set_eq:NN
-  \@@_dot_previous_definition:nnn
-  \markdownRendererInputFencedCodePrototype
-%    \end{macrocode}
-% \begin{markdown}
-%
-% If the infostring starts with `dot …`, we redefine the fenced code block
-% token renderer prototype, so that it typesets the code block via Graphviz
-% tools if and only if the \Opt{frozenCache} plain \TeX{} option is
-% disabled and the code block has not been previously typeset:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\regex_const:Nn
-  \c_@@_dot_infostring_regex
-  { ^dot(\s+(.+))? }
-\seq_new:N
-  \l_@@_dot_matches_seq
-\markdownSetup {
-  rendererPrototypes = {
-    inputFencedCode = {
-      \regex_extract_once:NnNTF
-        \c_@@_dot_infostring_regex
-        { #2 }
-        \l_@@_dot_matches_seq
-        {
-          \@@_if_option:nF
-            { frozenCache }
-            {
-              \sys_shell_now:n
-                {
-                  if~!~test~-e~#1.pdf.source~
-                  ||~!~diff~#1~#1.pdf.source;
-                  then~
-                    dot~-Tpdf~-o~#1.pdf~#1;
-                    cp~#1~#1.pdf.source;
-                  fi
-                }
-            }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We include the typeset image using the image token renderer:
-%
-% \end{markdown}
-%  \begin{macrocode}
-          \exp_args:NNne
-            \exp_last_unbraced:No
-            \markdownRendererImage
-              {
-                { Graphviz~image }
-                { #1.pdf }
-                { #1.pdf }
-              }
-              {
-                \seq_item:Nn
-                  \l_@@_dot_matches_seq
-                  { 3 }
-              }
-        }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% If the infostring does not start with `dot …`, we use the previous definition
-% of the fenced code token renderer prototype:
-%
-% \end{markdown}
-%  \begin{macrocode}
-        {
-          \@@_dot_previous_definition:nnn
-            { #1 }
-            { #2 }
-            { #3 }
-        }
-    },
-  },
-}
-\ExplSyntaxOff
+\markdownLoadPlainTeXTheme
 %    \end{macrocode}
 % \iffalse
-%</themes-witiko-dot>
-%<*themes-witiko-graphicx-http>
-% \fi
-% \par
-% \begin{markdown}
-%
-% The `witiko/graphicx/http` theme stores the previous definition of the image
-% token renderer prototype:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\ExplSyntaxOn
-\cs_set_eq:NN
-  \@@_graphicx_http_previous_definition:nnnn
-  \markdownRendererImagePrototype
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We load the \pkg{grffile} package, see also Section
-% <#sec:latex-prerequisites>:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\RequirePackage{grffile}
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We define variables and functions to enumerate the images for caching and to
-% store the pathname of the file containing the pathname of the downloaded
-% image file.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\int_new:N
-  \g_@@_graphicx_http_image_number_int
-\int_gset:Nn
-  \g_@@_graphicx_http_image_number_int
-  { 0 }
-\cs_new:Nn
-  \@@_graphicx_http_filename:
-  {
-    \markdownOptionCacheDir
-    / witiko_graphicx_http .
-    \int_use:N
-      \g_@@_graphicx_http_image_number_int
-  }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We define a function that will receive two arguments that correspond to the
-% URL of the online image and to the pathname, where the online image should
-% be downloaded. The function produces a shell command that tries to
-% downloads the online image to the pathname.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\cs_new:Nn
-  \@@_graphicx_http_download:nn
-  {
-    wget~-O~#2~#1~
-    ||~curl~--location~-o~#2~#1~
-    ||~rm~-f~#2
-  }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We locally change the category code of percent signs, so that we
-% can use them in the shell code:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\char_set_catcode_other:N \%
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We redefine the image token renderer prototype, so that it tries to download
-% an online image.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\str_new:N
-  \l_@@_graphicx_http_filename_str
-\ior_new:N
-  \g_@@_graphicx_http_filename_ior
-\markdownSetup {
-  rendererPrototypes = {
-    image = {
-      \@@_if_option:nF
-        { frozenCache }
-        {
-%    \end{macrocode}
-% \begin{markdown}
-%
-% The image will be downloaded only if the image URL has the http or https
-% protocols and the \Opt{frozenCache} plain \TeX{} option is disabled:
-%
-% \end{markdown}
-%  \begin{macrocode}
-          \sys_shell_now:e
-            {
-              mkdir~-p~" \markdownOptionCacheDir ";
-              if~printf~'%s'~"#3"~|~grep~-q~-E~'^https?:';
-              then~
-%    \end{macrocode}
-% \begin{markdown}
-%
-% The image will be downloaded to the pathname \Opt{cacheDir}<!--
-% -->`/`\meta{the MD5 digest of the image URL}`.`\meta{the suffix of the
-% image URL}:
-%
-% \end{markdown}
-%  \begin{macrocode}
-                OUTPUT_PREFIX=" \markdownOptionCacheDir ";
-                OUTPUT_BODY="$(printf~'%s'~'#3'
-                              |~md5sum~|~cut~-d'~'~-f1)";
-                OUTPUT_SUFFIX="$(printf~'%s'~'#3'
-                              |~sed~'s/.*[.]//')";
-                OUTPUT="$OUTPUT_PREFIX/$OUTPUT_BODY.$OUTPUT_SUFFIX";
-%    \end{macrocode}
-% \begin{markdown}
-%
-% The image will be downloaded only if it has not already been downloaded:
-%
-% \end{markdown}
-%  \begin{macrocode}
-                if~!~[~-e~"$OUTPUT"~];
-                then~
-                  \@@_graphicx_http_download:nn
-                    { '#3' }
-                    { "$OUTPUT" } ;
-                  printf~'%s'~"$OUTPUT"~
-                    >~" \@@_graphicx_http_filename: ";
-                fi;
-%    \end{macrocode}
-% \begin{markdown}
-%
-% If the image does not have the http or https protocols or the image has
-% already been downloaded, the URL will be stored as-is:
-%
-% \end{markdown}
-%  \begin{macrocode}
-              else~
-                printf~'%s'~'#3'~
-                  >~" \@@_graphicx_http_filename: ";
-              fi
-            }
-          }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We load the pathname of the downloaded image and we typeset the image using
-% the previous definition of the image renderer prototype:
-%
-% \end{markdown}
-%  \begin{macrocode}
-      \ior_open:Ne
-        \g_@@_graphicx_http_filename_ior
-        { \@@_graphicx_http_filename: }
-      \ior_str_get:NN
-        \g_@@_graphicx_http_filename_ior
-        \l_@@_graphicx_http_filename_str
-      \ior_close:N
-        \g_@@_graphicx_http_filename_ior
-      \@@_graphicx_http_previous_definition:nnVn
-        { #1 }
-        { #2 }
-        \l_@@_graphicx_http_filename_str
-        { #4 }
-      \int_gincr:N
-        \g_@@_graphicx_http_image_number_int
-    }
-  }
-}
-\char_set_catcode_comment:N \%
-\cs_generate_variant:Nn
-  \ior_open:Nn
-  { Ne }
-\cs_generate_variant:Nn
-  \@@_graphicx_http_previous_definition:nnnn
-  { nnVn }
-\ExplSyntaxOff
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-graphicx-http>
 %<*themes-witiko-markdown-defaults-latex>
 % \fi
 % \par
 % \begin{markdown}
 %
-% The `witiko/markdown/defaults` \LaTeX{} theme provides default definitions
-% for token renderer prototypes. First, the \LaTeX{} theme loads the plain
-% \TeX{} theme with the default definitions for plain \TeX{}:
+% The `witiko/dot`, `witiko/graphicx/http`, and `witiko/markdown/defaults`
+% \LaTeX{} themes load the corresponding plain \TeX{} themes.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -37662,6 +37668,7 @@ end
 % \end{markdown}
 % \iffalse
 %</themes-witiko-markdown-defaults-latex>
+%</themes-witiko-dot-latex,themes-witiko-graphicx-http-latex>
 %<*latex>
 % \fi
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1018,9 +1018,6 @@ Either of the two abovelisted approaches should produce the following files:
 * `markdown-cli.lua`: The Lua command-line interface
 * `markdown.tex`: The plain \TeX{} macro package
 * `markdown.sty`: The \LaTeX{} package
-* `markdownthemewitiko_dot.tex` and `markdownthemewitiko_dot.sty`: The `witiko/dot` \LaTeX{} theme
-* `markdownthemewitiko_graphicx_http.tex` and `markdownthemewitiko_graphicx_http.sty`: The `witiko/graphicx/http` \LaTeX{} theme
-* `markdownthemewitiko_tilde.tex`: The `witiko/tilde` theme
 * `markdownthemewitiko_markdown_defaults.tex`,
   `markdownthemewitiko_markdown_defaults.sty`, and
   `t-markdownthemewitiko_markdown_defaults.tex`: The `witiko/markdown/defaults`
@@ -1039,13 +1036,8 @@ placed:
 * `⟨TEXMF⟩/tex/luatex/markdown/markdown-tinyyaml.lua`
 * `⟨TEXMF⟩/scripts/markdown/markdown-cli.lua`
 * `⟨TEXMF⟩/tex/generic/markdown/markdown.tex`
-* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_tilde.tex`
 * `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_markdown_defaults.tex`
-* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_dot.tex`
-* `⟨TEXMF⟩/tex/generic/markdown/markdownthemewitiko_graphicx_http.tex`
 * `⟨TEXMF⟩/tex/latex/markdown/markdown.sty`
-* `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_dot.sty`
-* `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_graphicx_http.sty`
 * `⟨TEXMF⟩/tex/latex/markdown/markdownthemewitiko_markdown_defaults.sty`
 * `⟨TEXMF⟩/tex/context/third/markdown/t-markdown.tex`
 * `⟨TEXMF⟩/tex/context/third/markdown/t-markdownthemewitiko_markdown_defaults.tex`
@@ -1071,11 +1063,6 @@ This is where the individual files should be placed:
 * `./markdown/markdown.tex`
 * `./markdown.sty`
 * `./t-markdown.tex`
-* `./markdownthemewitiko_dot.tex`
-* `./markdownthemewitiko_dot.sty`
-* `./markdownthemewitiko_graphicx_http.tex`
-* `./markdownthemewitiko_graphicx_http.sty`
-* `./markdownthemewitiko_tilde.tex`
 * `./markdownthemewitiko_markdown_defaults.tex`
 * `./markdownthemewitiko_markdown_defaults.sty`
 * `./t-markdownthemewitiko_markdown_defaults.tex`
@@ -13122,7 +13109,17 @@ a specific look and other high-level goals without low-level programming.
 \cs_generate_variant:Nn
   \cs_gset:Npn
   { Npe }
-\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We also define the prop \mdef{g_@@_plain_tex_built_in_themes_prop} that
+% contains the code of built-in themes. This is a packaging optimization,
+% so that built-in themes does not need to be distributed in many small files.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\prop_new:N
+  \g_@@_plain_tex_built_in_themes_prop
 %    \end{macrocode}
 % \iffalse
 %</tex>
@@ -13261,15 +13258,6 @@ conference article:
 > Informatik V, RWTH Aachen., 2020, vol. 2020, No 2696, p. 1-30. ISSN 1613-0073.
 > <http://ceur-ws.org/Vol-2696/paper_235.pdf>
 
-%</manual-options>
-%<*themes-witiko-dot-latex>
-% \fi
-%  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_dot}[2024/11/20]%
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-dot-latex>
-%<*manual-options>
 % \fi
 % \par
 % \markdownBegin
@@ -13324,15 +13312,6 @@ following image:
 > ![Figure 1: The banner of the Markdown package](https://github.com/witiko/markdown/raw/main/markdown.png
                                                   "Figure 1: The banner of the Markdown package")
 
-%</manual-options>
-%<*themes-witiko-graphicx-http-latex>
-% \fi
-%  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_graphicx_http}[2024/11/20]%
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-graphicx-http-latex>
-%<*manual-options>
 % \fi
 % \par
 % \begin{markdown}
@@ -13412,7 +13391,6 @@ options locally.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\ExplSyntaxOn
 \prop_new:N
   \g_@@_snippets_prop
 \cs_new:Nn
@@ -23254,9 +23232,24 @@ would use the following code in the preamble of your document:
 Due to limitations of \LaTeX{}, themes may not be loaded after the
 beginning of a \LaTeX{} document.
 
+% We also define the prop \mdef{g_@@_latex_built_in_themes_prop} that
+% contains the code of built-in themes. This is a packaging optimization,
+% so that built-in themes does not need to be distributed in many small files.
+%
 % \end{markdown}
+% \iffalse
+%</manual-options>
+%<*latex>
+%  \begin{macrocode}
+\prop_new:N
+  \g_@@_latex_built_in_themes_prop
+%    \end{macrocode}
+% \iffalse
+%</latex>
+%<*manual-options>
+% \fi
 % \par
-% \markdownBegin
+% \begin{markdown}
 
 Built-in \LaTeX{} themes provided with the Markdown package include:
 
@@ -23314,13 +23307,6 @@ Built-in \LaTeX{} themes provided with the Markdown package include:
 %    \end{macrocode}
 % \iffalse
 %</latex>
-%<*themes-witiko-markdown-defaults-latex>
-% \fi
-%  \begin{macrocode}
-\ProvidesPackage{markdownthemewitiko_markdown_defaults}[2024/10/29]%
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-markdown-defaults-latex>
 %<*context>
 % \fi
 % \par
@@ -23698,6 +23684,25 @@ For example, to load a theme named `witiko/tilde` in your document:
 \setupmarkdown[import=witiko/tilde]
 ```````
 
+% We also define the prop \mdef{g_@@_context_built_in_themes_prop} that
+% contains the code of built-in themes. This is a packaging optimization,
+% so that built-in themes does not need to be distributed in many small files.
+%
+% \end{markdown}
+% \iffalse
+%</manual-options>
+%<*context>
+% \fi
+%  \begin{macrocode}
+\prop_new:N
+  \g_@@_context_built_in_themes_prop
+%    \end{macrocode}
+% \iffalse
+%</context>
+%<*manual-options>
+% \fi
+% \begin{markdown}
+
 Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
 
 \pkg{witiko/markdown/defaults}
@@ -23706,21 +23711,6 @@ Built-in \Hologo{ConTeXt} themes provided with the Markdown package include:
      prototypes for plain \TeX{}. This theme is loaded automatically together
      with the package and explicitly loading it has no effect.
 
-% \end{markdown}
-% \iffalse
-%</manual-options>
-%<*themes-witiko-markdown-defaults-ctx>
-% \fi
-%  \begin{macrocode}
-\startmodule[markdownthemewitiko_markdown_defaults]
-\unprotect
-%    \end{macrocode}
-% \iffalse
-%</themes-witiko-markdown-defaults-ctx>
-%<*manual-options>
-% \fi
-% \begin{markdown}
-%
 % Please, see Section <#sec:context-themes-implementation> for implementation
 % details of the built-in \Hologo{ConTeXt} themes.
 %
@@ -35505,11 +35495,6 @@ end
           }
       }
       {
-        \msg_info:nnnn
-          { markdown }
-          { loading-plain-tex-theme }
-          { #1 }
-          { #2 }
         \prop_gput:Nnx
           \g_@@_plain_tex_loaded_themes_linenos_prop
           { #1 }
@@ -35518,14 +35503,46 @@ end
           \g_@@_plain_tex_loaded_themes_versions_prop
           { #1 }
           { #2 }
-        \file_input:n
-          { markdown theme #3 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Load built-in plain \TeX{} themes from the prop
+% \mref{g_@@_plain_tex_built_in_themes_prop} and from the filesystem otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \prop_if_in:NnTF
+          \g_@@_plain_tex_built_in_themes_prop
+          { #1 }
+          {
+            \msg_info:nnnn
+              { markdown }
+              { loading-built-in-plain-tex-theme }
+              { #1 }
+              { #2 }
+            \prop_item:Nn
+              \g_@@_plain_tex_built_in_themes_prop
+              { #1 }
+          }
+          {
+            \msg_info:nnnn
+              { markdown }
+              { loading-plain-tex-theme }
+              { #1 }
+              { #2 }
+            \file_input:n
+              { markdown theme #3 }
+          }
       }
   }
 \msg_new:nnn
   { markdown }
   { loading-plain-tex-theme }
   { Loading~version~#2~of~plain~TeX~Markdown~theme~#1 }
+\msg_new:nnn
+  { markdown }
+  { loading-built-in-plain-tex-theme }
+  { Loading~version~#2~of~built-in~plain~TeX~Markdown~theme~#1 }
 \msg_new:nnn
   { markdown }
   { repeatedly-loaded-plain-tex-theme }
@@ -35620,21 +35637,18 @@ end
 \cs_generate_variant:Nn
   \@@_plain_tex_load_theme:nnn
   { VeV }
-\ExplSyntaxOff
 %    \end{macrocode}
-% \iffalse
-%</tex>
-%<*themes-witiko-dot>
-% \fi
-% \par
 % \begin{markdown}
 %
 % The `witiko/dot` theme enables the \Opt{fencedCode} Lua option:
 %
 % \end{markdown}
 %  \begin{macrocode}
-\ExplSyntaxOn
-\markdownSetup{fencedCode}
+\prop_gput:Nnn
+  \g_@@_plain_tex_built_in_themes_prop
+  { witiko / dot }
+  {
+    \markdownSetup{fencedCode}
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35642,9 +35656,9 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\cs_set_eq:NN
-  \@@_dot_previous_definition:nnn
-  \markdownRendererInputFencedCodePrototype
+    \cs_set_eq:NN
+      \@@_dot_previous_definition:nnn
+      \markdownRendererInputFencedCodePrototype
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35655,32 +35669,32 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\regex_const:Nn
-  \c_@@_dot_infostring_regex
-  { ^dot(\s+(.+))? }
-\seq_new:N
-  \l_@@_dot_matches_seq
-\markdownSetup {
-  rendererPrototypes = {
-    inputFencedCode = {
-      \regex_extract_once:NnNTF
-        \c_@@_dot_infostring_regex
-        { #2 }
-        \l_@@_dot_matches_seq
-        {
-          \@@_if_option:nF
-            { frozenCache }
+    \regex_const:Nn
+      \c_@@_dot_infostring_regex
+      { ^dot(\s+(.+))? }
+    \seq_new:N
+      \l_@@_dot_matches_seq
+    \markdownSetup {
+      rendererPrototypes = {
+        inputFencedCode = {
+          \regex_extract_once:NnNTF
+            \c_@@_dot_infostring_regex
+            { #2 }
+            \l_@@_dot_matches_seq
             {
-              \sys_shell_now:n
+              \@@_if_option:nF
+                { frozenCache }
                 {
-                  if~!~test~-e~#1.pdf.source~
-                  ||~!~diff~#1~#1.pdf.source;
-                  then~
-                    dot~-Tpdf~-o~#1.pdf~#1;
-                    cp~#1~#1.pdf.source;
-                  fi
+                  \sys_shell_now:n
+                    {
+                      if~!~test~-e~#1.pdf.source~
+                      ||~!~diff~#1~#1.pdf.source;
+                      then~
+                        dot~-Tpdf~-o~#1.pdf~#1;
+                        cp~#1~#1.pdf.source;
+                      fi
+                    }
                 }
-            }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35688,20 +35702,20 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-          \exp_args:NNne
-            \exp_last_unbraced:No
-            \markdownRendererImage
-              {
-                { Graphviz~image }
-                { #1.pdf }
-                { #1.pdf }
-              }
-              {
-                \seq_item:Nn
-                  \l_@@_dot_matches_seq
-                  { 3 }
-              }
-        }
+              \exp_args:NNne
+                \exp_last_unbraced:No
+                \markdownRendererImage
+                  {
+                    { Graphviz~image }
+                    { #1.pdf }
+                    { #1.pdf }
+                  }
+                  {
+                    \seq_item:Nn
+                      \l_@@_dot_matches_seq
+                      { 3 }
+                  }
+            }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35710,22 +35724,27 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-        {
-          \@@_dot_previous_definition:nnn
-            { #1 }
-            { #2 }
-            { #3 }
-        }
-    },
-  },
-}
-\ExplSyntaxOff
+            {
+              \@@_dot_previous_definition:nnn
+                { #1 }
+                { #2 }
+                { #3 }
+            }
+        },
+      },
+    }
+  }
 %    \end{macrocode}
-% \iffalse
-%</themes-witiko-dot>
-%<*themes-witiko-graphicx-http>
-% \fi
-% \par
+% \begin{markdown}
+%
+% We locally change the category code of percent signs, so that we
+% can use them in the shell code:
+%
+% \end{markdown}
+%  \begin{macrocode}
+\group_begin:
+\char_set_catcode_other:N \%
+%    \end{macrocode}
 % \begin{markdown}
 %
 % The `witiko/graphicx/http` theme stores the previous definition of the image
@@ -35733,10 +35752,13 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\ExplSyntaxOn
-\cs_set_eq:NN
-  \@@_graphicx_http_previous_definition:nnnn
-  \markdownRendererImagePrototype
+\prop_gput:Nnn
+  \g_@@_plain_tex_built_in_themes_prop
+  { witiko / graphicx / http }
+  {
+    \cs_set_eq:NN
+      \@@_graphicx_http_previous_definition:nnnn
+      \markdownRendererImagePrototype
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35746,19 +35768,19 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\int_new:N
-  \g_@@_graphicx_http_image_number_int
-\int_gset:Nn
-  \g_@@_graphicx_http_image_number_int
-  { 0 }
-\cs_new:Nn
-  \@@_graphicx_http_filename:
-  {
-    \markdownOptionCacheDir
-    / witiko_graphicx_http .
-    \int_use:N
+    \int_new:N
       \g_@@_graphicx_http_image_number_int
-  }
+    \int_gset:Nn
+      \g_@@_graphicx_http_image_number_int
+      { 0 }
+    \cs_new:Nn
+      \@@_graphicx_http_filename:
+      {
+        \markdownOptionCacheDir
+        / witiko_graphicx_http .
+        \int_use:N
+          \g_@@_graphicx_http_image_number_int
+      }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35769,22 +35791,13 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\cs_new:Nn
-  \@@_graphicx_http_download:nn
-  {
-    wget~-O~#2~#1~
-    ||~curl~--location~-o~#2~#1~
-    ||~rm~-f~#2
-  }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% We locally change the category code of percent signs, so that we
-% can use them in the shell code:
-%
-% \end{markdown}
-%  \begin{macrocode}
-\char_set_catcode_other:N \%
+    \cs_new:Nn
+      \@@_graphicx_http_download:nn
+      {
+        wget~-O~#2~#1~
+        ||~curl~--location~-o~#2~#1~
+        ||~rm~-f~#2
+      }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35793,16 +35806,16 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\str_new:N
-  \l_@@_graphicx_http_filename_str
-\ior_new:N
-  \g_@@_graphicx_http_filename_ior
-\markdownSetup {
-  rendererPrototypes = {
-    image = {
-      \@@_if_option:nF
-        { frozenCache }
-        {
+    \str_new:N
+      \l_@@_graphicx_http_filename_str
+    \ior_new:N
+      \g_@@_graphicx_http_filename_ior
+    \markdownSetup {
+      rendererPrototypes = {
+        image = {
+          \@@_if_option:nF
+            { frozenCache }
+            {
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35811,11 +35824,11 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-          \sys_shell_now:e
-            {
-              mkdir~-p~" \markdownOptionCacheDir ";
-              if~printf~'%s'~"#3"~|~grep~-q~-E~'^https?:';
-              then~
+              \sys_shell_now:e
+                {
+                  mkdir~-p~" \markdownOptionCacheDir ";
+                  if~printf~'%s'~"#3"~|~grep~-q~-E~'^https?:';
+                  then~
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35825,12 +35838,12 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-                OUTPUT_PREFIX=" \markdownOptionCacheDir ";
-                OUTPUT_BODY="$(printf~'%s'~'#3'
-                              |~md5sum~|~cut~-d'~'~-f1)";
-                OUTPUT_SUFFIX="$(printf~'%s'~'#3'
-                              |~sed~'s/.*[.]//')";
-                OUTPUT="$OUTPUT_PREFIX/$OUTPUT_BODY.$OUTPUT_SUFFIX";
+                    OUTPUT_PREFIX=" \markdownOptionCacheDir ";
+                    OUTPUT_BODY="$(printf~'%s'~'#3'
+                                  |~md5sum~|~cut~-d'~'~-f1)";
+                    OUTPUT_SUFFIX="$(printf~'%s'~'#3'
+                                  |~sed~'s/.*[.]//')";
+                    OUTPUT="$OUTPUT_PREFIX/$OUTPUT_BODY.$OUTPUT_SUFFIX";
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35838,14 +35851,14 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-                if~!~[~-e~"$OUTPUT"~];
-                then~
-                  \@@_graphicx_http_download:nn
-                    { '#3' }
-                    { "$OUTPUT" } ;
-                  printf~'%s'~"$OUTPUT"~
-                    >~" \@@_graphicx_http_filename: ";
-                fi;
+                    if~!~[~-e~"$OUTPUT"~];
+                    then~
+                      \@@_graphicx_http_download:nn
+                        { '#3' }
+                        { "$OUTPUT" } ;
+                      printf~'%s'~"$OUTPUT"~
+                        >~" \@@_graphicx_http_filename: ";
+                    fi;
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35854,12 +35867,12 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-              else~
-                printf~'%s'~'#3'~
-                  >~" \@@_graphicx_http_filename: ";
-              fi
-            }
-          }
+                  else~
+                    printf~'%s'~'#3'~
+                      >~" \@@_graphicx_http_filename: ";
+                  fi
+                }
+              }
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35868,38 +35881,33 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-      \ior_open:Ne
-        \g_@@_graphicx_http_filename_ior
-        { \@@_graphicx_http_filename: }
-      \ior_str_get:NN
-        \g_@@_graphicx_http_filename_ior
-        \l_@@_graphicx_http_filename_str
-      \ior_close:N
-        \g_@@_graphicx_http_filename_ior
-      \@@_graphicx_http_previous_definition:nnVn
-        { #1 }
-        { #2 }
-        \l_@@_graphicx_http_filename_str
-        { #4 }
-      \int_gincr:N
-        \g_@@_graphicx_http_image_number_int
+          \ior_open:Ne
+            \g_@@_graphicx_http_filename_ior
+            { \@@_graphicx_http_filename: }
+          \ior_str_get:NN
+            \g_@@_graphicx_http_filename_ior
+            \l_@@_graphicx_http_filename_str
+          \ior_close:N
+            \g_@@_graphicx_http_filename_ior
+          \@@_graphicx_http_previous_definition:nnVn
+            { #1 }
+            { #2 }
+            \l_@@_graphicx_http_filename_str
+            { #4 }
+          \int_gincr:N
+            \g_@@_graphicx_http_image_number_int
+        }
+      }
     }
+    \cs_generate_variant:Nn
+      \ior_open:Nn
+      { Ne }
+    \cs_generate_variant:Nn
+      \@@_graphicx_http_previous_definition:nnnn
+      { nnVn }
   }
-}
-\char_set_catcode_comment:N \%
-\cs_generate_variant:Nn
-  \ior_open:Nn
-  { Ne }
-\cs_generate_variant:Nn
-  \@@_graphicx_http_previous_definition:nnnn
-  { nnVn }
-\ExplSyntaxOff
+\group_end:
 %    \end{macrocode}
-% \iffalse
-%</themes-witiko-graphicx-http>
-%<*themes-witiko-tilde>
-% \fi
-% \par
 % \begin{markdown}
 %
 % The `witiko/tilde` theme redefines the tilde token renderer prototype,
@@ -35907,14 +35915,20 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-\markdownSetup {
-  rendererPrototypes = {
-    tilde = {~},
-  },
-}
+\prop_gput:Nnn
+  \g_@@_plain_tex_built_in_themes_prop
+  { witiko / tilde }
+  {
+    \markdownSetup {
+      rendererPrototypes = {
+        tilde = {~},
+      },
+    }
+  }
+\ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
-%</themes-witiko-tilde>
+%</tex>
 %<*themes-witiko-markdown-defaults-tex>
 % \fi
 % \begin{markdown}
@@ -37443,9 +37457,11 @@ end
 % \par
 % \begin{markdown}
 %
-% If the Markdown package has already been loaded, determine whether
-% a file named `markdowntheme`\meta{munged theme name}`.sty` exists
-% and whether we are still in the preamble.
+% If the Markdown package has not yet been loaded, determine whether
+% either this is a built-in theme according to the prop
+% \mref{g_@@_latex_built_in_themes_prop} or a file named
+% `markdowntheme`\meta{munged theme name}`.sty` exists and whether we are still
+% in the preamble.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -37454,20 +37470,37 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% If both conditions are true does, end with an error, since we cannot load
-% \LaTeX{} themes after the preamble. Otherwise, try loading a plain \TeX{}
-% theme instead.
+% If both conditions are true, end with an error, since we cannot load
+% \LaTeX{} themes after the preamble.
 %
 % \end{markdown}
 %  \begin{macrocode}
-        \file_if_exist:nTF
-          { markdown theme #3.sty }
+        \bool_if:nTF
+          {
+            \bool_lazy_or_p:nn
+              {
+                \prop_if_in_p:Nn
+                  \g_@@_latex_built_in_themes_prop
+                  { #1 }
+              }
+              {
+                \file_if_exist_p:n
+                  { markdown theme #3.sty }
+              }
+          }
           {
             \msg_error:nnn
               { markdown }
               { latex-theme-after-preamble }
               { #1 }
           }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Otherwise, try loading a plain \TeX{} theme instead.
+%
+% \end{markdown}
+%  \begin{macrocode}
           {
             \@@_plain_tex_load_theme:nnn
               { #1 }
@@ -37484,8 +37517,19 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-        \file_if_exist:nTF
-          { markdown theme #3.sty }
+        \bool_if:nTF
+          {
+            \bool_lazy_or_p:nn
+              {
+                \prop_if_in_p:Nn
+                  \g_@@_latex_built_in_themes_prop
+                  { #1 }
+              }
+              {
+                \file_if_exist_p:n
+                  { markdown theme #3.sty }
+              }
+          }
           {
             \prop_get:NnNTF
               \g_@@_latex_loaded_themes_linenos_prop
@@ -37518,11 +37562,6 @@ end
                   }
               }
               {
-                \msg_info:nnnn
-                  { markdown }
-                  { loading-latex-theme }
-                  { #1 }
-                  { #2 }
                 \prop_gput:Nnx
                   \g_@@_latex_loaded_themes_linenos_prop
                   { #1 }
@@ -37531,8 +37570,36 @@ end
                   \g_@@_latex_loaded_themes_versions_prop
                   { #1 }
                   { #2 }
-                \RequirePackage
-                  { markdown theme #3 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Load built-in plain \TeX{} themes from the prop
+% \mref{g_@@_latex_built_in_themes_prop} and from the filesystem otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+                \prop_if_in:NnTF
+                  \g_@@_latex_built_in_themes_prop
+                  { #1 }
+                  {
+                    \msg_info:nnnn
+                      { markdown }
+                      { loading-built-in-latex-theme }
+                      { #1 }
+                      { #2 }
+                    \prop_item:Nn
+                      \g_@@_latex_built_in_themes_prop
+                      { #1 }
+                  }
+                  {
+                    \msg_info:nnnn
+                      { markdown }
+                      { loading-latex-theme }
+                      { #1 }
+                      { #2 }
+                    \RequirePackage
+                      { markdown theme #3 }
+                  }
               }
           }
           {
@@ -37570,6 +37637,10 @@ end
     Postponing~loading~version~#2~of~Markdown~theme~#1~until~
     Markdown~package~has~finished~loading
   }
+\msg_new:nnn
+  { markdown }
+  { loading-built-in-latex-theme }
+  { Loading~version~#2~of~built-in~LaTeX~Markdown~theme~#1 }
 \msg_new:nnn
   { markdown }
   { loading-latex-theme }
@@ -37614,30 +37685,34 @@ end
   { latex-theme-after-preamble }
   \l_tmpa_tl
   \l_tmpb_tl
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes load the package
+% \pkg{graphicx}, see also Section <#sec:latex-prerequisites>. Then, they
+% load the corresponding plain \TeX{} themes.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\prop_gput:Nnn
+  \g_@@_latex_built_in_themes_prop
+  { witiko / dot }
+  {
+    \RequirePackage
+      { graphicx }
+    \markdownLoadPlainTeXTheme
+  }
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse
 %</latex>
-%<*themes-witiko-dot-latex,themes-witiko-graphicx-http-latex>
-% \fi
-% \begin{markdown}
-%
-% The `witiko/dot` and `witiko/graphicx/http` \LaTeX{} themes load the package
-% \pkg{graphicx}, see also Section <#sec:latex-prerequisites>.
-%
-% \end{markdown}
-%  \begin{macrocode}
-\RequirePackage{graphicx}
-\markdownLoadPlainTeXTheme
-%    \end{macrocode}
-% \iffalse
 %<*themes-witiko-markdown-defaults-latex>
 % \fi
 % \par
 % \begin{markdown}
 %
-% The `witiko/dot`, `witiko/graphicx/http`, and `witiko/markdown/defaults`
-% \LaTeX{} themes load the corresponding plain \TeX{} themes.
+% The `witiko/markdown/defaults` \LaTeX{} theme also loads the corresponding
+% plain \TeX{} theme.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -37656,7 +37731,6 @@ end
 % \end{markdown}
 % \iffalse
 %</themes-witiko-markdown-defaults-latex>
-%</themes-witiko-dot-latex,themes-witiko-graphicx-http-latex>
 %<*latex>
 % \fi
 %  \begin{macrocode}
@@ -39421,14 +39495,26 @@ end
 % \par
 % \begin{markdown}
 %
-% Determine whether a file named `t-markdowntheme`\meta{munged theme
-% name}`.tex` exists. If it does, load it. Otherwise, try loading a plain
-% \TeX{} theme instead.
+% Determine whether either this is a built-in theme according to the prop
+% \mref{g_@@_context_built_in_themes_prop} or a file named
+% `t-markdowntheme`\meta{munged theme name}`.tex` exists. If it does, load it.
+% Otherwise, try loading a plain \TeX{} theme instead.
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \file_if_exist:nTF
-      { t - markdown theme #3.tex }
+    \bool_if:nTF
+      {
+        \bool_lazy_or_p:nn
+          {
+            \prop_if_in_p:Nn
+              \g_@@_context_built_in_themes_prop
+              { #1 }
+          }
+          {
+            \file_if_exist_p:n
+              { t - markdown theme #3.tex }
+          }
+      }
       {
         \prop_get:NnNTF
           \g_@@_context_loaded_themes_linenos_prop
@@ -39461,11 +39547,6 @@ end
               }
           }
           {
-            \msg_info:nnn
-              { markdown }
-              { loading-context-theme }
-              { #1 }
-              { #2 }
             \prop_gput:Nnx
               \g_@@_context_loaded_themes_linenos_prop
               { #1 }
@@ -39474,9 +39555,37 @@ end
               \g_@@_context_loaded_themes_versions_prop
               { #1 }
               { #2 }
-            \usemodule
-              [ t ]
-              [ markdown theme #3 ]
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Load built-in plain \TeX{} themes from the prop
+% \mref{g_@@_context_built_in_themes_prop} and from the filesystem otherwise.
+%
+% \end{markdown}
+%  \begin{macrocode}
+            \prop_if_in:NnTF
+              \g_@@_context_built_in_themes_prop
+              { #1 }
+              {
+                \msg_info:nnnn
+                  { markdown }
+                  { loading-built-in-context-theme }
+                  { #1 }
+                  { #2 }
+                \prop_item:Nn
+                  \g_@@_context_built_in_themes_prop
+                  { #1 }
+              }
+              {
+                \msg_info:nnnn
+                  { markdown }
+                  { loading-context-theme }
+                  { #1 }
+                  { #2 }
+                \usemodule
+                  [ t ]
+                  [ markdown theme #3 ]
+              }
           }
       }
       {
@@ -39486,6 +39595,10 @@ end
           { #3 }
       }
   }
+\msg_new:nnn
+  { markdown }
+  { loading-built-in-context-theme }
+  { Loading~version~#2~of~built-in~ConTeXt~Markdown~theme~#1 }
 \msg_new:nnn
   { markdown }
   { loading-context-theme }

--- a/markdown.ins
+++ b/markdown.ins
@@ -12,8 +12,10 @@
     \file{markdown.tex}{\from{markdown.dtx}{tex}}
     \file{markdown.sty}{\from{markdown.dtx}{latex}}
     \file{t-markdown.tex}{\from{markdown.dtx}{context}}
-    \file{markdownthemewitiko_dot.sty}{\from{markdown.dtx}{themes-witiko-dot}}
-    \file{markdownthemewitiko_graphicx_http.sty}{\from{markdown.dtx}{themes-witiko-graphicx-http}}
+    \file{markdownthemewitiko_dot.tex}{\from{markdown.dtx}{themes-witiko-dot}}
+    \file{markdownthemewitiko_dot.sty}{\from{markdown.dtx}{themes-witiko-dot-latex}}
+    \file{markdownthemewitiko_graphicx_http.tex}{\from{markdown.dtx}{themes-witiko-graphicx-http}}
+    \file{markdownthemewitiko_graphicx_http.sty}{\from{markdown.dtx}{themes-witiko-graphicx-http-latex}}
     \file{markdownthemewitiko_tilde.tex}{\from{markdown.dtx}{themes-witiko-tilde}}
     \file{markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-tex}}
     \file{markdownthemewitiko_markdown_defaults.sty}{\from{markdown.dtx}{themes-witiko-markdown-defaults-latex}}

--- a/markdown.ins
+++ b/markdown.ins
@@ -12,11 +12,6 @@
     \file{markdown.tex}{\from{markdown.dtx}{tex}}
     \file{markdown.sty}{\from{markdown.dtx}{latex}}
     \file{t-markdown.tex}{\from{markdown.dtx}{context}}
-    \file{markdownthemewitiko_dot.tex}{\from{markdown.dtx}{themes-witiko-dot}}
-    \file{markdownthemewitiko_dot.sty}{\from{markdown.dtx}{themes-witiko-dot-latex}}
-    \file{markdownthemewitiko_graphicx_http.tex}{\from{markdown.dtx}{themes-witiko-graphicx-http}}
-    \file{markdownthemewitiko_graphicx_http.sty}{\from{markdown.dtx}{themes-witiko-graphicx-http-latex}}
-    \file{markdownthemewitiko_tilde.tex}{\from{markdown.dtx}{themes-witiko-tilde}}
     \file{markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-tex}}
     \file{markdownthemewitiko_markdown_defaults.sty}{\from{markdown.dtx}{themes-witiko-markdown-defaults-latex}}
     \file{t-markdownthemewitiko_markdown_defaults.tex}{\from{markdown.dtx}{themes-witiko-markdown-defaults-ctx}}


### PR DESCRIPTION
Closes #522.

### Tasks

- [x] Update all built-in themes to use expl3 exclusively and eliminate dependencies on packages `ifthen`, `gobble`, and `catchfile`.
- [x] Make built-in LaTeX themes `witiko/dot` and `witiko/graphicx/http` into plain TeX themes.
- [x] Store built-in themes in an expl3 prop in files `markdown.tex` and `markdown.sty`, simplifying distribution and installation.