### PR TITLE
In theme `witiko/diagrams`, add parameter `format` for GraphViz diagrams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,55 @@
 
 ## 3.12.2 (2025-12-XX)
 
+Development:
+
+- In theme `witiko/diagrams`, add parameter `format` for GraphViz diagrams.
+  (reported by @witiko in #611, fixed by @witiko in #612)
+
+  Here is an example LaTeX document using the new parameter:
+
+  ```` tex
+  \documentclass{article}
+  \usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
+  \begin{document}
+  \begin{markdown}
+  ``` dot {caption="An example directed graph" format=svg width=12cm #dot}
+  digraph tree {
+    margin = 0;
+    rankdir = "LR";
+
+    latex -> pmml;
+    latex -> cmml;
+    pmml -> slt;
+    cmml -> opt;
+    cmml -> prefix;
+    cmml -> infix;
+    pmml -> mterms [style=dashed];
+    cmml -> mterms;
+
+    latex [label = "LaTeX"];
+    pmml [label = "Presentation MathML"];
+    cmml [label = "Content MathML"];
+    slt [label = "Symbol Layout Tree"];
+    opt [label = "Operator Tree"];
+    prefix [label = "Prefix"];
+    infix [label = "Infix"];
+    mterms [label = "M-Terms"];
+  }
+  ```
+
+  See the diagram in Figure <#dot>.
+  \end{markdown}
+  \end{document}
+  ````
+
+  This can be used to circumvent missing support for PDF output in some
+  distributions of GraphViz, [notably Debian Forky][bugs-debian-1123051],
+  which the `texlive/texlive` Docker images are currently based on.
+
+ [bugs-debian-1123051]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1123051
+                       ( Make `-Tpdf` available in forky (testing), not just stable (trixie) and unstable (sid))
+
 Defaults:
 
 - In LaTeX, fix header attribute `{-}` for chapters and parts. (reported by

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -13072,16 +13072,19 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
      `dot`, `mermaid`, and `plantuml` as figures with diagrams produced with
      the command `dot` from Graphviz tools, the command `mmdc` from the npm
      package `@mermaid-js/mermaid-cli`, and the command `plantuml` from the
-     package PlantUML, respectively. The key-value attribute `caption` can be
-     used to specify the caption of the figure. The remaining attributes are
-     treated as image attributes.
+     package PlantUML, respectively.
+
+     The key-value attribute `caption` can be used to specify the caption of
+     the figure and for the infostrings `dot` and `plantuml`, the key-value
+     attribute `format` can be used to specify the output image format. The
+     remaining attributes are treated as image attributes.
 
 %    ```` tex
 %    \documentclass{article}
 %    \usepackage[import=witiko/diagrams@v2, relativeReferences]{markdown}
 %    \begin{document}
 %    \begin{markdown}
-%    ``` dot {caption="An example directed graph" width=12cm #dot}
+%    ``` dot {caption="An example directed graph" format=svg width=12cm #dot}
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
@@ -13152,7 +13155,7 @@ Built-in plain \TeX{} themes provided with the Markdown package include:
 %    figures <#fig:witiko-diagrams-dot>, <#fig:witiko-diagrams-mermaid>, and
 %    <#fig:witiko-diagrams-plantuml>.
 %
-%    ``` dot {caption="An example directed graph" #fig:witiko-diagrams-dot}
+%    ``` dot {caption="An example directed graph" format=svg #fig:witiko-diagrams-dot}
 %    digraph tree {
 %      margin = 0;
 %      rankdir = "LR";
@@ -37437,12 +37440,51 @@ end
     \cs_set:Nn
       \@@_diagrams_infostrings_current:n
       {
-        \@@_diagrams_render_diagram:nnnn
+        \tl_set:Nn
+          \l_tmpb_tl
+          { dot~-T }
+        \tl_put_right:NV
+          \l_tmpb_tl
+          \l_@@_diagrams_format_tl
+        \tl_put_right:Nn
+          \l_tmpb_tl
+          { ~-o~#1. }
+        \tl_put_right:NV
+          \l_tmpb_tl
+          \l_@@_diagrams_format_tl
+        \tl_put_right:Nn
+          \l_tmpb_tl
+          { ~#1 }
+%    \end{macrocode}
+% \begin{markdown}
+%
+% For the SVG format, use Inkscape to convert the resulting image to PDF.
+%
+% \end{markdown}
+%  \begin{macrocode}
+        \str_if_eq:VnT
+          \l_@@_diagrams_format_tl
+          { svg }
+          {
+            \tl_put_right:Nn
+              \l_tmpb_tl
+              { ;~inkscape~#1. }
+            \tl_put_right:NV
+              \l_tmpb_tl
+              \l_@@_diagrams_format_tl
+            \tl_put_right:Nn
+              \l_tmpb_tl
+              { ~--export-area-drawing~--export-dpi=300~-o~#1.pdf }
+          }
+        \@@_diagrams_render_diagram:nnVn
           { #1 }
           { #1.pdf }
-          { dot~-Tpdf~-o~#1.pdf~#1 }
+          \l_tmpb_tl
           { Graphviz~image }
       }
+    \cs_generate_variant:Nn
+      \@@_diagrams_render_diagram:nnnn
+      { nnVn }
     \@@_tl_set_from_cs:NNn
       \l_tmpa_tl
       \@@_diagrams_infostrings_current:n


### PR DESCRIPTION
Closes #611.