### PR TITLE
Add a built-in theme `witiko/diagrams@v2` for drawing different types of diagrams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,86 @@
 
 Development:
 
+- Add a built-in theme `witiko/diagrams@v2` for drawing different types of
+  diagrams. (#448, #514, #531, originally suggested by @anubane)
+
+  Here is an example LaTeX document using the new theme:
+
+  ```` tex
+  \documentclass{article}
+  \usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
+  \begin{document}
+  \begin{markdown}
+  ``` dot {caption="An example directed graph" width=12cm #dot}
+  digraph tree {
+    margin = 0;
+    rankdir = "LR";
+
+    latex -> pmml;
+    latex -> cmml;
+    pmml -> slt;
+    cmml -> opt;
+    cmml -> prefix;
+    cmml -> infix;
+    pmml -> mterms [style=dashed];
+    cmml -> mterms;
+
+    latex [label = "LaTeX"];
+    pmml [label = "Presentation MathML"];
+    cmml [label = "Content MathML"];
+    slt [label = "Symbol Layout Tree"];
+    opt [label = "Operator Tree"];
+    prefix [label = "Prefix"];
+    infix [label = "Infix"];
+    mterms [label = "M-Terms"];
+  }
+  ```
+
+  ``` mermaid {caption="An example mindmap" width=9cm #mermaid}
+  mindmap
+      root )base-idea(
+          sub<br/>idea 1
+              ((?))
+          sub<br/>idea 2
+              ((?))
+          sub<br/>idea 3
+              ((?))
+          sub<br/>idea 4
+              ((?))
+  ```
+
+  ``` plantuml {caption="An example UML sequence diagram" width=7cm #plantuml}
+  @startuml
+  ' Define participants (actors)
+  participant "Client" as C
+  participant "Server" as S
+  participant "Database" as DB
+
+  ' Diagram title
+  title Simple Request-Response Flow
+
+  ' Messages
+  C -> S: Send Request
+  note over S: Process request
+
+  alt Request is valid
+      S -> DB: Query Data
+      DB -> S: Return Data
+      S -> C: Respond with Data
+  else Request is invalid
+      S -> C: Return Error
+  end
+  @enduml
+  ```
+
+  See the diagrams in figures <#dot>, <#mermaid>, and <#plantuml>.
+  \end{markdown}
+  \end{document}
+  ````````
+
+  You may use the expl3 prop `\g_markdown_diagrams_infostrings_prop` to
+  register other types of diagrams.
+
 - Add option `jekyllDataKeyValue` for routing YAML metadata to expl3 key–values.
   (#77, #517, [matrix.org][matrix-517], #539, [matrix.org][matrix-539],
    f57a8c45, originally suggested by @TeXhackse)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ ARG DEPENDENCIES="\
     graphviz \
     m4 \
     moreutils \
+    npm \
     pandoc \
     parallel \
+    plantuml \
     poppler-utils \
     python3-pygments \
     python3-venv \
@@ -80,6 +82,8 @@ set -o xtrace
 # Install OS dependencies
 apt-get -qy update
 apt-get -qy install --no-install-recommends ${DEPENDENCIES}
+npm install -g @mermaid-js/mermaid-cli
+sed -i "s/headless: 'shell'/&, args: ['--no-sandbox']/" /usr/local/lib/node_modules/@mermaid-js/mermaid-cli/src/index.js
 
 # Update packages in non-historic TeX Live versions
 if echo ${TEXLIVE_TAG} | grep -q latest
@@ -195,6 +199,8 @@ set -o xtrace
 # Install dependencies, but this time we clean up after ourselves
 apt-get -qy update
 apt-get -qy install --no-install-recommends ${DEPENDENCIES}
+npm install -g @mermaid-js/mermaid-cli
+sed -i "s/headless: 'shell'/&, args: ['--no-sandbox']/" /usr/local/lib/node_modules/@mermaid-js/mermaid-cli/src/index.js
 if [ ${DEV_IMAGE} = true ]
 then
   apt-get -qy install --no-install-recommends ${DEV_DEPENDENCIES}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35429,7 +35429,8 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% The `witiko/diagrams` loads the theme `witiko/dot`.
+% The theme `witiko/diagrams` loads either the theme `witiko/dot` for version
+% `v1` or the theme `witiko/diagrams/v2` for version `v2`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -35444,7 +35445,7 @@ end
           {
             \markdownWarning
               {
-                Write~"witiko/diagrams@v1"~to~pin~version~"v1"~of~the~
+                Write~"witiko/diagrams@v2"~to~pin~version~"v2"~of~the~
                 theme~"witiko/diagrams".~This~will~keep~your~documents~
                 from~suddenly~breaking~when~we~have~released~future~
                 versions~of~the~theme~with~backwards-incompatible~
@@ -35452,7 +35453,14 @@ end
               }
             \markdownSetup
               {
-                import = witiko/dot@silent,
+                import = witiko/diagrams/v2,
+              }
+          }
+        { v2 }
+          {
+            \markdownSetup
+              {
+                import = witiko/diagrams/v2,
               }
           }
         { v1 }
@@ -35480,6 +35488,19 @@ end
   { unknown-theme-version }
   { Unknown~version~"#2"~of~theme~"#1"~has~been~requested. }
   { Known~versions~are:~#3 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% The theme `witiko/diagrams/v2` ...
+%
+% \end{markdown}
+%  \begin{macrocode}
+\prop_gput:Nnn
+  \g_@@_plain_tex_built_in_themes_prop
+  { witiko / diagrams / v2 }
+  {
+    % TODO
+  }
 %    \end{macrocode}
 % \begin{markdown}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -13238,9 +13238,9 @@ three diagrams.
 %    \end{document}
 %    ```````
 %    Typesetting the above document produces the output shown in
-%    Figure <#fig:witiko/graphicx/http>.
+%    Figure <#fig:witiko-graphicx-http>.
 %    ![img](https://github.com/witiko/markdown/raw/main/markdown.png
-%           "The banner of the Markdown package"){#fig:witiko/graphicx/http}
+%           "The banner of the Markdown package"){#fig:witiko-graphicx-http}
      The theme requires the \pkg{catchfile} \LaTeX{} package and a Unix-like
      operating system with GNU Coreutils `md5sum` and either GNU Wget or cURL
      installed. The theme also requires shell access unless the

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -90,7 +90,7 @@
 ]{markdown}
 \markdownSetup{
   import = {
-    witiko/diagrams@v1,
+    witiko/diagrams@v2,
     witiko/graphicx/http,
     witiko/markdown/techdoc = {
       options as lua-options
@@ -12979,21 +12979,17 @@ a specific look and other high-level goals without low-level programming.
 
 Built-in plain \TeX{} themes provided with the Markdown package include:
 
-\pkg{witiko/diagrams@v1}
+\pkg{witiko/diagrams}
 
 :    A theme that typesets fenced code blocks with the `dot …` infostring
      as images of directed graphs rendered by the Graphviz tools. The
      right tail of the infostring is used as the image title.
 %    ```` tex
 %    \documentclass{article}
-%    \usepackage[import=witiko/diagrams@v1]{markdown}
-%    \setkeys{Gin}{
-%      width = \columnwidth,
-%      height = 0.65\paperheight,
-%      keepaspectratio}
+%    \usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
 %    \begin{document}
 %    \begin{markdown}
-%    ``` dot Various formats of mathemathical formulae
+%    ``` dot {caption="Various formats of mathemathical formulae" width=10cm #diagram}
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
@@ -13017,12 +13013,14 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      mterms [label = "M-Terms"];
 %    }
 %    ```
+%
+%    See the diagram in Figure <#diagram>.
 %    \end{markdown}
 %    \end{document}
 %    ````````
 %    Typesetting the above document produces the output shown in
-%    Figure <#fig:witiko/diagrams@v1>.
-%    ``` dot Various formats of mathemathical formulae \label{fig:witiko/diagrams@v1}
+%    Figure <#fig:witiko-diagrams>.
+%    ``` dot {caption="Various formats of mathemathical formulae" #fig:witiko-diagrams}
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
@@ -13065,14 +13063,10 @@ Using a text editor, create a text document named `document.tex` with the
 following content:
 ```` tex
 \documentclass{article}
-\usepackage[import=witiko/diagrams@v1]{markdown}
-\setkeys{Gin}{
-  width=\columnwidth,
-  height=0.65\paperheight,
-  keepaspectratio}
+\usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
 \begin{document}
 \begin{markdown}
-``` dot Various formats of mathemathical formulae
+``` dot {caption="Various formats of mathemathical formulae" width=10cm #diagram}
 digraph tree {
   margin = 0;
   rankdir = "LR";
@@ -13096,6 +13090,8 @@ digraph tree {
   mterms [label = "M-Terms"];
 }
 ```
+
+See the diagram in Figure <#diagram>.
 \end{markdown}
 \end{document}
 ````````
@@ -35520,7 +35516,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
     \cs_set_eq:NN
-      \@@_diagrams_previous_definition:nnn
+      \@@_diagrams_previous_fenced_code:nnn
       \markdownRendererInputFencedCodePrototype
 %    \end{macrocode}
 % \begin{markdown}
@@ -35536,11 +35532,15 @@ end
         rendererPrototypes = {
           fencedCodeAttributeContextBegin = {
             \group_begin:
+            \markdownRendererImageAttributeContextBegin
+            \cs_set_eq:NN
+              \@@_diagrams_previous_key_value:nn
+              \markdownRendererAttributeKeyValuePrototype
             \@@_setup:n
               {
                 rendererPrototypes = {
                   attributeKeyValue = {
-                    \str_if_eq:nnT
+                    \str_if_eq:nnTF
                       { ##1 }
                       { caption }
                       {
@@ -35548,11 +35548,17 @@ end
                           \@@_diagrams_caption_tl
                           { ##2 }
                       }
+                      {
+                        \@@_diagrams_previous_key_value:nn
+                          { ##1 }
+                          { ##2 }
+                      }
                   },
                 },
               }
           },
           fencedCodeAttributeContextEnd = {
+            \markdownRendererImageAttributeContextEnd
             \group_end:
           },
           inputFencedCode = {
@@ -35600,7 +35606,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
               {
-                \@@_diagrams_previous_definition:nnn
+                \@@_diagrams_previous_fenced_code:nnn
                   { #1 }
                   { #2 }
                   { #3 }
@@ -39417,31 +39423,31 @@ end
   { linkAttributes }
   {
     \RequirePackage { graphicx }
-    \markdownSetup {
-      rendererPrototypes = {
-        imageAttributeContextBegin = {
-          \group_begin:
-          \markdownSetup {
-            rendererPrototypes = {
-              attributeIdentifier = {
-                \seq_put_right:Nn
-                  \l_@@_image_identifiers_seq
-                  { ##1 }
-              },
-              attributeKeyValue = {
-                \setkeys
-                  { Gin }
-                  { { ##1 } = { ##2 } }
-              },
-            },
-          }
-        },
-        imageAttributeContextEnd = {
-          \group_end:
-        },
-      },
-    }
   }
+\markdownSetup {
+  rendererPrototypes = {
+    imageAttributeContextBegin = {
+      \group_begin:
+      \markdownSetup {
+        rendererPrototypes = {
+          attributeIdentifier = {
+            \seq_put_right:Nn
+              \l_@@_image_identifiers_seq
+              { ##1 }
+          },
+          attributeKeyValue = {
+            \setkeys
+              { Gin }
+              { { ##1 } = { ##2 } }
+          },
+        },
+      }
+    },
+    imageAttributeContextEnd = {
+      \group_end:
+    },
+  },
+}
 \ExplSyntaxOff
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35597,47 +35597,38 @@ end
                 \l_@@_diagrams_caption_tl
           }
       }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Use the prop \mdef{\g_@@_diagrams_infostrings_prop} to determine how the code
+% with a given infostring should be processed and routed to the token renderer
+% prototype(s) for images.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \prop_new:N
+      \g_@@_diagrams_infostrings_prop
+%    \end{macrocode}
+% \begin{markdown}
+%
+% If we know a processing function for a given infostring, use it.
+%
+% \end{markdown}
+%  \begin{macrocode}
     \@@_setup:n
       {
         rendererPrototypes = {
           inputFencedCode = {
-            \str_case:nnF
+            \prop_get:NnNTF
+              \g_@@_diagrams_infostrings_prop
               { #2 }
+              \l_tmpa_tl
               {
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Typeset fenced code with infostring `dot` using Graphviz.
-%
-% \end{markdown}
-%  \begin{macrocode}
-                { dot }
-                {
-                  \@@_diagrams_render_diagram:nnnn
-                    { #1 }
-                    { #1.pdf }
-                    { dot~-Tpdf~-o~#1.pdf~#1 }
-                    { Graphviz~image }
-                }
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Typeset fenced code with infostring `mermaid` using the npm package
-% [@mermaid-js/mermaid-cli](https://www.npmjs.com/package/@mermaid-js/mermaid-cli).
-%
-% \end{markdown}
-%  \begin{macrocode}
-                { mermaid }
-                {
-                  \@@_diagrams_render_diagram:nnnn
-                    { #1 }
-                    { #1.pdf }
-                    {
-                      npx~-p~@mermaid-js/mermaid-cli~mmdc~
-                        --pdfFit~-i~#1~-o~#1.pdf
-                    }
-                    { Mermaid~image }
-                }
+                \cs_set:NV
+                  \@@_diagrams_infostrings_current:n
+                  \l_tmpa_tl
+                \@@_diagrams_infostrings_current:n
+                  { #1 }
               }
 %    \end{macrocode}
 % \begin{markdown}
@@ -35655,6 +35646,61 @@ end
           },
         },
       }
+    \cs_generate_variant:Nn
+      \cs_set:Nn
+      { NV }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Typeset fenced code with infostring `dot` using Graphviz.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \cs_new:Nn
+      \@@_diagrams_infostrings_dot:n
+      {
+        \@@_diagrams_render_diagram:nnnn
+          { #1 }
+          { #1.pdf }
+          { dot~-Tpdf~-o~#1.pdf~#1 }
+          { Graphviz~image }
+      }
+    \@@_tl_set_from_cs:NNn
+      \l_tmpa_tl
+      \@@_diagrams_infostrings_dot:n
+      { 1 }
+    \prop_gput:NnV
+      \g_@@_diagrams_infostrings_prop
+      { dot }
+      \l_tmpa_tl
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Typeset fenced code with infostring `mermaid` using the npm package
+% [@mermaid-js/mermaid-cli](https://www.npmjs.com/package/@mermaid-js/mermaid-cli).
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \cs_new:Nn
+      \@@_diagrams_infostrings_mermaid:n
+      {
+        \@@_diagrams_render_diagram:nnnn
+          { #1 }
+          { #1.pdf }
+          {
+            npx~-p~@mermaid-js/mermaid-cli~mmdc~
+              --pdfFit~-i~#1~-o~#1.pdf
+          }
+          { Mermaid~image }
+      }
+    \@@_tl_set_from_cs:NNn
+      \l_tmpa_tl
+      \@@_diagrams_infostrings_mermaid:n
+      { 1 }
+    \prop_gput:NnV
+      \g_@@_diagrams_infostrings_prop
+      { mermaid }
+      \l_tmpa_tl
   }
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35600,14 +35600,14 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Use the prop \mdef{\g_@@_diagrams_infostrings_prop} to determine how the code
-% with a given infostring should be processed and routed to the token renderer
-% prototype(s) for images.
+% Use the prop \mdef{g_markdown_diagrams_infostrings_prop} to determine how the
+% code with a given infostring should be processed and routed to the token
+% renderer prototype(s) for images.
 %
 % \end{markdown}
 %  \begin{macrocode}
     \prop_new:N
-      \g_@@_diagrams_infostrings_prop
+      \g_markdown_diagrams_infostrings_prop
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -35620,7 +35620,7 @@ end
         rendererPrototypes = {
           inputFencedCode = {
             \prop_get:NnNTF
-              \g_@@_diagrams_infostrings_prop
+              \g_markdown_diagrams_infostrings_prop
               { #2 }
               \l_tmpa_tl
               {
@@ -35670,7 +35670,7 @@ end
       \@@_diagrams_infostrings_current:n
       { 1 }
     \prop_gput:NnV
-      \g_@@_diagrams_infostrings_prop
+      \g_markdown_diagrams_infostrings_prop
       { dot }
       \l_tmpa_tl
 %    \end{macrocode}
@@ -35698,7 +35698,7 @@ end
       \@@_diagrams_infostrings_current:n
       { 1 }
     \prop_gput:NnV
-      \g_@@_diagrams_infostrings_prop
+      \g_markdown_diagrams_infostrings_prop
       { mermaid }
       \l_tmpa_tl
 %    \end{macrocode}
@@ -35735,7 +35735,7 @@ end
       \@@_diagrams_infostrings_current:n
       { 1 }
     \prop_gput:NnV
-      \g_@@_diagrams_infostrings_prop
+      \g_markdown_diagrams_infostrings_prop
       { plantuml }
       \l_tmpa_tl
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35582,8 +35582,8 @@ end
                 if~!~test~-e~#2.source~
                 ||~!~diff~#1~#2.source;
                 then~
-                  dot~-Tpdf~-o~#2~#1;
                   (#3);
+                  cp~#1~#2.source;
                 fi
               }
             \exp_args:NNnV

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35676,8 +35676,8 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Typeset fenced code with infostring `mermaid` using the npm package
-% [@mermaid-js/mermaid-cli](https://www.npmjs.com/package/@mermaid-js/mermaid-cli).
+% Typeset fenced code with infostring `mermaid` using the command `mmdc` from
+% the npm package `@mermaid-js/mermaid-cli`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -35687,10 +35687,7 @@ end
         \@@_diagrams_render_diagram:nnnn
           { #1 }
           { #1.pdf }
-          {
-            npx~-p~@mermaid-js/mermaid-cli~mmdc~
-              --pdfFit~-i~#1~-o~#1.pdf
-          }
+          { mmdc~--pdfFit~-i~#1~-o~#1.pdf }
           { Mermaid~image }
       }
     \@@_tl_set_from_cs:NNn

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35701,6 +35701,43 @@ end
       \g_@@_diagrams_infostrings_prop
       { mermaid }
       \l_tmpa_tl
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Typeset fenced code with infostring `plantuml` using PlantUML.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \regex_const:Nn
+      \c_@@_diagrams_filename_suffix_regex
+      { \.[^.]*$ }
+    \cs_set:Nn
+      \@@_diagrams_infostrings_current:n
+      {
+        \tl_set:Nn
+          \l_tmpa_tl
+          { #1 }
+        \regex_replace_once:NnN
+          \c_@@_diagrams_filename_suffix_regex
+          { .pdf }
+          \l_tmpa_tl
+        \@@_diagrams_render_diagram:nVnn
+          { #1 }
+          \l_tmpa_tl
+          { plantuml~-tpdf~#1 }
+          { PlantUML~image }
+      }
+    \cs_generate_variant:Nn
+      \@@_diagrams_render_diagram:nnnn
+      { nVnn }
+    \@@_tl_set_from_cs:NNn
+      \l_tmpa_tl
+      \@@_diagrams_infostrings_current:n
+      { 1 }
+    \prop_gput:NnV
+      \g_@@_diagrams_infostrings_prop
+      { plantuml }
+      \l_tmpa_tl
   }
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -13033,23 +13033,27 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %                ((?))
 %    ```
 %
-%    ``` plantuml {caption="An example UML sequence diagram" width=11cm #plantuml}
+%    ``` plantuml {caption="An example UML sequence diagram" width=7cm #plantuml}
 %    @startuml
-%    participant Participant as Foo
-%    actor       Actor       as Foo1
-%    boundary    Boundary    as Foo2
-%    control     Control     as Foo3
-%    entity      Entity      as Foo4
-%    database    Database    as Foo5
-%    collections Collections as Foo6
-%    queue       Queue       as Foo7
-%    Foo -> Foo1 : To actor
-%    Foo -> Foo2 : To boundary
-%    Foo -> Foo3 : To control
-%    Foo -> Foo4 : To entity
-%    Foo -> Foo5 : To database
-%    Foo -> Foo6 : To collections
-%    Foo -> Foo7: To queue
+%    ' Define participants (actors)
+%    participant "Client" as C
+%    participant "Server" as S
+%    participant "Database" as DB
+%
+%    ' Diagram title
+%    title Simple Request-Response Flow
+%
+%    ' Messages
+%    C -> S: Send Request
+%    note over S: Process request
+%
+%    alt Request is valid
+%        S -> DB: Query Data
+%        DB -> S: Return Data
+%        S -> C: Respond with Data
+%    else Request is invalid
+%        S -> C: Return Error
+%    end
 %    @enduml
 %    ```
 %
@@ -13102,21 +13106,25 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %
 %    ``` plantuml {caption="An example UML sequence diagram" #fig:witiko-diagrams-plantuml}
 %    @startuml
-%    participant Participant as Foo
-%    actor       Actor       as Foo1
-%    boundary    Boundary    as Foo2
-%    control     Control     as Foo3
-%    entity      Entity      as Foo4
-%    database    Database    as Foo5
-%    collections Collections as Foo6
-%    queue       Queue       as Foo7
-%    Foo -> Foo1 : To actor
-%    Foo -> Foo2 : To boundary
-%    Foo -> Foo3 : To control
-%    Foo -> Foo4 : To entity
-%    Foo -> Foo5 : To database
-%    Foo -> Foo6 : To collections
-%    Foo -> Foo7: To queue
+%    ' Define participants (actors)
+%    participant "Client" as C
+%    participant "Server" as S
+%    participant "Database" as DB
+%
+%    ' Diagram title
+%    title Simple Request-Response Flow
+%
+%    ' Messages
+%    C -> S: Send Request
+%    note over S: Process request
+%
+%    alt Request is valid
+%        S -> DB: Query Data
+%        DB -> S: Return Data
+%        S -> C: Respond with Data
+%    else Request is invalid
+%        S -> C: Return Error
+%    end
 %    @enduml
 %    ```
 
@@ -13177,23 +13185,27 @@ mindmap
             ((?))
 ```
 
-``` plantuml {caption="An example UML sequence diagram" width=11cm #plantuml}
+``` plantuml {caption="An example UML sequence diagram" width=7cm #plantuml}
 @startuml
-participant Participant as Foo
-actor       Actor       as Foo1
-boundary    Boundary    as Foo2
-control     Control     as Foo3
-entity      Entity      as Foo4
-database    Database    as Foo5
-collections Collections as Foo6
-queue       Queue       as Foo7
-Foo -> Foo1 : To actor
-Foo -> Foo2 : To boundary
-Foo -> Foo3 : To control
-Foo -> Foo4 : To entity
-Foo -> Foo5 : To database
-Foo -> Foo6 : To collections
-Foo -> Foo7: To queue
+' Define participants (actors)
+participant "Client" as C
+participant "Server" as S
+participant "Database" as DB
+
+' Diagram title
+title Simple Request-Response Flow
+
+' Messages
+C -> S: Send Request
+note over S: Process request
+
+alt Request is valid
+    S -> DB: Query Data
+    DB -> S: Return Data
+    S -> C: Respond with Data
+else Request is invalid
+    S -> C: Return Error
+end
 @enduml
 ```
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35656,8 +35656,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \cs_new:Nn
-      \@@_diagrams_infostrings_dot:n
+    \cs_set:Nn
+      \@@_diagrams_infostrings_current:n
       {
         \@@_diagrams_render_diagram:nnnn
           { #1 }
@@ -35667,7 +35667,7 @@ end
       }
     \@@_tl_set_from_cs:NNn
       \l_tmpa_tl
-      \@@_diagrams_infostrings_dot:n
+      \@@_diagrams_infostrings_current:n
       { 1 }
     \prop_gput:NnV
       \g_@@_diagrams_infostrings_prop
@@ -35681,8 +35681,8 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \cs_new:Nn
-      \@@_diagrams_infostrings_mermaid:n
+    \cs_set:Nn
+      \@@_diagrams_infostrings_current:n
       {
         \@@_diagrams_render_diagram:nnnn
           { #1 }
@@ -35695,7 +35695,7 @@ end
       }
     \@@_tl_set_from_cs:NNn
       \l_tmpa_tl
-      \@@_diagrams_infostrings_mermaid:n
+      \@@_diagrams_infostrings_current:n
       { 1 }
     \prop_gput:NnV
       \g_@@_diagrams_infostrings_prop

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -84,6 +84,7 @@
   hybrid,
   inlineNotes,
   jekyllData,
+  linkAttributes,
   relativeReferences,
   stripPercentSigns,
   underscores = false,
@@ -12981,19 +12982,24 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 
 \pkg{witiko/diagrams}
 
-:    A theme that typesets fenced code blocks with the `dot …` infostring
-     as images of directed graphs rendered by the Graphviz tools. The
-     right tail of the infostring is used as the image title.
+:    A theme that typesets fenced code blocks with the infostrings
+     `dot`, `mermaid`, and `plantuml` as figures with diagrams produced with
+     the command `dot` from Graphviz tools, the command `mmdc` from the npm
+     package `@mermaid-js/mermaid-cli`, and the command `plantuml` from the
+     package PlantUML, respectively. The key-value attribute `caption` can be
+     used to specify the caption of the figure. The remaining attributes are
+     treated as image attributes.
+
 %    ```` tex
 %    \documentclass{article}
 %    \usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
 %    \begin{document}
 %    \begin{markdown}
-%    ``` dot {caption="Various formats of mathemathical formulae" width=10cm #diagram}
+%    ``` dot {caption="An example directed graph" width=12cm #dot}
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
-%
+%    
 %      latex -> pmml;
 %      latex -> cmml;
 %      pmml -> slt;
@@ -13002,7 +13008,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      cmml -> infix;
 %      pmml -> mterms [style=dashed];
 %      cmml -> mterms;
-%
+%    
 %      latex [label = "LaTeX"];
 %      pmml [label = "Presentation MathML"];
 %      cmml [label = "Content MathML"];
@@ -13013,18 +13019,54 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      mterms [label = "M-Terms"];
 %    }
 %    ```
+%    
+%    ``` mermaid {caption="An example mindmap" width=9cm #mermaid}
+%    mindmap
+%        root )base-idea(
+%            sub<br/>idea 1
+%                ((?))
+%            sub<br/>idea 2
+%                ((?))
+%            sub<br/>idea 3
+%                ((?))
+%            sub<br/>idea 4
+%                ((?))
+%    ```
+%    
+%    ``` plantuml {caption="An example UML sequence diagram" width=11cm #plantuml}
+%    @startuml
+%    participant Participant as Foo
+%    actor       Actor       as Foo1
+%    boundary    Boundary    as Foo2
+%    control     Control     as Foo3
+%    entity      Entity      as Foo4
+%    database    Database    as Foo5
+%    collections Collections as Foo6
+%    queue       Queue       as Foo7
+%    Foo -> Foo1 : To actor 
+%    Foo -> Foo2 : To boundary
+%    Foo -> Foo3 : To control
+%    Foo -> Foo4 : To entity
+%    Foo -> Foo5 : To database
+%    Foo -> Foo6 : To collections
+%    Foo -> Foo7: To queue
+%    @enduml
+%    ```
 %
-%    See the diagram in Figure <#diagram>.
+%    See the diagrams in figures <#dot>, <#mermaid>, and <#plantuml>.
 %    \end{markdown}
 %    \end{document}
 %    ````````
+%
 %    Typesetting the above document produces the output shown in
-%    Figure <#fig:witiko-diagrams>.
-%    ``` dot {caption="Various formats of mathemathical formulae" #fig:witiko-diagrams}
+%    figures <#fig:witiko-diagrams-dot>, <#fig:witiko-diagrams-mermaid>, and
+%    <#fig:witiko-diagrams-plantuml>.
+%
+%    ``` dot {caption="An example directed graph" #fig:witiko-diagrams-dot}
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
-%
+%    
 %      latex -> pmml;
 %      latex -> cmml;
 %      pmml -> slt;
@@ -13033,7 +13075,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      cmml -> infix;
 %      pmml -> mterms [style=dashed];
 %      cmml -> mterms;
-%
+%    
 %      latex [label = "LaTeX"];
 %      pmml [label = "Presentation MathML"];
 %      cmml [label = "Content MathML"];
@@ -13044,15 +13086,46 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      mterms [label = "M-Terms"];
 %    }
 %    ```
-     The theme requires a Unix-like operating system with GNU Diffutils and
-     Graphviz installed. The theme also requires shell access unless the
-     \Opt{frozenCache} plain \TeX{} option is enabled.
+%    
+%    ``` mermaid {caption="An example mindmap" #fig:witiko-diagrams-mermaid}
+%    mindmap
+%        root )base-idea(
+%            sub<br/>idea 1
+%                ((?))
+%            sub<br/>idea 2
+%                ((?))
+%            sub<br/>idea 3
+%                ((?))
+%            sub<br/>idea 4
+%                ((?))
+%    ```
+%    
+%    ``` plantuml {caption="An example UML sequence diagram" #fig:witiko-diagrams-plantuml}
+%    @startuml
+%    participant Participant as Foo
+%    actor       Actor       as Foo1
+%    boundary    Boundary    as Foo2
+%    control     Control     as Foo3
+%    entity      Entity      as Foo4
+%    database    Database    as Foo5
+%    collections Collections as Foo6
+%    queue       Queue       as Foo7
+%    Foo -> Foo1 : To actor 
+%    Foo -> Foo2 : To boundary
+%    Foo -> Foo3 : To control
+%    Foo -> Foo4 : To entity
+%    Foo -> Foo5 : To database
+%    Foo -> Foo6 : To collections
+%    Foo -> Foo7: To queue
+%    @enduml
+%    ```
 
-     The above example loads version `v1` of the theme, which is an alias for
-     an earlier theme named `witiko/dot`. Future versions of the theme may have
-     backwards-incompatible syntax and behavior. Therefore, you are encouraged
-     to always specify the version `v1` to keep your documents from suddenly
-     breaking.
+     The theme requires a Unix-like operating system with GNU Diffutils,
+     Graphviz, the npm package `@mermaid-js/mermaid-cli`, and PlantUML
+     installed. All these packages are already included in the Docker image
+     `witiko/markdown`; consult `Dockerfile` to see how they are installed.
+     The theme also requires shell access unless the \Opt{frozenCache} plain
+     \TeX{} option is enabled.
 
 % \markdownEnd
 % \iffalse
@@ -13066,7 +13139,7 @@ following content:
 \usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
 \begin{document}
 \begin{markdown}
-``` dot {caption="Various formats of mathemathical formulae" width=10cm #diagram}
+``` dot {caption="An example directed graph" width=12cm #dot}
 digraph tree {
   margin = 0;
   rankdir = "LR";
@@ -13091,7 +13164,40 @@ digraph tree {
 }
 ```
 
-See the diagram in Figure <#diagram>.
+``` mermaid {caption="An example mindmap" width=9cm #mermaid}
+mindmap
+    root )base-idea(
+        sub<br/>idea 1
+            ((?))
+        sub<br/>idea 2
+            ((?))
+        sub<br/>idea 3
+            ((?))
+        sub<br/>idea 4
+            ((?))
+```
+
+``` plantuml {caption="An example UML sequence diagram" width=11cm #plantuml}
+@startuml
+participant Participant as Foo
+actor       Actor       as Foo1
+boundary    Boundary    as Foo2
+control     Control     as Foo3
+entity      Entity      as Foo4
+database    Database    as Foo5
+collections Collections as Foo6
+queue       Queue       as Foo7
+Foo -> Foo1 : To actor 
+Foo -> Foo2 : To boundary
+Foo -> Foo3 : To control
+Foo -> Foo4 : To entity
+Foo -> Foo5 : To database
+Foo -> Foo6 : To collections
+Foo -> Foo7: To queue
+@enduml
+```
+
+See the diagrams in figures <#dot>, <#mermaid>, and <#plantuml>.
 \end{markdown}
 \end{document}
 ````````
@@ -13100,14 +13206,7 @@ Next, invoke LuaTeX from the terminal:
 lualatex --shell-escape document.tex
 ``````
 A PDF document named `document.pdf` should be produced and contain
-a drawing of a directed graph similar to Figure 1 from the following
-conference article:
-
-> NOVOTNÝ, Vít, Petr SOJKA, Michal ŠTEFÁNIK and Dávid LUPTÁK. Three is Better
-> than One: Ensembling Math Information Retrieval Systems. *CEUR Workshop
-> Proceedings*. Thessaloniki, Greece: M. Jeusfeld c/o Redaktion Sun SITE,
-> Informatik V, RWTH Aachen., 2020, vol. 2020, No 2696, p. 1-30. ISSN 1613-0073.
-> <http://ceur-ws.org/Vol-2696/paper_235.pdf>
+three diagrams.
 
 % \fi
 % \markdownBegin
@@ -13129,7 +13228,7 @@ conference article:
 %    Typesetting the above document produces the output shown in
 %    Figure <#fig:witiko/graphicx/http>.
 %    ![img](https://github.com/witiko/markdown/raw/main/markdown.png
-%           "The banner of the Markdown package \label{fig:witiko/graphicx/http}")
+%           "The banner of the Markdown package"){#fig:witiko/graphicx/http}
      The theme requires the \pkg{catchfile} \LaTeX{} package and a Unix-like
      operating system with GNU Coreutils `md5sum` and either GNU Wget or cURL
      installed. The theme also requires shell access unless the
@@ -35652,7 +35751,8 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Typeset fenced code with infostring `dot` using Graphviz.
+% Typeset fenced code with infostring `dot` using the command `dot` from
+% the package Graphviz.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -35701,7 +35801,8 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Typeset fenced code with infostring `plantuml` using PlantUML.
+% Typeset fenced code with infostring `plantuml` using the command `plantuml`
+% from the package PlantUML.
 %
 % \end{markdown}
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35526,7 +35526,7 @@ end
 % \end{markdown}
 %  \begin{macrocode}
     \tl_new:N
-      \@@_diagrams_caption_tl
+      \l_@@_diagrams_caption_tl
     \@@_setup:n
       {
         rendererPrototypes = {
@@ -35545,7 +35545,7 @@ end
                       { caption }
                       {
                         \tl_set:Nn
-                          \@@_diagrams_caption_tl
+                          \l_@@_diagrams_caption_tl
                           { ##2 }
                       }
                       {
@@ -35594,7 +35594,7 @@ end
                             { #1.pdf }
                             { #1.pdf }
                           }
-                          \@@_diagrams_caption_tl
+                          \l_@@_diagrams_caption_tl
                     }
                 }
               }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -39441,19 +39441,28 @@ end
 \markdownSetup {
   rendererPrototypes = {
     image = {
-      \begin { figure }
-        \begin { center }
-          \includegraphics
-            [ alt = { #1 } ]
-            { #3 }
-          \tl_if_empty:nF
-            { #4 }
-            { \caption { #4 } }
-          \seq_map_inline:Nn
-            \l_@@_image_identifiers_seq
-            { \label { ##1 } }
-        \end { center }
-      \end { figure }
+      \tl_if_empty:nTF
+        { #4 }
+        {
+          \begin { center }
+            \includegraphics
+              [ alt = { #1 } ]
+              { #3 }
+          \end { center }
+        }
+        {
+          \begin { figure }
+            \begin { center }
+              \includegraphics
+                [ alt = { #1 } ]
+                { #3 }
+              \caption { #4 }
+              \seq_map_inline:Nn
+                \l_@@_image_identifiers_seq
+                { \label { ##1 } }
+            \end { center }
+          \end { figure }
+        }
     },
   }
 }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35530,6 +35530,14 @@ end
     \@@_setup:n
       {
         rendererPrototypes = {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Route attributes on fenced code blocks to the image attribute renderer
+% prototypes.
+%
+% \end{markdown}
+%  \begin{macrocode}
           fencedCodeAttributeContextBegin = {
             \group_begin:
             \markdownRendererImageAttributeContextBegin
@@ -35561,6 +35569,37 @@ end
             \markdownRendererImageAttributeContextEnd
             \group_end:
           },
+        },
+      }
+    \cs_new:Nn
+      \@@_diagrams_render_diagram:nnnn
+      {
+        \@@_if_option:nF
+          { frozenCache }
+          {
+            \sys_shell_now:n
+              {
+                if~!~test~-e~#2.source~
+                ||~!~diff~#1~#2.source;
+                then~
+                  dot~-Tpdf~-o~#2~#1;
+                  (#3);
+                fi
+              }
+            \exp_args:NNnV
+              \exp_last_unbraced:No
+              \markdownRendererImage
+                {
+                  { #4 }
+                  { #2 }
+                  { #2 }
+                }
+                \l_@@_diagrams_caption_tl
+          }
+      }
+    \@@_setup:n
+      {
+        rendererPrototypes = {
           inputFencedCode = {
             \str_case:nnF
               { #2 }
@@ -35568,34 +35607,33 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Typeset fenced code with infostring `dot` using GraphViz.
+% Typeset fenced code with infostring `dot` using Graphviz.
 %
 % \end{markdown}
 %  \begin{macrocode}
                 { dot }
                 {
-                  \@@_if_option:nF
-                    { frozenCache }
-                    {
-                      \sys_shell_now:n
-                        {
-                          if~!~test~-e~#1.pdf.source~
-                          ||~!~diff~#1~#1.pdf.source;
-                          then~
-                            dot~-Tpdf~-o~#1.pdf~#1;
-                            cp~#1~#1.pdf.source;
-                          fi
-                        }
-                      \exp_args:NNnV
-                        \exp_last_unbraced:No
-                        \markdownRendererImage
-                          {
-                            { Graphviz~image }
-                            { #1.pdf }
-                            { #1.pdf }
-                          }
-                          \l_@@_diagrams_caption_tl
-                    }
+                  \@@_diagrams_render_diagram:nnnn
+                    { #1 }
+                    { #1.pdf }
+                    { dot~-Tpdf~-o~#1.pdf~#1 }
+                    { Graphviz~image }
+                }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Typeset fenced code with infostring `mermaid` using the npm package
+% [@mermaid-js/mermaid-cli](https://www.npmjs.com/package/@mermaid-js/mermaid-cli).
+%
+% \end{markdown}
+%  \begin{macrocode}
+                { mermaid }
+                {
+                  \@@_diagrams_render_diagram:nnnn
+                    { #1 }
+                    { #1.pdf }
+                    { npx~-p~@mermaid-js/mermaid-cli~mmdc~--pdfFit~-i~#1~-o~#1.pdf }
+                    { Mermaid~image }
                 }
               }
 %    \end{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35632,7 +35632,10 @@ end
                   \@@_diagrams_render_diagram:nnnn
                     { #1 }
                     { #1.pdf }
-                    { npx~-p~@mermaid-js/mermaid-cli~mmdc~--pdfFit~-i~#1~-o~#1.pdf }
+                    {
+                      npx~-p~@mermaid-js/mermaid-cli~mmdc~
+                        --pdfFit~-i~#1~-o~#1.pdf
+                    }
                     { Mermaid~image }
                 }
               }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -35491,7 +35491,7 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% The theme `witiko/diagrams/v2` ...
+% Next, we implement the theme `witiko/diagrams/v2`.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -35499,7 +35499,115 @@ end
   \g_@@_plain_tex_built_in_themes_prop
   { witiko / diagrams / v2 }
   {
-    % TODO
+%    \end{macrocode}
+% \begin{markdown}
+%
+% We enable the \Opt{fencedCode} and \Opt{fencedCodeAttributes} Lua
+% option.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \@@_setup:n
+      {
+        fencedCode = true,
+        fencedCodeAttributes = true,
+      }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Store the previous fenced code token renderer prototype.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \cs_set_eq:NN
+      \@@_diagrams_previous_definition:nnn
+      \markdownRendererInputFencedCodePrototype
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Store the caption of the diagram.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \tl_new:N
+      \@@_diagrams_caption_tl
+    \@@_setup:n
+      {
+        rendererPrototypes = {
+          fencedCodeAttributeContextBegin = {
+            \group_begin:
+            \@@_setup:n
+              {
+                rendererPrototypes = {
+                  attributeKeyValue = {
+                    \str_if_eq:nnT
+                      { ##1 }
+                      { caption }
+                      {
+                        \tl_set:Nn
+                          \@@_diagrams_caption_tl
+                          { ##2 }
+                      }
+                  },
+                },
+              }
+          },
+          fencedCodeAttributeContextEnd = {
+            \group_end:
+          },
+          inputFencedCode = {
+            \str_case:nnF
+              { #2 }
+              {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Typeset fenced code with infostring `dot` using GraphViz.
+%
+% \end{markdown}
+%  \begin{macrocode}
+                { dot }
+                {
+                  \@@_if_option:nF
+                    { frozenCache }
+                    {
+                      \sys_shell_now:n
+                        {
+                          if~!~test~-e~#1.pdf.source~
+                          ||~!~diff~#1~#1.pdf.source;
+                          then~
+                            dot~-Tpdf~-o~#1.pdf~#1;
+                            cp~#1~#1.pdf.source;
+                          fi
+                        }
+                      \exp_args:NNnV
+                        \exp_last_unbraced:No
+                        \markdownRendererImage
+                          {
+                            { Graphviz~image }
+                            { #1.pdf }
+                            { #1.pdf }
+                          }
+                          \@@_diagrams_caption_tl
+                    }
+                }
+              }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Otherwise, use the previous fenced code token renderer prototype.
+%
+% \end{markdown}
+%  \begin{macrocode}
+              {
+                \@@_diagrams_previous_definition:nnn
+                  { #1 }
+                  { #2 }
+                  { #3 }
+              }
+          },
+        },
+      }
   }
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12999,7 +12999,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
-%    
+%
 %      latex -> pmml;
 %      latex -> cmml;
 %      pmml -> slt;
@@ -13008,7 +13008,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      cmml -> infix;
 %      pmml -> mterms [style=dashed];
 %      cmml -> mterms;
-%    
+%
 %      latex [label = "LaTeX"];
 %      pmml [label = "Presentation MathML"];
 %      cmml [label = "Content MathML"];
@@ -13019,7 +13019,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      mterms [label = "M-Terms"];
 %    }
 %    ```
-%    
+%
 %    ``` mermaid {caption="An example mindmap" width=9cm #mermaid}
 %    mindmap
 %        root )base-idea(
@@ -13032,7 +13032,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %            sub<br/>idea 4
 %                ((?))
 %    ```
-%    
+%
 %    ``` plantuml {caption="An example UML sequence diagram" width=11cm #plantuml}
 %    @startuml
 %    participant Participant as Foo
@@ -13043,7 +13043,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %    database    Database    as Foo5
 %    collections Collections as Foo6
 %    queue       Queue       as Foo7
-%    Foo -> Foo1 : To actor 
+%    Foo -> Foo1 : To actor
 %    Foo -> Foo2 : To boundary
 %    Foo -> Foo3 : To control
 %    Foo -> Foo4 : To entity
@@ -13066,7 +13066,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
-%    
+%
 %      latex -> pmml;
 %      latex -> cmml;
 %      pmml -> slt;
@@ -13075,7 +13075,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      cmml -> infix;
 %      pmml -> mterms [style=dashed];
 %      cmml -> mterms;
-%    
+%
 %      latex [label = "LaTeX"];
 %      pmml [label = "Presentation MathML"];
 %      cmml [label = "Content MathML"];
@@ -13086,7 +13086,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %      mterms [label = "M-Terms"];
 %    }
 %    ```
-%    
+%
 %    ``` mermaid {caption="An example mindmap" #fig:witiko-diagrams-mermaid}
 %    mindmap
 %        root )base-idea(
@@ -13099,7 +13099,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %            sub<br/>idea 4
 %                ((?))
 %    ```
-%    
+%
 %    ``` plantuml {caption="An example UML sequence diagram" #fig:witiko-diagrams-plantuml}
 %    @startuml
 %    participant Participant as Foo
@@ -13110,7 +13110,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %    database    Database    as Foo5
 %    collections Collections as Foo6
 %    queue       Queue       as Foo7
-%    Foo -> Foo1 : To actor 
+%    Foo -> Foo1 : To actor
 %    Foo -> Foo2 : To boundary
 %    Foo -> Foo3 : To control
 %    Foo -> Foo4 : To entity
@@ -13187,7 +13187,7 @@ entity      Entity      as Foo4
 database    Database    as Foo5
 collections Collections as Foo6
 queue       Queue       as Foo7
-Foo -> Foo1 : To actor 
+Foo -> Foo1 : To actor
 Foo -> Foo2 : To boundary
 Foo -> Foo3 : To control
 Foo -> Foo4 : To entity


### PR DESCRIPTION
### Tasks
- [x] Redirect theme `witiko/diagrams@latest` and `@v2` to `witiko/diagrams/v2`.
- [x] Implement theme `witiko/diagrams/v2`:
    - [x] Implement theme `witiko/diagrams/v2` for GraphViz.
    - [x] Implement theme `witiko/diagrams/v2` for PlantUML.
    - [x] Implement theme `witiko/diagrams/v2` for Mermaid.
- [x] Document theme `witiko/diagrams/v2`.
- [x] Use theme `witiko/diagrams@v2` in the technical documentation.
    - [x] Showcase all supported types of themes in the technical documentation.
- [x] Include all necessary packages in `Dockerfile`.
- [x] Update `CHANGES.md`.

Closes #448, #514, and #531.