### PR TITLE
Remove dependency on Selene Unicode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Development:
 
 - Add a built-in theme `witiko/diagrams@v2` for drawing different types of
   diagrams. (#448, #514, #531, #542, [matrix.org][matrix-542], a9cadc41,
-  578e64d6, 22efe7f4, originally suggested by @anubane)
+  578e64d6, 22efe7f4, a3c2d93b, originally suggested by @anubane)
 
    [matrix-542]: https://matrix.to/#/!UeAwznpYwwsinVTetR:matrix.org/$CpfhKJT8DAkzH7Rx6ynV1BKFKbfMUtxkpNzqftvLGec?via=matrix.org&via=im.f3l.de
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 ## 3.11.0
 
+Development:
+
+- Remove dependency on Selene Unicode and support ConTeXt standalone.
+  (originally reported by @andreiborisov in #402 and #436,
+  fixed in #551..#553 with contributions from @lostenderman)
+
+Fixes:
+
+- Prevent left-flanking and right-flanking delimiter runs followed by
+  multi-byte whitespace or punctuation characters. (#552, #553, with
+  contributions from @lostenderman)
+
 Documentation:
 
 - Add a man page for `markdown2tex`. (#547, #554, suggested by @kberry)

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27257,7 +27257,10 @@ function M.writer.new(options)
 
       -- Remove everything up to the first letter.
       if not letter_found then
-        local is_letter = lpeg.match(parsers.following_alpha, char)
+        local is_letter = lpeg.match(
+          parsers.unicode.following_alpha,
+          char
+        )
         if is_letter then
           letter_found = true
         else
@@ -27332,7 +27335,7 @@ function M.writer.new(options)
       -- Remove everything up to the first non-space.
       if not letter_found then
         local is_letter = not lpeg.match(
-          parsers.following_whitespace,
+          parsers.unicode.following_whitespace,
           char
         )
         if is_letter then

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -30210,9 +30210,6 @@ function M.reader.new(writer, options)
       ::continue::
     end
   end
-
-  local cont = lpeg.R("\128\191") -- continuation byte
-
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -30222,7 +30219,6 @@ function M.reader.new(writer, options)
 % \end{markdown}
 %  \begin{macrocode}
   local function check_unicode_type(s, i, start_pos, end_pos, chartype)
-    local c
     local char_length
     for pos = start_pos, end_pos, 1 do
       if (start_pos < 0) then

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27760,10 +27760,12 @@ end
 %  \begin{macrocode}
 parsers.unicode = {}
 parsers.unicode.punctuation = {}
+parsers.unicode.preceding_punctuation = parsers.fail
 parsers.unicode.following_punctuation = parsers.fail
 parsers.unicode.alpha = {}
 parsers.unicode.word = {}
 parsers.unicode.whitespace = {}
+parsers.unicode.preceding_whitespace = parsers.fail
 parsers.unicode.following_whitespace = parsers.fail
 for n = 1, 4 do
 %    \end{macrocode}
@@ -27779,6 +27781,9 @@ for n = 1, 4 do
 %  \begin{macrocode}
   parsers.unicode.punctuation[n] = unicode_data.categories.P[n]
                                  + unicode_data.categories.S[n]
+  parsers.unicode.preceding_punctuation
+    = parsers.unicode.preceding_punctuation
+    + B(parsers.unicode.punctuation[n])
   parsers.unicode.following_punctuation
     = parsers.unicode.following_punctuation
     + #parsers.unicode.punctuation[n]
@@ -27819,39 +27824,13 @@ for n = 1, 4 do
     parsers.unicode.whitespace[n] = parsers.unicode.whitespace[n]
                                   + R("\t\r")
   end
+  parsers.unicode.preceding_whitespace
+    = parsers.unicode.preceding_whitespace
+    + B(parsers.unicode.whitespace[n])
   parsers.unicode.following_whitespace
     = parsers.unicode.following_whitespace
     + #parsers.unicode.whitespace[n]
 end
-
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Check if a there is a character of a type `chartype` between the start position `start_pos`
-% and end position `end_pos` in a string `s` relative to current index `i`.
-%
-% \end{markdown}
-%  \begin{macrocode}
-local function check_preceding_unicode(chartype)
-  local parser = parsers.unicode[chartype]
-  if parser ~= nil then
-    return function(s, i)
-      for pos = -4, -1, 1 do
-        if lpeg.match(parser[-pos], s, i+pos) then
-          return i
-        end
-      end
-    end
-  else
-    assert(false, 'Unknown character type "' .. chartype .. '"')
-  end
-end
-
-parsers.unicode.preceding_punctuation
-  = Cmt(parsers.succeed, check_preceding_unicode("punctuation"))
-
-parsers.unicode.preceding_whitespace
-  = Cmt(parsers.succeed, check_preceding_unicode("whitespace"))
 
 parsers.escapable              = parsers.ascii_punctuation
 parsers.anyescaped             = parsers.backslash / ""

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27273,7 +27273,7 @@ function M.writer.new(options)
 
       -- Remove everything up to the first letter.
       if not letter_found then
-        local is_letter = unicode.utf8.match(char, "%a")
+        local is_letter = lpeg.match(parsers.following_alpha, char)
         if is_letter then
           letter_found = true
         else
@@ -27283,12 +27283,23 @@ function M.writer.new(options)
 
       -- Remove all non-alphanumeric characters, except underscores,
       -- hyphens, and periods.
-      if not unicode.utf8.match(char, "[%w_%-%.%s]") then
+      if not lpeg.match(
+        ( parsers.underscore
+        + parsers.dash
+        + parsers.period
+        + parsers.unicode.following_word
+        + parsers.unicode.following_whitespace ),
+        char
+      ) then
         goto continue
       end
 
       -- Replace all spaces and newlines with hyphens.
-      if unicode.utf8.match(char, "[%s\n]") then
+      if not lpeg.match(
+        ( parsers.newline
+        + parsers.unicode.following_whitespace ),
+        char
+      ) then
         char = "-"
         if prev_space then
           goto continue
@@ -27336,7 +27347,10 @@ function M.writer.new(options)
 
       -- Remove everything up to the first non-space.
       if not letter_found then
-        local is_letter = unicode.utf8.match(char, "%S")
+        local is_letter = not lpeg.match(
+          parsers.following_whitespace,
+          char
+        )
         if is_letter then
           letter_found = true
         else
@@ -27346,13 +27360,23 @@ function M.writer.new(options)
 
       -- Remove all non-alphanumeric characters, except underscores
       -- and hyphens.
-      if not unicode.utf8.match(char, "[%w_%-%s]") then
+      if not lpeg.match(
+        ( parsers.underscore
+        + parsers.dash
+        + parsers.unicode.following_word
+        + parsers.unicode.following_whitespace ),
+        char
+      ) then
         prev_space = false
         goto continue
       end
 
       -- Replace all spaces and newlines with hyphens.
-      if unicode.utf8.match(char, "[%s\n]") then
+      if not lpeg.match(
+        ( parsers.newline
+        + parsers.unicode.following_whitespace ),
+        char
+      ) then
         char = "-"
         if prev_space then
           goto continue

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27567,14 +27567,11 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 % \fi
 % \begin{markdown}
 %
-%### Unicode punctuation
-% This section documents [the Unicode punctuation][unicode-punctuation]
-% recognized by the markdown reader. The punctuation is organized in the
-% \luamdef{parsers.punctuation} table according to the number of bytes occupied
-% after conversion to \acro{utf}8.
-%
-% [unicode-punctuation]: https://spec.commonmark.org/0.31.2/#unicode-punctuation-character
-%                        (CommonMark Spec, Version 0.31.2 (2024-01-28))
+%### Unicode data
+% This section documents different Unicode character categories recognized by
+% the markdown reader. The parsers for the different categories are organized
+% in the table \luamdef{parsers.unicode_data} according to the number of bytes
+% occupied after conversion to \acro{utf}8.
 %
 % All code from this section will be executed during the compilation of
 % the Markdown package and the standard output will be stored in a file
@@ -27592,20 +27589,29 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 % \begin{markdown}
 %
 % In order to minimize the size and speed of the parser, we will first
-% construct a prefix tree of UTF-8 encodings for all codepoints of a
-% given code length.
+% construct prefixs tree of UTF-8 encodings for all codepoints of a
+% given Unicode category and code length.
 %
 % \end{markdown}
 %  \begin{macrocode}
+  local categories = {"L", "N", "P", "Pc", "S", "Z"}
   local prefix_trees = {}
+  for _, category in ipairs(categories) do
+    prefix_trees[category] = {}
+    for char_length = 1, 4 do
+      prefix_trees[category][char_length] = {}
+    end
+  end
   for line in file:lines() do
-    local codepoint, major_category = line:match("^(%x+);[^;]*;(%a)")
-    if major_category == "P" or major_category == "S" then
-      local code = utf8.char(tonumber(codepoint, 16))
-      if prefix_trees[#code] == nil then
-        prefix_trees[#code] = {}
+    local codepoint, full_category = line:match("^(%x+);[^;]*;(%a*)")
+    assert(#full_category >= 1)
+    local major_category = full_category:sub(1, 1)
+    for _, category in ipairs({full_category, major_category}) do
+      if prefix_trees[category] == nil then
+        goto continue
       end
-      local node = prefix_trees[#code]
+      local code = utf8.char(tonumber(codepoint, 16))
+      local node = prefix_trees[category][#code]
       for i = 1, #code do
         local byte = code:sub(i, i)
         if i < #code then
@@ -27617,6 +27623,7 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
           table.insert(node, byte)
         end
       end
+      ::continue::
     end
   end
   assert(file:close())
@@ -27624,7 +27631,7 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Next, we will construct a parser out of the prefix tree.
+% Next, we will construct parsers out of the prefix trees.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -27640,51 +27647,58 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
     leave(node, path)
   end
 
-  print("M.punctuation = {}")
+  print("M.categories = {}")
   print("local P = lpeg.P")
+  print("local fail = P(false)")
   print("-- luacheck: push no max line length")
-  for length, prefix_tree in pairs(prefix_trees) do
-    local subparsers = {}
-    depth_first_search(prefix_tree, "", function(node, path)
-      if type(node) == "string" then
-        local suffix
-        if node == "]" then
-          suffix = "P('" .. node .. "')"
-        else
-          suffix = "P([[" .. node .. "]])"
+  for _, category in ipairs(categories) do
+    print("M.categories." .. category .. " = {}")
+    for length, prefix_tree in pairs(prefix_trees[category]) do
+      local subparsers = {}
+      depth_first_search(prefix_tree, "", function(node, path)
+        if type(node) == "string" then
+          local suffix
+          if node == "]" then
+            suffix = "P('" .. node .. "')"
+          else
+            suffix = "P([[" .. node .. "]])"
+          end
+          if subparsers[path] ~= nil then
+            subparsers[path] = subparsers[path] .. " + " .. suffix
+          else
+            subparsers[path] = suffix
+          end
         end
-        if subparsers[path] ~= nil then
-          subparsers[path] = subparsers[path] .. " + " .. suffix
+      end, function(_, path)
+        if #path > 0 then
+          local byte = path:sub(#path, #path)
+          local parent_path = path:sub(1, #path-1)
+          local prefix
+          if byte == "]" then
+            prefix = "P('" .. byte .. "')"
+          else
+            prefix = "P([[" .. byte .. "]])"
+          end
+          local suffix
+          if subparsers[path]:find(" %+ ") then
+            suffix = prefix .. " * (" .. subparsers[path] .. ")"
+          else
+            suffix = prefix .. " * " .. subparsers[path]
+          end
+          if subparsers[parent_path] ~= nil then
+            subparsers[parent_path] = subparsers[parent_path]
+                                   .. " + " .. suffix
+          else
+            subparsers[parent_path] = suffix
+          end
         else
-          subparsers[path] = suffix
+          print(
+            "M.categories." .. category .. "[" .. length .. "] = "
+            .. (subparsers[path] or "fail")
+          )
         end
-      end
-    end, function(_, path)
-      if #path > 0 then
-        local byte = path:sub(#path, #path)
-        local parent_path = path:sub(1, #path-1)
-        local prefix
-        if byte == "]" then
-          prefix = "P('" .. byte .. "')"
-        else
-          prefix = "P([[" .. byte .. "]])"
-        end
-        local suffix
-        if subparsers[path]:find(" %+ ") then
-          suffix = prefix .. " * (" .. subparsers[path] .. ")"
-        else
-          suffix = prefix .. " * " .. subparsers[path]
-        end
-        if subparsers[parent_path] ~= nil then
-          subparsers[parent_path] = subparsers[parent_path]
-                                 .. " + " .. suffix
-        else
-          subparsers[parent_path] = suffix
-        end
-      else
-        print("M.punctuation[" .. length .. "] = " .. subparsers[path])
-      end
-    end)
+      end)
+    end
   end
   print("-- luacheck: pop")
 end)()
@@ -27696,8 +27710,8 @@ print("return M")
 % \fi
 % \begin{markdown}
 %
-% Back in the Markdown package, we will load the precompiled parser of
-% Unicode punctuation.
+% Back in the Markdown package, we will load the precompiled parsers of
+% Unicode categories.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -27708,7 +27722,71 @@ if metadata.version ~= unicode_data.metadata.version then
     "markdown-unicode-data.lua " .. unicode_data.metadata.version .. "."
   )
 end
-parsers.punctuation = unicode_data.punctuation
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Finally, we define high-level parsers for specific types of characters that
+% are interesting for us.
+%
+% \end{markdown}
+%  \begin{macrocode}
+parsers.unicode = {}
+parsers.unicode.punctuation = {}
+parsers.unicode.alpha = {}
+parsers.unicode.word = {}
+parsers.unicode.space = {}
+for n = 1, 4 do
+%    \end{macrocode}
+% \begin{markdown}
+%
+% For punctuation, accept any characters from Unicode categories P
+% (punctuation) and S (symbol), as mandated by [the CommonMark standard][1].
+%
+% [1]: https://spec.commonmark.org/0.31.2/#unicode-punctuation-character
+%     (CommonMark Spec, Version 0.31.2 (2024-01-28))
+%
+% \end{markdown}
+%  \begin{macrocode}
+  parsers.unicode.punctuation[n] = unicode_data.categories.P[n]
+                                 + unicode_data.categories.S[n]
+%    \end{macrocode}
+% \begin{markdown}
+%
+% For alphabetical characters, accept any characters from Unicode category
+% L (letter), similar to the character class `%a` from the Lua library Selene
+% Unicode.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  parsers.unicode.alpha[n] = unicode_data.categories.L[n]
+%    \end{macrocode}
+% \begin{markdown}
+%
+% For word characters, accept any characters from Unicode categories
+% L (letter), N (number), and Pc (connector punctuation), similar to the
+% character class `%w` from the Lua library Selene Unicode.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  parsers.unicode.word[n] = unicode_data.categories.L[n]
+                          + unicode_data.categories.N[n]
+                          + unicode_data.categories.Pc[n]
+%    \end{macrocode}
+% \begin{markdown}
+%
+% For space characters, accept any characters from Unicode category Z
+% (separator), as well as the ASCII control characters 9 (horizontal tab)
+% through 13 (carriage return), similar to the character class `%s` from the
+% Lua library Selene Unicode.
+%
+% \end{markdown}
+%  \begin{macrocode}
+  parsers.unicode.space[n] = unicode_data.categories.Z[n]
+  if n == 1 then
+    parsers.unicode.space[n] = parsers.unicode.space[n]
+                             + R("\t\r")
+  end
+end
 
 parsers.escapable              = parsers.ascii_punctuation
 parsers.anyescaped             = parsers.backslash / ""
@@ -30138,27 +30216,6 @@ function M.reader.new(writer, options)
 %    \end{macrocode}
 % \begin{markdown}
 %
-% Match a UTF-8 character of byte length `n`.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function utf8_by_byte_count(n)
-    if (n == 1) then
-      return lpeg.R("\0\127")
-    end
-    if (n == 2) then
-      return lpeg.R("\194\223") * cont
-    end
-    if (n == 3) then
-      return lpeg.R("\224\239") * cont * cont
-    end
-    if (n == 4) then
-      return lpeg.R("\240\244") * cont * cont * cont
-    end
-  end
-%    \end{macrocode}
-% \begin{markdown}
-%
 % Check if a there is a character of a type `chartype` between the start position `start_pos`
 % and end position `end_pos` in a string `s` relative to current index `i`.
 %
@@ -30173,16 +30230,13 @@ function M.reader.new(writer, options)
       else
         char_length = pos + 1
       end
-
-      if (chartype == "punctuation") then
-        if lpeg.match(parsers.punctuation[char_length], s, i+pos) then
+      local parser = parsers.unicode[chartype]
+      if parser ~= nil then
+        if lpeg.match(parser[char_length], s, i+pos) then
           return i
         end
       else
-        c = lpeg.match({ C(utf8_by_byte_count(char_length)) },s,i+pos)
-        if (c ~= nil) and (unicode.utf8.match(c, chartype)) then
-          return i
-        end
+        assert(false, 'Unknown character type "' .. chartype .. '"')
       end
     end
   end
@@ -30192,7 +30246,7 @@ function M.reader.new(writer, options)
   end
 
   local function check_preceding_unicode_whitespace(s, i)
-    return check_unicode_type(s, i, -4, -1, "%s")
+    return check_unicode_type(s, i, -4, -1, "space")
   end
 
   local function check_following_unicode_punctuation(s, i)
@@ -30200,7 +30254,7 @@ function M.reader.new(writer, options)
   end
 
   local function check_following_unicode_whitespace(s, i)
-    return check_unicode_type(s, i, 0, 3, "%s")
+    return check_unicode_type(s, i, 0, 3, "space")
   end
 
   parsers.unicode_preceding_punctuation

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27760,9 +27760,11 @@ end
 %  \begin{macrocode}
 parsers.unicode = {}
 parsers.unicode.punctuation = {}
+parsers.unicode.following_punctuation = parsers.fail
 parsers.unicode.alpha = {}
 parsers.unicode.word = {}
-parsers.unicode.space = {}
+parsers.unicode.whitespace = {}
+parsers.unicode.following_whitespace = parsers.fail
 for n = 1, 4 do
 %    \end{macrocode}
 % \begin{markdown}
@@ -27777,6 +27779,9 @@ for n = 1, 4 do
 %  \begin{macrocode}
   parsers.unicode.punctuation[n] = unicode_data.categories.P[n]
                                  + unicode_data.categories.S[n]
+  parsers.unicode.following_punctuation
+    = parsers.unicode.following_punctuation
+    + #parsers.unicode.punctuation[n]
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -27809,12 +27814,44 @@ for n = 1, 4 do
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.unicode.space[n] = unicode_data.categories.Z[n]
+  parsers.unicode.whitespace[n] = unicode_data.categories.Z[n]
   if n == 1 then
-    parsers.unicode.space[n] = parsers.unicode.space[n]
-                             + R("\t\r")
+    parsers.unicode.whitespace[n] = parsers.unicode.whitespace[n]
+                                  + R("\t\r")
+  end
+  parsers.unicode.following_whitespace
+    = parsers.unicode.following_whitespace
+    + #parsers.unicode.whitespace[n]
+end
+
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Check if a there is a character of a type `chartype` between the start position `start_pos`
+% and end position `end_pos` in a string `s` relative to current index `i`.
+%
+% \end{markdown}
+%  \begin{macrocode}
+local function check_preceding_unicode(chartype)
+  local parser = parsers.unicode[chartype]
+  if parser ~= nil then
+    return function(s, i)
+      for pos = -4, -1, 1 do
+        if lpeg.match(parser[-pos], s, i+pos) then
+          return i
+        end
+      end
+    end
+  else
+    assert(false, 'Unknown character type "' .. chartype .. '"')
   end
 end
+
+parsers.unicode.preceding_punctuation
+  = Cmt(parsers.succeed, check_preceding_unicode("punctuation"))
+
+parsers.unicode.preceding_whitespace
+  = Cmt(parsers.succeed, check_preceding_unicode("whitespace"))
 
 parsers.escapable              = parsers.ascii_punctuation
 parsers.anyescaped             = parsers.backslash / ""
@@ -30238,62 +30275,6 @@ function M.reader.new(writer, options)
       ::continue::
     end
   end
-%    \end{macrocode}
-% \begin{markdown}
-%
-% Check if a there is a character of a type `chartype` between the start position `start_pos`
-% and end position `end_pos` in a string `s` relative to current index `i`.
-%
-% \end{markdown}
-%  \begin{macrocode}
-  local function check_unicode_type(s, i, start_pos, end_pos, chartype)
-    local char_length
-    for pos = start_pos, end_pos, 1 do
-      if (start_pos < 0) then
-        char_length = -pos
-      else
-        char_length = pos + 1
-      end
-      local parser = parsers.unicode[chartype]
-      if parser ~= nil then
-        if lpeg.match(parser[char_length], s, i+pos) then
-          return i
-        end
-      else
-        assert(false, 'Unknown character type "' .. chartype .. '"')
-      end
-    end
-  end
-
-  local function check_preceding_unicode_punctuation(s, i)
-    return check_unicode_type(s, i, -4, -1, "punctuation")
-  end
-
-  local function check_preceding_unicode_whitespace(s, i)
-    return check_unicode_type(s, i, -4, -1, "space")
-  end
-
-  local function check_following_unicode_punctuation(s, i)
-    return check_unicode_type(s, i, 0, 3, "punctuation")
-  end
-
-  local function check_following_unicode_whitespace(s, i)
-    return check_unicode_type(s, i, 0, 3, "space")
-  end
-
-  parsers.unicode_preceding_punctuation
-    = B(parsers.escapable)
-    + Cmt(parsers.succeed, check_preceding_unicode_punctuation)
-
-  parsers.unicode_preceding_whitespace
-    = Cmt(parsers.succeed, check_preceding_unicode_whitespace)
-
-  parsers.unicode_following_punctuation
-    = #parsers.escapable
-    + Cmt(parsers.succeed, check_following_unicode_punctuation)
-
-  parsers.unicode_following_whitespace
-    = Cmt(parsers.succeed, check_following_unicode_whitespace)
 
   parsers.delimiter_run = function(character)
     return  (B(parsers.backslash * character) + -B(character))
@@ -30303,26 +30284,26 @@ function M.reader.new(writer, options)
 
   parsers.left_flanking_delimiter_run = function(character)
     return  (B( parsers.any)
-              * ( parsers.unicode_preceding_punctuation
-                + parsers.unicode_preceding_whitespace)
+              * ( parsers.unicode.preceding_punctuation
+                + parsers.unicode.preceding_whitespace)
              + -B(parsers.any))
             * parsers.delimiter_run(character)
-            * parsers.unicode_following_punctuation
+            * parsers.unicode.following_punctuation
             + parsers.delimiter_run(character)
-            * -#( parsers.unicode_following_punctuation
-                + parsers.unicode_following_whitespace
+            * -#( parsers.unicode.following_punctuation
+                + parsers.unicode.following_whitespace
                 + parsers.eof)
   end
 
   parsers.right_flanking_delimiter_run = function(character)
-    return  parsers.unicode_preceding_punctuation
+    return  parsers.unicode.preceding_punctuation
           * parsers.delimiter_run(character)
-          * ( parsers.unicode_following_punctuation
-            + parsers.unicode_following_whitespace
+          * ( parsers.unicode.following_punctuation
+            + parsers.unicode.following_whitespace
             + parsers.eof)
           + (B(parsers.any)
-            * -( parsers.unicode_preceding_punctuation
-               + parsers.unicode_preceding_whitespace))
+            * -( parsers.unicode.preceding_punctuation
+               + parsers.unicode.preceding_whitespace))
           * parsers.delimiter_run(character)
   end
 
@@ -30330,7 +30311,7 @@ function M.reader.new(writer, options)
     parsers.emph_start
       = parsers.left_flanking_delimiter_run(parsers.asterisk)
       + ( -#parsers.right_flanking_delimiter_run(parsers.underscore)
-        + ( parsers.unicode_preceding_punctuation
+        + ( parsers.unicode.preceding_punctuation
           * #parsers.right_flanking_delimiter_run(parsers.underscore)))
       * parsers.left_flanking_delimiter_run(parsers.underscore)
 
@@ -30338,7 +30319,7 @@ function M.reader.new(writer, options)
       = parsers.right_flanking_delimiter_run(parsers.asterisk)
       + ( -#parsers.left_flanking_delimiter_run(parsers.underscore)
         + #( parsers.left_flanking_delimiter_run(parsers.underscore)
-           * parsers.unicode_following_punctuation))
+           * parsers.unicode.following_punctuation))
       * parsers.right_flanking_delimiter_run(parsers.underscore)
   else
     parsers.emph_start

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26229,7 +26229,7 @@ function entities.dec_entity(s)
   if n == nil then
     return "&#" .. s .. ";"  -- fallback for unknown entities
   end
-  return unicode.utf8.char(n)
+  return utf8.char(n)
 end
 %    \end{macrocode}
 % \begin{markdown}
@@ -26245,7 +26245,7 @@ function entities.hex_entity(s)
   if n == nil then
     return "&#x" .. s .. ";"  -- fallback for unknown entities
   end
-  return unicode.utf8.char(n)
+  return utf8.char(n)
 end
 %    \end{macrocode}
 % \begin{markdown}
@@ -26261,7 +26261,7 @@ function entities.hex_entity_with_x_char(x, s)
   if n == nil then
     return "&#" .. x .. s .. ";"  -- fallback for unknown entities
   end
-  return unicode.utf8.char(n)
+  return utf8.char(n)
 end
 %    \end{macrocode}
 % \begin{markdown}
@@ -26282,7 +26282,7 @@ function entities.char_entity(s)
   end
   local char_table = {}
     for _, code_point in ipairs(code_points) do
-      table.insert(char_table, unicode.utf8.char(code_point))
+      table.insert(char_table, utf8.char(code_point))
     end
   return table.concat(char_table)
 end
@@ -27601,7 +27601,7 @@ parsers.ascii_punctuation      = S("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
   for line in file:lines() do
     local codepoint, major_category = line:match("^(%x+);[^;]*;(%a)")
     if major_category == "P" or major_category == "S" then
-      local code = unicode.utf8.char(tonumber(codepoint, 16))
+      local code = utf8.char(tonumber(codepoint, 16))
       if prefix_trees[#code] == nil then
         prefix_trees[#code] = {}
       end

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27759,12 +27759,10 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 parsers.unicode = {}
-parsers.unicode.punctuation = {}
 parsers.unicode.preceding_punctuation = parsers.fail
 parsers.unicode.following_punctuation = parsers.fail
-parsers.unicode.alpha = {}
-parsers.unicode.word = {}
-parsers.unicode.whitespace = {}
+parsers.unicode.following_alpha = parsers.fail
+parsers.unicode.following_word = parsers.fail
 parsers.unicode.preceding_whitespace = parsers.fail
 parsers.unicode.following_whitespace = parsers.fail
 for n = 1, 4 do
@@ -27779,14 +27777,15 @@ for n = 1, 4 do
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.unicode.punctuation[n] = unicode_data.categories.P[n]
-                                 + unicode_data.categories.S[n]
+  local punctuation_of_length_n
+    = unicode_data.categories.P[n]
+    + unicode_data.categories.S[n]
   parsers.unicode.preceding_punctuation
     = parsers.unicode.preceding_punctuation
-    + B(parsers.unicode.punctuation[n])
+    + B(punctuation_of_length_n)
   parsers.unicode.following_punctuation
     = parsers.unicode.following_punctuation
-    + #parsers.unicode.punctuation[n]
+    + #punctuation_of_length_n
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -27796,7 +27795,10 @@ for n = 1, 4 do
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.unicode.alpha[n] = unicode_data.categories.L[n]
+  local alpha_of_length_n = unicode_data.categories.L[n]
+  parsers.unicode.following_alpha
+    = parsers.unicode.following_alpha
+    + alpha_of_length_n
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -27806,9 +27808,13 @@ for n = 1, 4 do
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.unicode.word[n] = unicode_data.categories.L[n]
-                          + unicode_data.categories.N[n]
-                          + unicode_data.categories.Pc[n]
+  local word_of_length_n
+    = unicode_data.categories.L[n]
+    + unicode_data.categories.N[n]
+    + unicode_data.categories.Pc[n]
+  parsers.unicode.following_word
+    = parsers.unicode.following_word
+    + word_of_length_n
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -27819,17 +27825,18 @@ for n = 1, 4 do
 %
 % \end{markdown}
 %  \begin{macrocode}
-  parsers.unicode.whitespace[n] = unicode_data.categories.Z[n]
+  local whitespace_of_length_n = unicode_data.categories.Z[n]
   if n == 1 then
-    parsers.unicode.whitespace[n] = parsers.unicode.whitespace[n]
-                                  + R("\t\r")
+    whitespace_of_length_n
+      = whitespace_of_length_n
+      + R("\t\r")
   end
   parsers.unicode.preceding_whitespace
     = parsers.unicode.preceding_whitespace
-    + B(parsers.unicode.whitespace[n])
+    + B(whitespace_of_length_n)
   parsers.unicode.following_whitespace
     = parsers.unicode.following_whitespace
-    + #parsers.unicode.whitespace[n]
+    + #whitespace_of_length_n
 end
 
 parsers.escapable              = parsers.ascii_punctuation

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -1128,23 +1128,6 @@ local lpeg = require("lpeg")
 %    \end{macrocode}
 % \begin{markdown}
 %
-% \pkg{Selene Unicode}
-%
-%:    A library that provides support for the processing of wide strings. It is
-%     used by the \pkg{Lunamark} library to cast image, link, and note tags
-%     to the lower case. \pkg{Selene Unicode} is included in all releases of
-%     Lua\TeX{} (\TeX Live${}\geq{}2008$).
-%
-% \end{markdown}
-% \iffalse
-%</lua,lua-unicode-data>
-%<*lua,lua-unicode-data-generator>
-% \fi
-%  \begin{macrocode}
-local unicode = require("unicode")
-%    \end{macrocode}
-% \begin{markdown}
-%
 % \pkg{MD5}
 %
 %:    A library that provides \acro{md5} crypto functions. It is used by the
@@ -1154,7 +1137,7 @@ local unicode = require("unicode")
 %
 % \end{markdown}
 % \iffalse
-%</lua,lua-unicode-data-generator>
+%</lua,lua-unicode-data>
 %<*lua,lua-loader>
 % \fi
 %  \begin{macrocode}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27282,7 +27282,7 @@ function M.writer.new(options)
       end
 
       -- Replace all spaces and newlines with hyphens.
-      if not lpeg.match(
+      if lpeg.match(
         ( parsers.newline
         + parsers.unicode.following_whitespace ),
         char
@@ -27359,7 +27359,7 @@ function M.writer.new(options)
       end
 
       -- Replace all spaces and newlines with hyphens.
-      if not lpeg.match(
+      if lpeg.match(
         ( parsers.newline
         + parsers.unicode.following_whitespace ),
         char

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -26332,6 +26332,7 @@ M.writer = {}
 %
 % \end{markdown}
 %  \begin{macrocode}
+local parsers
 function M.writer.new(options)
   local self = {}
 %    \end{macrocode}
@@ -27533,7 +27534,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-local parsers                  = {}
+parsers                        = {}
 %    \end{macrocode}
 % \begin{markdown}
 %

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -27268,8 +27268,8 @@ function M.writer.new(options)
           prev_space = true
         end
       else
-        -- Convert all alphabetic characters to lowercase.
-        char = unicode.utf8.lower(char)
+        -- Case-fold all alphabetic characters.
+        char = uni_algos.case.casefold(char)
         prev_space = false
       end
 
@@ -27332,8 +27332,8 @@ function M.writer.new(options)
           prev_space = true
         end
       else
-        -- Convert all alphabetic characters to lowercase.
-        char = unicode.utf8.lower(char)
+        -- Case-fold all alphabetic characters.
+        char = uni_algos.case.casefold(char)
         prev_space = false
       end
 

--- a/tests/testfiles/unit/lunamark-markdown/auto-identifiers.test
+++ b/tests/testfiles/unit/lunamark-markdown/auto-identifiers.test
@@ -1,3 +1,5 @@
+last-failed-in: #551
+---
 \markdownSetup{
   autoIdentifiers=true,
   headerAttributes=true,

--- a/tests/testfiles/unit/lunamark-markdown/gfm-auto-identifiers.test
+++ b/tests/testfiles/unit/lunamark-markdown/gfm-auto-identifiers.test
@@ -1,3 +1,5 @@
+last-failed-in: #551
+---
 \markdownSetup{
   gfmAutoIdentifiers=true,
   headerAttributes=true,


### PR DESCRIPTION
### Tasks

- [x] Replace functions `unicode.utf8.char()` and `lower()`.
- [x] Replace function `unicode.utf8.match()`.
- [x] Remove Selene Unicode from `DEPENDS.txt`.
- [x] Update `CHANGES.md`.

Closes #402, #436, #552, and #553.