### PR TITLE
Make `markdown-cli` executable and symlink it to system directories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Test Lua command-line interface
         run: |
           set -ex
-          printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | bash -c 'time markdown-cli texMathDollars=true' 1>stdout 2>stderr
+          printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | bash -c 'time markdown-cli eagerCache=false texMathDollars=true' 1>stdout 2>stderr
           test "$(cat stdout)" = '\markdownRendererDocumentBegin
           Hello \markdownRendererEmphasis{Markdown}! \markdownRendererInlineMath{a_x + b_x = c_x}\markdownRendererDocumentEnd'  # Check that the output is correct.
           grep 'real\s*0m[01]' stderr  # Check that the command finishes in less than a second.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 Distribution:
 
-- Make `markdown-cli` executable and symlinked to system directories.
+- Make `markdown-cli` executable and symlink it to system directories.
   (#534, #537, [tex-live@tug.org][tex-live-2024-12-050952])
 
  [tex-live-2024-12-050952]: https://tug.org/pipermail/tex-live/2024-December/050952.html

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## 3.9.1
 
+Distribution:
+
+- Make `markdown-cli` executable and symlinked to system directories.
+  (#534, #537, [tex-live@tug.org][tex-live-2024-12-050952])
+
+ [tex-live-2024-12-050952]: https://tug.org/pipermail/tex-live/2024-December/050952.html
+
 ## 3.9.0 (2024-11-21)
 
 Development:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ FROM $FROM_IMAGE:$TEXLIVE_TAG as build
 ARG DEPENDENCIES
 ARG TEXLIVE_DEPENDENCIES
 
+ARG BINARY_DIR
 ARG BUILD_DIR
 ARG INSTALL_DIR
 ARG PREINSTALLED_DIR
@@ -121,6 +122,9 @@ cp ${BUILD_DIR}/markdownthemewitiko_markdown_defaults.sty    ${INSTALL_DIR}/tex/
 mkdir -p                                                     ${INSTALL_DIR}/tex/context/third/markdown/
 cp ${BUILD_DIR}/t-markdown.tex                               ${INSTALL_DIR}/tex/context/third/markdown/
 cp ${BUILD_DIR}/t-markdownthemewitiko_markdown_defaults.tex  ${INSTALL_DIR}/tex/context/third/markdown/
+
+# Make the markdown-cli script executable
+ln -s ${INSTALL_DIR}/scripts/markdown/markdown-cli.lua       ${BINARY_DIR}/markdown-cli
 
 # Generate the ConTeXt file database
 if test ${DEV_IMAGE} != true
@@ -216,7 +220,7 @@ set -o nounset
 set -o xtrace
 
 # Make the markdown-cli script executable
-ln -s ${INSTALL_DIR}/scripts/markdown/markdown-cli.lua ${BINARY_DIR}/markdown-cli
+ln -s ${INSTALL_DIR}/scripts/markdown/markdown-cli.lua       ${BINARY_DIR}/markdown-cli
 
 # Generate the ConTeXt file database
 if echo ${TEXLIVE_TAG} | grep -q latest-minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ rm -rfv ${PREINSTALLED_DIR}/scripts/markdown/
 rm -rfv ${PREINSTALLED_DIR}/tex/generic/markdown/
 rm -rfv ${PREINSTALLED_DIR}/tex/latex/markdown/
 rm -rfv ${PREINSTALLED_DIR}/tex/context/third/markdown/
+rm -fv ${BINARY_DIR}/markdown-cli
 
 # Install the current Markdown package
 make -C ${BUILD_DIR} implode
@@ -201,17 +202,12 @@ rm -rfv ${PREINSTALLED_DIR}/scripts/markdown/
 rm -rfv ${PREINSTALLED_DIR}/tex/generic/markdown/
 rm -rfv ${PREINSTALLED_DIR}/tex/latex/markdown/
 rm -rfv ${PREINSTALLED_DIR}/tex/context/third/markdown/
+rm -fv ${BINARY_DIR}/markdown-cli
 
 EOF
 
 # Install the Markdown package
 COPY --from=build ${BUILD_DIR}/dist ${INSTALL_DIR}/
-
-COPY <<EOF ${BINARY_DIR}/markdown-cli
-#!/bin/bash
-texlua ${INSTALL_DIR}/scripts/markdown/markdown-cli.lua eagerCache=false \"\$@\"
-echo
-EOF
 
 RUN <<EOF
 
@@ -220,7 +216,7 @@ set -o nounset
 set -o xtrace
 
 # Make the markdown-cli script executable
-chmod +x ${BINARY_DIR}/markdown-cli
+ln -s ${INSTALL_DIR}/scripts/markdown/markdown-cli.lua ${BINARY_DIR}/markdown-cli
 
 # Generate the ConTeXt file database
 if echo ${TEXLIVE_TAG} | grep -q latest-minimal

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ $(GITHUB_PAGES): $(HTML_USER_MANUAL)
 # This target extracts the source files out of the DTX archive.
 $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	luatex $<
-	sed -i '1i#!/usr/bin/env luatex' markdown-cli.lua
+	sed -i '1i#!/usr/bin/env texlua' markdown-cli.lua
 	chmod +x markdown-cli.lua
 	texlua markdown-unicode-data-generator.lua >> markdown-unicode-data.lua
 	sed -i \

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ $(GITHUB_PAGES): $(HTML_USER_MANUAL)
 # This target extracts the source files out of the DTX archive.
 $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	luatex $<
+	sed -i '1i#!/usr/bin/env luatex' markdown-cli.lua
 	texlua markdown-unicode-data-generator.lua >> markdown-unicode-data.lua
 	sed -i \
 	    -e 's#(((VERSION)))#$(VERSION)#g' \

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ $(GITHUB_PAGES): $(HTML_USER_MANUAL)
 $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	luatex $<
 	sed -i '1i#!/usr/bin/env luatex' markdown-cli.lua
+	chmod +x markdown-cli.lua
 	texlua markdown-unicode-data-generator.lua >> markdown-unicode-data.lua
 	sed -i \
 	    -e 's#(((VERSION)))#$(VERSION)#g' \

--- a/README.md
+++ b/README.md
@@ -339,3 +339,11 @@ BibTeX file that is included in your TeX distribution like this:
 ```
 
  [tugboat.bib]: http://mirrors.ctan.org/info/digests/tugboat/biblio/tugboat.bib
+
+Notes to Distributors
+---------------------
+
+The file `markdown-cli.lua` should be installed in the TDS directory
+`scripts/markdown`. Furthermore, it should be made executable and either
+symlinked to system directories as `markdown-cli` on Unix or have a wrapper
+`markdown-cli.exe` installed on Windows.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -67,7 +67,7 @@ optex.pdf: optex.tex
 # This target converts the markdown example to a plain TeX representation
 # using the Lua command-line interface for the Markdown package.
 example.tex: example.md
-	texlua "`kpsewhich -a markdown-cli.lua | head -n 1`" $(LUACLI_OPTIONS) -- $< $@
+	markdown-cli $(LUACLI_OPTIONS) -- $< $@
 
 # This pseudo-target removes any existing auxiliary files and directories.
 clean:

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1628,21 +1628,14 @@ Hello *world*!
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- hello.md hello.tex
+markdown-cli -- hello.md hello.tex
 luatex document.tex
 ``````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
-
- [Kpathsea]: https://tug.org/kpathsea/ (Kpathsea - TeX Users Group)
 
 A PDF document named `document.pdf` should be produced and contain the text “Hello
 *world*!” Invoking pdfTeX should have the same effect:
 ``` sh
-texlua ⟨CLI pathname⟩ -- hello.md hello.tex
+markdown-cli -- hello.md hello.tex
 pdftex document.tex
 ``````
 
@@ -2111,15 +2104,10 @@ $\sqrt{-1}$ *equals* $i$.
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- example.md nomath.tex
-texlua ⟨CLI pathname⟩ tex_math_dollars=true -- example.md math.tex
+markdown-cli -- example.md nomath.tex
+markdown-cli tex_math_dollars=true -- example.md math.tex
 luatex document.tex
 ``````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -2132,8 +2120,8 @@ following text:
 
 Invoking pdfTeX should have the same effect:
 ``` sh
-texlua ⟨CLI pathname⟩ -- example.md nomath.tex
-texlua ⟨CLI pathname⟩ tex_math_dollars=true -- example.md math.tex
+markdown-cli -- example.md nomath.tex
+markdown-cli tex_math_dollars=true -- example.md math.tex
 pdftex document.tex
 ``````
 
@@ -2588,13 +2576,8 @@ Hello *world*!
 Next, invoke LuaTeX from the terminal with the \Opt{eagerCache} option
 disabled:
 ``` sh
-texlua ⟨CLI pathname⟩ eagerCache=false -- hello.md hello.tex
+markdown-cli eagerCache=false -- hello.md hello.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A \TeX{} document named `hello.tex` should be produced and contain the
 following code:
@@ -2608,7 +2591,7 @@ Invoke LuaTeX from the terminal again, this time with the \Opt{eagerCache}
 option enabled:
 
 ``` tex
-texlua ⟨CLI pathname⟩ eagerCache=true -- hello.md hello.tex
+markdown-cli eagerCache=true -- hello.md hello.tex
 ```
 
 A \TeX{} document named `hello.tex` should be produced and contain the
@@ -2961,14 +2944,9 @@ Hello *world*!
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ cacheDir=cache -- hello.md hello.tex
+markdown-cli cacheDir=cache -- hello.md hello.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the text
 “Hello *world*!” A directory named `cache` containing several cache files of
@@ -3340,14 +3318,9 @@ Hello *world*!
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ finalizeCache=true frozenCacheFileName=cache.tex -- hello.md hello.tex
+markdown-cli finalizeCache=true frozenCacheFileName=cache.tex -- hello.md hello.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the text
 “Hello *world*!” A frozen cache will also be produced in the `cache.tex`
@@ -3650,15 +3623,10 @@ A paragraph.
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ blankBeforeBlockquote=true -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli blankBeforeBlockquote=true -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -3884,15 +3852,10 @@ A code fence?
 ```````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ fencedCode=true -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ fencedCode=true blankBeforeCodeFence=true  -- content.md optiontrue.tex
+markdown-cli fencedCode=true -- content.md optionfalse.tex
+markdown-cli fencedCode=true blankBeforeCodeFence=true  -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -4217,15 +4180,10 @@ A heading?
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ blankBeforeHeading=true  -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli blankBeforeHeading=true  -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -4452,15 +4410,10 @@ A paragraph.
 ```````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ blankBeforeList=true  -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli blankBeforeList=true  -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -4772,15 +4725,10 @@ following content:
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ breakableBlockquotes=false -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩  -- content.md optiontrue.tex
+markdown-cli breakableBlockquotes=false -- content.md optionfalse.tex
+markdown-cli  -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -5208,15 +5156,10 @@ following content:
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ codeSpans=false -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ -- content.md optiontrue.tex
+markdown-cli codeSpans=false -- content.md optionfalse.tex
+markdown-cli -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -7260,15 +7203,10 @@ _Is there <? HTML instruction ?> support?_
 ````````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ html=false -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ -- content.md optiontrue.tex
+markdown-cli html=false -- content.md optionfalse.tex
+markdown-cli -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -7573,15 +7511,10 @@ $\sqrt{-1}$ *equals* $i$.
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ hybrid=true -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli hybrid=true -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -9297,15 +9230,10 @@ Are these just three regular dots, a victorian ellipsis, or ... ?
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ smartEllipses=true -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli smartEllipses=true -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -10546,15 +10474,10 @@ $$\hat{f} \left ( \xi  \right )= \int_{-\infty}^{\infty} f\left ( x  \right ) e^
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ texMathDollars=true -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli texMathDollars=true -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -10756,15 +10679,10 @@ following content:
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ texMathDoubleBackslash=true -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli texMathDoubleBackslash=true -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:
@@ -10966,15 +10884,10 @@ following content:
 ``````
 Next, invoke LuaTeX from the terminal:
 ``` sh
-texlua ⟨CLI pathname⟩ -- content.md optionfalse.tex
-texlua ⟨CLI pathname⟩ texMathSingleBackslash=true -- content.md optiontrue.tex
+markdown-cli -- content.md optionfalse.tex
+markdown-cli texMathSingleBackslash=true -- content.md optiontrue.tex
 luatex document.tex
 ```````
-where \meta{CLI pathname} corresponds to the location of the Lua CLI script file,
-such as `~/texmf/scripts/markdown/markdown-cli.lua` on UN\*X systems or
-`C:\Users\`\meta{Your username}`\texmf\scripts\markdown\markdown-cli.lua` on Windows
-systems. Use the command `kpsewhich -a markdown-cli.lua` to locate the Lua CLI
-script file using [Kpathsea][].
 
 A PDF document named `document.pdf` should be produced and contain the
 following text:


### PR DESCRIPTION
Closes https://github.com/Witiko/markdown/issues/534.