### PR TITLE
Implement option `jekyllDataKeyValue` for routing YAML metadata to expl3 key–values

### DIFF
--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35928,12 +35928,12 @@ end
 % To keep track of our current place when we are traversing a \acro{yaml}
 % document, we will maintain the
 % \mdef{g_\@\@_jekyll_data_wildcard_absolute_address_seq} stack of keys using
-% the \mdef{markdown_jekyll_data_push_address_segment:n} macro.
+% the \mdef{\@\@_jekyll_data_push_address_segment:n} macro.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \seq_new:N \g_@@_jekyll_data_wildcard_absolute_address_seq
-\cs_new:Nn \markdown_jekyll_data_push_address_segment:n
+\cs_new:Nn \@@_jekyll_data_push_address_segment:n
   {
     \seq_if_empty:NF
       \g_@@_jekyll_data_datatypes_seq
@@ -35998,23 +35998,23 @@ end
 %     ```
 %
 % We will construct \mref{g_\@\@_jekyll_data_wildcard_absolute_address_tl}
-% using the \mdef{markdown_jekyll_data_concatenate_address:NN} macro and
+% using the \mdef{\@\@_jekyll_data_concatenate_address:NN} macro and
 % we will construct both token lists using the
-% \mdef{markdown_jekyll_data_update_address_tls:} macro.
+% \mdef{\@\@_jekyll_data_update_address_tls:} macro.
 %
 % \end{markdown}
 %  \begin{macrocode}
 \tl_new:N  \g_@@_jekyll_data_wildcard_absolute_address_tl
 \tl_new:N  \g_@@_jekyll_data_wildcard_relative_address_tl
-\cs_new:Nn \markdown_jekyll_data_concatenate_address:NN
+\cs_new:Nn \@@_jekyll_data_concatenate_address:NN
   {
     \seq_pop_left:NN #1 \l_tmpa_tl
     \tl_set:Nx #2 { / \seq_use:Nn #1 { / } }
     \seq_put_left:NV #1 \l_tmpa_tl
   }
-\cs_new:Nn \markdown_jekyll_data_update_address_tls:
+\cs_new:Nn \@@_jekyll_data_update_address_tls:
   {
-    \markdown_jekyll_data_concatenate_address:NN
+    \@@_jekyll_data_concatenate_address:NN
       \g_@@_jekyll_data_wildcard_absolute_address_seq
       \g_@@_jekyll_data_wildcard_absolute_address_tl
     \seq_get_right:NN
@@ -36025,21 +36025,21 @@ end
 % \begin{markdown}
 %
 % To make sure that the stacks and token lists stay in sync, we will use the
-% \mdef{markdown_jekyll_data_push:nN} and \mdef{markdown_jekyll_data_pop:}
+% \mdef{\@\@_jekyll_data_push:nN} and \mdef{\@\@_jekyll_data_pop:}
 % macros.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\cs_new:Nn \markdown_jekyll_data_push:nN
+\cs_new:Nn \@@_jekyll_data_push:nN
   {
-    \markdown_jekyll_data_push_address_segment:n
+    \@@_jekyll_data_push_address_segment:n
       { #1 }
     \seq_put_right:NV
      \g_@@_jekyll_data_datatypes_seq
      #2
-    \markdown_jekyll_data_update_address_tls:
+    \@@_jekyll_data_update_address_tls:
   }
-\cs_new:Nn \markdown_jekyll_data_pop:
+\cs_new:Nn \@@_jekyll_data_pop:
   {
     \seq_pop_right:NN
       \g_@@_jekyll_data_wildcard_absolute_address_seq
@@ -36047,39 +36047,39 @@ end
     \seq_pop_right:NN
       \g_@@_jekyll_data_datatypes_seq
       \l_tmpa_tl
-    \markdown_jekyll_data_update_address_tls:
+    \@@_jekyll_data_update_address_tls:
   }
 %    \end{macrocode}
 % \begin{markdown}
 %
 % To set a single key--value, we will use the
-% \mdef{markdown_jekyll_data_set_keyval:Nn} macro, ignoring unknown keys.
+% \mdef{\@\@_jekyll_data_set_keyval:Nn} macro, ignoring unknown keys.
 % To set key--values for both absolute and relative wildcards, we will use the
-% \mdef{markdown_jekyll_data_set_keyvals:nn} macro.
+% \mdef{\@\@_jekyll_data_set_keyvals:nn} macro.
 %
 % \end{markdown}
 %  \begin{macrocode}
-\cs_new:Nn \markdown_jekyll_data_set_keyval:nn
+\cs_new:Nn \@@_jekyll_data_set_keyval:nn
   {
     \keys_set_known:nn
       { markdown/jekyllData }
       { { #1 } = { #2 } }
   }
 \cs_generate_variant:Nn
-  \markdown_jekyll_data_set_keyval:nn
+  \@@_jekyll_data_set_keyval:nn
   { Vn }
-\cs_new:Nn \markdown_jekyll_data_set_keyvals:nn
+\cs_new:Nn \@@_jekyll_data_set_keyvals:nn
   {
-    \markdown_jekyll_data_push:nN
+    \@@_jekyll_data_push:nN
       { #1 }
       \c_@@_jekyll_data_scalar_tl
-    \markdown_jekyll_data_set_keyval:Vn
+    \@@_jekyll_data_set_keyval:Vn
       \g_@@_jekyll_data_wildcard_absolute_address_tl
       { #2 }
-    \markdown_jekyll_data_set_keyval:Vn
+    \@@_jekyll_data_set_keyval:Vn
       \g_@@_jekyll_data_wildcard_relative_address_tl
       { #2 }
-    \markdown_jekyll_data_pop:
+    \@@_jekyll_data_pop:
   }
 %    \end{macrocode}
 % \begin{markdown}
@@ -36090,29 +36090,29 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \def\markdownRendererJekyllDataSequenceBeginPrototype#1#2{
-  \markdown_jekyll_data_push:nN
+  \@@_jekyll_data_push:nN
     { #1 }
     \c_@@_jekyll_data_sequence_tl
 }
 \def\markdownRendererJekyllDataMappingBeginPrototype#1#2{
-  \markdown_jekyll_data_push:nN
+  \@@_jekyll_data_push:nN
     { #1 }
     \c_@@_jekyll_data_mapping_tl
 }
 \def\markdownRendererJekyllDataSequenceEndPrototype{
-  \markdown_jekyll_data_pop:
+  \@@_jekyll_data_pop:
 }
 \def\markdownRendererJekyllDataMappingEndPrototype{
-  \markdown_jekyll_data_pop:
+  \@@_jekyll_data_pop:
 }
 \def\markdownRendererJekyllDataBooleanPrototype#1#2{
-  \markdown_jekyll_data_set_keyvals:nn
+  \@@_jekyll_data_set_keyvals:nn
     { #1 }
     { #2 }
 }
 \def\markdownRendererJekyllDataEmptyPrototype#1{}
 \def\markdownRendererJekyllDataNumberPrototype#1#2{
-  \markdown_jekyll_data_set_keyvals:nn
+  \@@_jekyll_data_set_keyvals:nn
     { #1 }
     { #2 }
 }
@@ -36126,7 +36126,7 @@ end
 %  \begin{macrocode}
 \def\markdownRendererJekyllDataProgrammaticStringPrototype#1#2{}
 \def\markdownRendererJekyllDataTypographicStringPrototype#1#2{
-  \markdown_jekyll_data_set_keyvals:nn
+  \@@_jekyll_data_set_keyvals:nn
     { #1 }
     { #2 }
 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35890,7 +35890,10 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-%#### YAML Metadata Renderer Prototypes
+%#### Simple YAML Metadata Renderer Prototypes
+% In this section, we implement the simple high-level interface for processing
+% simple \acro{YAML} metadata using the key--value `markdown/jekyllData`. See
+% also Section <#sec:expl3yamlmetadata>.
 %
 % To keep track of the current type of structure we inhabit when we are
 % traversing a \acro{yaml} document, we will maintain the
@@ -36127,6 +36130,19 @@ end
     { #1 }
     { #2 }
 }
+\ExplSyntaxOff
+%    \end{macrocode}
+% \begin{markdown}
+%
+%#### Complex YAML Metadata Renderer Prototypes
+% In this section, we implement the high-level interface for routing complex
+% \acro{YAML} metadata to expl3 key--values using the option
+% `jekyllDataKeyValue`=\meta{module}. See also Section <#sec:expl3yamlmetadata>.
+%
+% \end{markdown}
+%  \begin{macrocode}
+\ExplSyntaxOn
+\iffalse TODO \fi
 \ExplSyntaxOff
 %    \end{macrocode}
 % \iffalse

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -688,6 +688,14 @@ abbr {
   url        = {https://tex.stackexchange.com/q/716362/70941},
   urldate    = {2024-04-28},
 }
+@online{starynovotny25,
+  author     = {Starý Novotný, Vít},
+  title      = {Routing YAML metadata to expl3 key–values},
+  titleaddon = {Markdown Enhancement Proposal},
+  url        = {https://github.com/witiko/markdown/discussions/517},
+  date       = {2024-10-14},
+  urldate    = {2025-01-06},
+}
 @book{tantau21,
   author     = {Till Tantau and Joseph Wright and Vedran Miletić},
   title      = {The Beamer class},
@@ -809,6 +817,13 @@ abbr {
   date       = {2024-06-01},
   url        = {https://mirrors.ctan.org/macros/latex/required/latex-lab/documentmetadata-support-code.pdf},
   urldate    = {2024-10-21}}
+@online{latex25,
+  author     = {{\LaTeX{} Project}},
+  title      = {l3kernel},
+  subtitle   = {\LaTeX3 programming conventions},
+  date       = {2024-12-25},
+  url        = {https://ctan.org/pkg/l3kernel},
+  urldate    = {2025-01-06}}
 %</techdoc-bibliography>
 %<@@=markdown>
 %<*themes-witiko-markdown-techdoc>
@@ -1220,8 +1235,8 @@ hard lua-tinyyaml
 %
 % \pkg{expl3}
 %
-%:    A package that enables the expl3 language from the \LaTeX3 kernel in
-%     \TeX{} Live${}\leq{}2019$. It is used to implement reflection
+%:    A package that enables the expl3 language [@latex25] from the \LaTeX3
+%     kernel in \TeX{} Live${}\leq{}2019$. It is used to implement reflection
 %     capabilities that allow us to enumerate and inspect high-level concepts
 %     such as options, renderers, and renderer prototypes.
 %
@@ -21751,9 +21766,9 @@ following text:
 
 #### YAML Metadata Renderer Prototypes {#expl3yamlmetadata}
 
-By default, the renderer prototypes for YAML metadata provide a high-level
-interface that can be programmed using the `markdown/jekyllData` key--values
-from the l3keys module of the \LaTeX{}3 kernel.
+For simple \acro{YAML} metadata, a simple high-level interface is provided
+that can be programmed by setting the expl3 key-values [@latex25] for the
+module `markdown/jekyllData`.
 
 % \end{markdown}
 % \iffalse
@@ -21877,8 +21892,9 @@ following text:
 %    \end{macrocode}
 % \begin{markdown}
 %
-% The `jekyllDataRenderers` key can be used as a syntactic sugar for setting
-% the `markdown/jekyllData` key--values without using the expl3 language.
+% The option `jekyllDataRenderers`=\meta{key-values} can be used to set the
+% \meta{key-values} for the module `markdown/jekyllData` without using the
+% expl3 syntax.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -21940,6 +21956,84 @@ following text:
   { nV }
 \ExplSyntaxOff
 %    \end{macrocode}
+% \begin{markdown}
+%
+% For complex \acro{YAML} metadata, the option `jekyllDataKeyValue`=\meta{module}
+% [@starynovotny25] can be used to route the processing of all \acro{YAML}
+% metadata in the current \TeX{} group to the key-values from \meta{module}.
+%
+% \end{markdown}
+% \iffalse
+%</tex>
+%<*manual-tokens>
+
+##### \LaTeX{} Example {.unnumbered}
+
+Using a text editor, create a text document named `document.tex` with the
+following content:
+``` tex
+\documentclass{article}
+\usepackage{markdown}
+\ExplSyntaxOn
+\str_new:N \g_markdown_example_title_str
+\seq_new:N \g_markdown_example_author_seq
+\keys_define:nn
+  { markdown / some / example / module }
+  {  % Define a key-value that processes YAML metadata.
+    title / programmaticString .str_gset:N = \g_markdown_example_title_str,  % Store the raw title in a variable.
+    title .code:n = { \title { #1 } },  % Set the title. This is the same as writing `title / typographicString`.
+    author / unknown .code = {  % Store a variable-length list of authors in an array variable.
+      \seq_put_right:Nn
+        \g_markdown_example_author_seq
+        { #1 }
+    },
+  }
+\markdownSetupSnippet
+  { metadata }
+  {  % Define a snippet that routes YAML metadata to the above key key–value.
+    jekyllDataKeyValue = markdown / some / example / module,
+    renderers = {
+      jekyllDataEnd = {  % At the end of the YAML metadata, ...
+        \clist_set_from_seq:NN  % ... set the list of authors and
+          \l_tmpa_clist
+          \g_markdown_example_author_seq
+        \exp_args:Nx
+          \author
+          { \clist_use:Nn \l_tmpa_clist { ,~ } }
+        \AtBeginDocument { \maketitle }  % ... typeset the title page.
+      },
+    }
+  }
+\ExplSyntaxOff
+% Process the YAML metadata.
+\begin{yaml}[snippet=metadata]
+title: Some title that includes _markup_
+authors: [Jane Doe, John Moe]
+\end{yaml}
+\begin{document}
+The raw title of the document is:
+\ExplSyntaxOn
+\str_use:N \g_markdown_example_title_str
+\ExplSyntaxOff
+\end{document}
+```````
+Next, invoke LuaTeX from the terminal:
+``` sh
+lualatex document.tex
+``````
+A PDF document named `document.pdf` should be produced and contain the
+following text:
+
+> ### Some title that includes _markup_
+> ##### Jane Doe, John Moe
+> ##### _⟨Current date⟩_
+>
+> The raw title of the document is:
+> Some title that includes \_markup\_
+
+%</manual-tokens>
+%<*tex>
+% \fi
 % \begin{markdown}
 %
 %#### Generating Plain \TeX{} Token Renderer Prototype Macros and Key-Values {#plain-tex-renderer-prototypes}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1362,7 +1362,7 @@ soft url
 % \pkg{graphicx}
 %
 %:    A package that provides the `\includegraphics` macro for the typesetting
-%     of images. Furthermore, it also provides a key-value interface that is
+%     of images. Furthermore, it also provides a key--value interface that is
 %     used in the default renderer prototypes for image attribute contexts.
 %
 % \end{markdown}
@@ -12327,16 +12327,16 @@ A PDF document named `document.pdf` should be produced and contain the text
 %#### Generating Plain \TeX{} Option Macros and Key-Values
 %
 % We define the command \mdef{@@_define_option_commands_and_keyvals:} that
-% defines plain \TeX{} macros and the key-value interface
+% defines plain \TeX{} macros and the key--value interface
 % of the \mref{markdownSetup} macro for the above plain \TeX{} options.
 %
-% The command also defines macros and key-values that map
+% The command also defines macros and key--values that map
 % directly to the options recognized by the Lua interface, such as
 % \mdef{markdownOptionHybrid} for the \Opt{hybrid} Lua option (see Section
 % <#sec:lua-options>), which are not processed by the plain \TeX{}
 % implementation, only passed along to Lua.
 %
-% Furthermore, the command also defines options and key-values
+% Furthermore, the command also defines options and key--values
 % for subsequently loaded layers that correspond to higher-level \TeX{} formats
 % such as \LaTeX{} and \Hologo{ConTeXt}.
 %
@@ -12668,7 +12668,7 @@ A PDF document named `document.pdf` should be produced and contain the text
 %
 % If plain \TeX{} is the top layer, we use the
 % \mref{@@_define_option_commands_and_keyvals:} macro to define plain \TeX{}
-% option macros and key-values immediately. Otherwise, we
+% option macros and key--values immediately. Otherwise, we
 % postpone the definition until the upper layers have been loaded.
 %
 % \end{markdown}
@@ -12696,7 +12696,7 @@ User-defined themes for the Markdown package provide a domain-specific
 interpretation of Markdown tokens. Themes allow the authors to achieve
 a specific look and other high-level goals without low-level programming.
 
-% The key-values `theme`=\meta{theme name} and `import`=\meta{theme name},
+% The key--values `theme`=\meta{theme name} and `import`=\meta{theme name},
 % optionally followed by `@`\meta{theme version}, load a \TeX{} document
 % (further referred to as *a theme*) named `markdowntheme`\meta{munged theme
 % name}`.tex`, where the *munged theme name* is the *theme name* after the
@@ -21205,7 +21205,7 @@ following text:
 % We define the command \mdef{@@_define_renderers:} that defines plain \TeX{}
 % macros for token renderers. Furthermore, the `\markdownSetup` macro also accepts
 % the `renderers` and `unprotectedRenderers` keys. The value for these keys
-% must be a list of key-values, where the keys correspond to the markdown token
+% must be a list of key--values, where the keys correspond to the markdown token
 % renderer macros and the values are new definitions of these token renderers.
 %
 % Whereas the key `renderers` defines protected functions, which are usually
@@ -21630,7 +21630,7 @@ following text:
 % \begin{markdown}
 %
 % If plain \TeX{} is the top layer, we use the \mref{@@_define_renderers:}
-% macro to define plain \TeX{} token renderer macros and key-values
+% macro to define plain \TeX{} token renderer macros and key--values
 % immediately. Otherwise, we postpone the definition until the upper layers
 % have been loaded.
 %
@@ -21767,7 +21767,7 @@ following text:
 #### YAML Metadata Renderer Prototypes {#expl3yamlmetadata}
 
 For simple \acro{YAML} metadata, a simple high-level interface is provided
-that can be programmed by setting the expl3 key-values [@latex25] for the
+that can be programmed by setting the expl3 key--values [@latex25] for the
 module `markdown/jekyllData`.
 
 % \end{markdown}
@@ -21892,8 +21892,8 @@ following text:
 %    \end{macrocode}
 % \begin{markdown}
 %
-% The option `jekyllDataRenderers`=\meta{key-values} can be used to set the
-% \meta{key-values} for the module `markdown/jekyllData` without using the
+% The option `jekyllDataRenderers`=\meta{key--values} can be used to set the
+% \meta{key--values} for the module `markdown/jekyllData` without using the
 % expl3 syntax.
 %
 % \end{markdown}
@@ -21960,7 +21960,7 @@ following text:
 %
 % For complex \acro{YAML} metadata, the option `jekyllDataKeyValue`=\meta{module}
 % [@starynovotny25] can be used to route the processing of all \acro{YAML}
-% metadata in the current \TeX{} group to the key-values from \meta{module}.
+% metadata in the current \TeX{} group to the key--values from \meta{module}.
 %
 % \end{markdown}
 % \iffalse
@@ -21979,7 +21979,7 @@ following content:
 \seq_new:N \g_markdown_example_author_seq
 \keys_define:nn
   { markdown / some / example / module }
-  {  % Define a key-value that processes YAML metadata.
+  {  % Define a key--value that processes YAML metadata.
     title / programmaticString .str_gset:N = \g_markdown_example_title_str,  % Store the raw title in a variable.
     title .code:n = { \title { #1 } },  % Set the title. This is the same as writing `title / typographicString`.
     author / unknown .code = {  % Store a variable-length list of authors in an array variable.
@@ -22041,7 +22041,7 @@ following text:
 % We define the command \mdef{@@_define_renderer_prototypes:} that defines plain \TeX{}
 % macros for token renderer prototypes. Furthermore, the `\markdownSetup` macro also accepts
 % the `rendererPrototypes` and `unprotectedRendererPrototypes` keys. The value
-% for these keys must be a list of key-values, where the keys correspond to the
+% for these keys must be a list of key--values, where the keys correspond to the
 % markdown token renderer prototype macros and the values are new definitions
 % of these token renderer prototypes.
 %
@@ -22363,7 +22363,7 @@ following text:
 % \begin{markdown}
 %
 % If plain \TeX{} is the top layer, we use the \mref{@@_define_renderer_prototypes:}
-% macro to define plain \TeX{} token renderer prototype macros and key-values
+% macro to define plain \TeX{} token renderer prototype macros and key--values
 % immediately. Otherwise, we postpone the definition until the upper layers
 % have been loaded.
 %
@@ -22932,7 +22932,7 @@ document:
 % If \LaTeX{} is the top layer, we use the
 % \mref{@@_define_option_commands_and_keyvals:}, \mref{@@_define_renderers:},
 % and \mref{@@_define_renderer_prototypes:} macro to define plain \TeX{}
-% option, token renderer, and token renderer prototype macros and key-values
+% option, token renderer, and token renderer prototype macros and key--values
 % immediately. Otherwise, we postpone the definition until the upper layers
 % have been loaded.
 %
@@ -22980,7 +22980,7 @@ In \LaTeX{}, we expand on the concept of
 [themes](#themes)
 % \fi
 by allowing a theme to be a full-blown \LaTeX{} package. Specifically, the
-key-values `theme`=\meta{theme name} and `import`=\meta{theme name} load a
+key--values `theme`=\meta{theme name} and `import`=\meta{theme name} load a
 \LaTeX{} package named `markdowntheme`\meta{munged theme name}`.sty` if it
 exists and a \TeX{} document named `markdowntheme`\meta{munged theme
 name}`.tex` otherwise.
@@ -23429,7 +23429,7 @@ following text:
 % If \Hologo{ConTeXt} is the top layer, we use the
 % \mref{@@_define_option_commands_and_keyvals:}, \mref{@@_define_renderers:},
 % and \mref{@@_define_renderer_prototypes:} macro to define plain \TeX{}
-% option, token renderer, and token renderer prototype macros and key-values
+% option, token renderer, and token renderer prototype macros and key--values
 % immediately. Otherwise, we postpone the definition until the upper layers
 % have been loaded.
 %
@@ -23462,7 +23462,7 @@ In \Hologo{ConTeXt}, we expand on the concept of
 [themes](#themes)
 % \fi
 by allowing a theme to be a full-blown \Hologo{ConTeXt} module. Specifically,
-the key-values `theme`=\meta{theme name} and `import`=\meta{theme name} load a
+the key--values `theme`=\meta{theme name} and `import`=\meta{theme name} load a
 \Hologo{ConTeXt} module named `t-markdowntheme`\meta{munged theme name}`.tex`
 if it exists and a \TeX{} document named `markdowntheme`\meta{munged theme
 name}`.tex` otherwise.


### PR DESCRIPTION
This PR implements and closes MEP #517.

### Tasks
- [x] Document option `jekyllDataKeyValue`.
- [ ] Implement option `jekyllDataKeyValue`.
- [ ] Update `CHANGES.md`.