### PR TITLE
Check out the speed of tests using the latest `l3kernel` (2025-09-02)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -299,6 +299,9 @@ then
   tlmgr path add
 fi
 
+# Update the LaTeX3 kernel
+tlmgr update l3kernel
+
 # Uninstall the distribution Markdown package
 rm -rfv ${PREINSTALLED_DIR}/tex/luatex/markdown/
 rm -rfv ${PREINSTALLED_DIR}/scripts/markdown/


### PR DESCRIPTION
In #1791, released in [version 2025-09-02 of package `l3kernel`][1], @josephwright switched to using Lua to implement Unicode algorithms in LaTeX3. This PR is meant to check the speed of our tests after the update. [Previously][2], our tests finished in ~1h 38m. It is not meant to be merged. The speed increase will affect our main Docker image `witiko/markdown` after the parent Docker image `texlive/texlive` will have been updated this Sunday.

 [1]: https://ctan.org/ctan-ann/id/16005d3bd193bce6@hogwart
 [2]: https://github.com/Witiko/markdown/actions/runs/17808009388