### PR TITLE
Bump copyright year and remove needless parentheses in file `markdown-unicode-data.lua`

### DIFF
--- a/docstrip.cfg
+++ b/docstrip.cfg
@@ -22,7 +22,7 @@
 -- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE^^J%
 -- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.^^J%
 --^^J%
--- Copyright (C) 2016-2024 Vít Starý Novotný, Andrej Genčur^^J%
+-- Copyright (C) 2016-2025 Vít Starý Novotný, Andrej Genčur^^J%
 --^^J%
 -- This work may be distributed and/or modified under the^^J%
 -- conditions of the LaTeX Project Public License, either version 1.3^^J%
@@ -62,7 +62,7 @@
 \let\luapostamble\empty
 \declarepreamble\texpreamble
 
-Copyright (C) 2016-2024 Vít Starý Novotný, Andrej Genčur
+Copyright (C) 2016-2025 Vít Starý Novotný, Andrej Genčur
 
 This work may be distributed and/or modified under the
 conditions of the LaTeX Project Public License, either version 1.3c

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27528,7 +27528,7 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
   end
 
   print("M.punctuation = {}")
-  print("local S = lpeg.S")
+  print("local P = lpeg.P")
   print("-- luacheck: push no max line length")
   for length, prefix_tree in pairs(prefix_trees) do
     local subparsers = {}
@@ -27536,9 +27536,9 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
       if type(node) == "string" then
         local suffix
         if node == "]" then
-          suffix = "S('" .. node .. "')"
+          suffix = "P('" .. node .. "')"
         else
-          suffix = "S([[" .. node .. "]])"
+          suffix = "P([[" .. node .. "]])"
         end
         if subparsers[path] ~= nil then
           subparsers[path] = subparsers[path] .. " + " .. suffix
@@ -27550,20 +27550,23 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
       if #path > 0 then
         local byte = path:sub(#path, #path)
         local parent_path = path:sub(1, #path-1)
-        if subparsers[path] ~= nil then
-          local suffix
-          if byte == "]" then
-            suffix = "S('" .. byte .. "')"
-          else
-            suffix = "S([[" .. byte .. "]])"
-          end
-          suffix = suffix .. " * (" .. subparsers[path] .. ")"
-          if subparsers[parent_path] ~= nil then
-            subparsers[parent_path] = subparsers[parent_path]
-                                   .. " + " .. suffix
-          else
-            subparsers[parent_path] = suffix
-          end
+        local prefix
+        if byte == "]" then
+          prefix = "P('" .. byte .. "')"
+        else
+          prefix = "P([[" .. byte .. "]])"
+        end
+        local suffix
+        if subparsers[path]:find(" %+ ") then
+          suffix = prefix .. " * (" .. subparsers[path] .. ")"
+        else
+          suffix = prefix .. " * " .. subparsers[path]
+        end
+        if subparsers[parent_path] ~= nil then
+          subparsers[parent_path] = subparsers[parent_path]
+                                 .. " + " .. suffix
+        else
+          subparsers[parent_path] = suffix
         end
       else
         print("M.punctuation[" .. length .. "] = " .. subparsers[path])


### PR DESCRIPTION
This PR makes the following changes:
- Bump copyright year.
- Remove needless parentheses and replace `lpeg.S` with `lpeg.P` in file `markdown-unicode-data.lua`.
  This change was inspired by changes from [expltools\#21](https://github.com/Witiko/expltools/pull/21). 