### PR TITLE
Add a man page for `markdown2tex`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,7 +283,7 @@ jobs:
       - name: Test Lua command-line interface
         run: |
           set -ex
-          printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | bash -c 'time markdown-cli eagerCache=false texMathDollars=true' 1>stdout 2>stderr
+          printf '%s\n' 'Hello *Markdown*! $a_x + b_x = c_x$' | bash -c 'time markdown2tex texMathDollars=true' 1>stdout 2>stderr
           test "$(cat stdout)" = '\markdownRendererDocumentBegin
           Hello \markdownRendererEmphasis{Markdown}! \markdownRendererInlineMath{a_x + b_x = c_x}\markdownRendererDocumentEnd'  # Check that the output is correct.
           grep 'real\s*0m[01]' stderr  # Check that the command finishes in less than a second.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 3.11.0
 
+Documentation:
+
+- Add a man page for `markdown2tex`. (#547, #554, suggested by @kberry)
+
 Docker:
 
 - Install the current package `tinyyaml` in historical TeX Live Docker images.

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ DEPENDENCIES=DEPENDS.txt
 TECHNICAL_DOCUMENTATION=markdown.pdf
 MARKDOWN_USER_MANUAL=markdown.md markdown.css
 HTML_USER_MANUAL=markdown.html markdown.css
+MAN_PAGES=markdown2tex.1
 USER_MANUAL=$(MARKDOWN_USER_MANUAL) $(HTML_USER_MANUAL)
 DOCUMENTATION=$(TECHNICAL_DOCUMENTATION) $(HTML_USER_MANUAL) $(ROOT_README) $(VERSION_FILE) \
   $(CHANGES_FILE) $(DEPENDENCIES)
@@ -52,7 +53,7 @@ INSTALLABLES=markdown.lua markdown-parser.lua markdown-cli.lua markdown2tex.lua 
   markdownthemewitiko_markdown_defaults.sty \
   t-markdownthemewitiko_markdown_defaults.tex
 EXTRACTABLES=$(INSTALLABLES) $(MARKDOWN_USER_MANUAL) $(TECHNICAL_DOCUMENTATION_RESOURCES) \
-  $(RAW_DEPENDENCIES)
+  $(RAW_DEPENDENCIES) $(MAN_PAGES)
 MAKEABLES=$(TECHNICAL_DOCUMENTATION) $(USER_MANUAL) $(INSTALLABLES) $(EXAMPLES) $(DEPENDENCIES)
 RESOURCES=$(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES) $(EXAMPLES) \
   $(MAKES) $(READMES) $(INSTALLER) $(DTXARCHIVE) $(TESTS)
@@ -92,7 +93,7 @@ all: $(MAKEABLES)
 	$(MAKE) clean
 
 # This pseudo-target extracts the source files out of the DTX archive.
-base: $(INSTALLABLES)
+base: $(EXTRACTABLES)
 	$(MAKE) clean
 
 # This pseudo-target builds a witiko/markdown Docker image.
@@ -139,7 +140,8 @@ $(EXTRACTABLES): $(INSTALLER) $(DTXARCHIVE)
 	    -e 's#(((VERSION)))#$(VERSION)#g' \
 	    -e 's#(((SHORTVERSION)))#$(SHORTVERSION)#g' \
 	    -e 's#(((LASTMODIFIED)))#$(LASTMODIFIED)#g' \
-	    $(INSTALLABLES)
+	    $(INSTALLABLES) \
+	    $(MAN_PAGES)
 	sed -i \
 	    -e '/\\ExplSyntaxOff/ { N; /\\ExplSyntaxOn/d; }' \
 	    $(INSTALLABLES)
@@ -223,7 +225,7 @@ dist: implode
 	$(MAKE) clean
 
 # This target produces the TeX directory structure archive.
-$(TDSARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(INSTALLABLES) $(DOCUMENTATION) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES)
+$(TDSARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(INSTALLABLES) $(DOCUMENTATION) $(MAN_PAGES) $(EXAMPLES_RESOURCES) $(EXAMPLES_SOURCES)
 	@# Installing the macro package.
 	mkdir -p tex/generic/markdown tex/luatex/markdown tex/latex/markdown \
 	  tex/context/third/markdown scripts/markdown
@@ -234,9 +236,10 @@ $(TDSARCHIVE): $(DTXARCHIVE) $(INSTALLER) $(INSTALLABLES) $(DOCUMENTATION) $(EXA
 	cp markdown.sty markdownthemewitiko_markdown_defaults.sty tex/latex/markdown/
 	cp t-markdown.tex t-markdownthemewitiko_markdown_defaults.tex tex/context/third/markdown/
 	@# Installing the documentation.
-	mkdir -p doc/generic/markdown doc/latex/markdown/examples \
+	mkdir -p doc/generic/markdown doc/man/man1 doc/latex/markdown/examples \
 	  doc/context/third/markdown/examples doc/optex/markdown/examples
 	cp $(DOCUMENTATION) doc/generic/markdown/
+	cp $(MAN_PAGES) doc/man/man1/
 	cp examples/context-mkiv.tex $(EXAMPLES_RESOURCES) \
 	  doc/context/third/markdown/examples/
 	cp -L examples/latex-*.tex $(EXAMPLES_RESOURCES) doc/latex/markdown/examples/

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11293,7 +11293,7 @@ defaultOptions.underscores = true
 % \endgroup
 % \iffalse
 %</lua,lua-cli,lua-loader>
-%<*lua-cli>
+%<*lua-cli-manpage>
 % \fi
 % \begin{markdown}
 %
@@ -11355,15 +11355,40 @@ defaultOptions.underscores = true
 % \label{fig:sequence-diagram-lua-cli}
 % \end{figure}
 %  \begin{macrocode}
+.TH MARKDOWN2TEX 1 "(((LASTMODIFIED)))"
+.SH NAME
+markdown2tex \- convert .md files to .tex
+.SH SYNOPSIS
+%    \end{macrocode}
+%</lua-cli-manpage>
+%<*lua-cli>
+%  \begin{macrocode}
+local HELP_STRING = "Usage: " .. [[
+%    \end{macrocode}
+%</lua-cli>
+%<*lua-cli,lua-cli-manpage>
+%  \begin{macrocode}
+markdown2tex [OPTIONS] -- [INPUT_FILE] [OUTPUT_FILE]
 
-local HELP_STRING = [[
-Usage: texlua ]] .. arg[0] .. [[ [OPTIONS] -- [INPUT_FILE] [OUTPUT_FILE]
-where OPTIONS are documented in the Lua interface section of the
-technical Markdown package documentation.
+%    \end{macrocode}
+%</lua-cli,lua-cli-manpage>
+%<*lua-cli-manpage>
+%  \begin{macrocode}
+.SH DESCRIPTION
+%  \end{macrocode}
+%</lua-cli-manpage>
+%<*lua-cli,lua-cli-manpage>
+%  \begin{macrocode}
+OPTIONS are documented in Section 2.2.1 of the Markdown Package User
+Manual (https://ctan.org/pkg/markdown).
 
 When OUTPUT_FILE is unspecified, the result of the conversion will be
 written to the standard output. When INPUT_FILE is also unspecified, the
 result of the conversion will be read from the standard input.
+%  \end{macrocode}
+%</lua-cli,lua-cli-manpage>
+%<*lua-cli>
+%  \begin{macrocode}
 
 Report bugs to: witiko@mail.muni.cz
 Markdown package home page: <https://github.com/witiko/markdown>]]

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -23762,8 +23762,10 @@ end
 %
 % The \luamdef{util.cache} method used `dir`, `string`, `salt`, and `suffix`
 % to determine a pathname. If a file with such a pathname does not exists,
-% it gets created with `transform(string)` as its content. Regardless, the
-% pathname is then returned.
+% it gets created with `transform(string)` as its content and the result of
+% `transform(string)` is returned as the second return value in case it's
+% useful to the caller. Regardless, the pathname is always returned as the
+% first return value.
 %
 % \end{markdown}
 %  \begin{macrocode}
@@ -23771,17 +23773,18 @@ function util.cache(dir, string, salt, transform, suffix)
   local digest = md5.sumhexa(string .. (salt or ""))
   local name = util.pathname(dir, digest .. suffix)
   local file = io.open(name, "r")
+  local result = nil
   if file == nil then -- If no cache entry exists, create a new one.
     file = assert(io.open(name, "w"),
       [[Could not open file "]] .. name .. [[" for writing]])
-    local result = string
+    result = string
     if transform ~= nil then
       result = transform(result)
     end
     assert(file:write(result))
     assert(file:close())
   end
-  return name
+  return name, result
 end
 %    \end{macrocode}
 % \iffalse
@@ -34665,7 +34668,7 @@ end
 %### Conversion from Markdown to Plain \TeX{}
 %
 % The \luamref{new} function of file `markdown.lua` loads file
-% `markdown-parser.lua` and calls its own function \luamref{new} unless option
+% `markdown-parser.lua` and calls its function \luamref{new} unless option
 % \Opt{eagerCache} or \Opt{finalizeCache} has been enabled and a cached
 % conversion output exists, in which case it is returned without loading file
 % `markdown-parser.lua`.
@@ -34728,18 +34731,31 @@ function M.new(options)
 % \end{markdown}
 %  \begin{macrocode}
     local output
+    local raw_output, flat_output
     if options.eagerCache or options.finalizeCache then
       local salt = util.salt(options)
-      local name = util.cache(options.cacheDir, input, salt, convert,
-                              ".md.tex")
-      output = [[\input{]] .. name .. [[}\relax]]
+      local name, result = util.cache(options.cacheDir, input, salt,
+                                      convert, ".md.tex")
+      raw_output = [[\input{]] .. name .. [[}\relax]]
+      flat_output = function()
+        if result == nil then
+          local input_file = assert(io.open(name, "r"),
+            [[Could not open file "]] .. name .. [[" for reading]])
+          result = assert(input_file:read("*a"))
+          assert(input_file:close())
+        end
+        return result
+      end
 %    \end{macrocode}
 % \begin{markdown}
 % Otherwise, return the result of the conversion directly.
 % \end{markdown}
 %  \begin{macrocode}
     else
-      output = convert(input)
+      raw_output = convert(input)
+      flat_output = function()
+        return raw_output
+      end
     end
 %    \end{macrocode}
 % \begin{markdown}
@@ -34761,10 +34777,17 @@ function M.new(options)
       assert(file:write(
         [[\expandafter\global\expandafter\def\csname ]]
         .. [[markdownFrozenCache]] .. options.frozenCacheCounter
-        .. [[\endcsname{]] .. output .. [[}]] .. "\n"))
+        .. [[\endcsname{]] .. raw_output .. [[}]] .. "\n"))
       assert(file:close())
     end
-    return output
+%    \end{macrocode}
+% \begin{markdown}
+% Besides the canonical output of the conversion, which may contain cached
+% files behind \m{input}, also return a function that always produces a flat
+% output regardless of caching as the second return value.
+% \end{markdown}
+%  \begin{macrocode}
+    return raw_output, flat_output
   end
 end
 %    \end{macrocode}
@@ -35163,8 +35186,19 @@ if metadata.version ~= md.metadata.version then
   warn("markdown-cli.lua " .. metadata.version .. " used with " ..
        "markdown.lua " .. md.metadata.version .. ".")
 end
+
 local convert = md.new(options)
-local output = convert(input)
+local raw_output, flat_output = convert(input)
+local output
+if flat_output == nil then
+  warn("markdown.lua has not produced flat output, using " ..
+       "backwards-compatible raw output instead. This may cause " ..
+       "the result of the conversion may to be hidden behind " ..
+       [[`\input` when option `eagerCache` is enabled.]])
+  output = raw_output
+else
+  output = flat_output()
+end
 
 if output_filename then
   local output_file = assert(io.open(output_filename, "w"),

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -11394,7 +11394,7 @@ Report bugs to: witiko@mail.muni.cz
 Markdown package home page: <https://github.com/witiko/markdown>]]
 
 local VERSION_STRING = [[
-markdown-cli (Markdown) ]] .. metadata.version .. [[
+markdown2tex (Markdown) ]] .. metadata.version .. [[
 
 Copyright (C) ]] .. table.concat(metadata.copyright,
                                  "\nCopyright (C) ") .. [[
@@ -11551,10 +11551,10 @@ end
 %    \end{macrocode}
 % \begin{markdown}
 %
-% The command-line Lua interface is implemented by the `markdown-cli.lua`
-% file that can be invoked from the command line as follows:
+% The command-line Lua interface is implemented by the files `markdown-cli.lua`
+% and `markdown2tex.lua`, which can be invoked from the command line as follows:
 % ``` sh
-% texlua /path/to/markdown-cli.lua cacheDir=. -- hello.md hello.tex
+% markdown2tex cacheDir=. -- hello.md hello.tex
 % ``````
 % \noindent to convert the Markdown document `hello.md` to a \TeX{} document
 % `hello.tex`.  After the Markdown package for our \TeX{} format has been

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -34730,7 +34730,6 @@ function M.new(options)
 % Lua interface (see Section <#sec:lua-options>).
 % \end{markdown}
 %  \begin{macrocode}
-    local output
     local raw_output, flat_output
     if options.eagerCache or options.finalizeCache then
       local salt = util.salt(options)

--- a/markdown.ins
+++ b/markdown.ins
@@ -27,5 +27,6 @@
     \file{markdown-figure-block-diagram.tex}{\from{markdown.dtx}{techdoc-block-diagram}}
     \file{markdown.bib}{\from{markdown.dtx}{techdoc-bibliography}}
     \file{DEPENDS-raw.txt}{\from{markdown.dtx}{depends}}
+    \file{markdown2tex.1}{\from{markdown.dtx}{lua-cli-manpage}}
 }
 \endbatchfile


### PR DESCRIPTION
This PR makes the following changes:
- Generate a man page `markdown2tex.1` from `markdown.dtx` and `markdown.ins` and install it in `Makefile`.
- Flatten the output of `markdown2tex` regardless of whether option `eagerCache` is enabled, as discussed [here][1].
- Update `CHANGES.md`.

Closes #547.

 [1]: https://github.com/Witiko/markdown/issues/547#issuecomment-2631129345