### PR TITLE
Make `\markdownInput` handle file names with spaces correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,11 @@
 
 Fixes:
 
-- Fix style issues identified by explcheck's semantic analysis. (expltools#75, #562, #564)
+- Fix style issues identified by explcheck's semantic analysis.
+  (expltools#75, #562, #564)
+
+- Make `\markdownInput` handle file names with spaces correctly.
+  (reported by @u-fischer in #563, fixed by @witiko in #565)
 
 ## 3.11.1 (2025-03-30)
 

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -37727,7 +37727,7 @@ end
 % changes to the markdown document.
 % \end{markdown}
 %  \begin{macrocode}
-      |openin|markdownInputFileStream&1
+      |openin|markdownInputFileStream{&1}%
       |closein|markdownInputFileStream
       |markdownPrepareLuaOptions
       |markdownPrepareInputFilename{&1}%


### PR DESCRIPTION
Closes #563.