### PR TITLE
 Specify `.value_required:n = { true }` for all options that require values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## 3.15.0 (2026-03-XX)
 
+### Fixes
+
+This version of the Markdown package has fixed the following issues:
+
+- Specify `.value_required:n = { true }` for all options that require values.
+  (discovered by @michal-h21 in #615, fixed in #640)
+
 ### Continuous integration
 
 This version of the Markdown package has made the following changes to our

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -13136,6 +13136,7 @@ A PDF document named `document.pdf` should be produced and contain the text
                 { #2 }
                 \l_tmpa_tl
             },
+            #3 .value_required:n = { false },
             #3 .default:n = { true },
           }
       }
@@ -13143,6 +13144,7 @@ A PDF document named `document.pdf` should be produced and contain the text
         \keys_define:nn
           { markdown/options }
           {
+            #3 .value_required:n = { true },
             #3 .code:n = {
               \@@_set_option_value:nn
                 { #2 }
@@ -13191,8 +13193,14 @@ A PDF document named `document.pdf` should be produced and contain the text
           }
         \tl_reverse:N
           \l_tmpa_tl
+        \tl_set_eq:NN
+          \l_tmpb_tl
+          \l_tmpa_tl
         \tl_put_right:Nn
           \l_tmpa_tl
+          { .value_required:n = { true } }
+        \tl_put_right:Nn
+          \l_tmpb_tl
           {
             .code:n = {
               \@@_append_option_value:nn
@@ -13203,6 +13211,9 @@ A PDF document named `document.pdf` should be produced and contain the text
         \keys_define:nV
           { markdown/options }
           \l_tmpa_tl
+        \keys_define:nV
+          { markdown/options }
+          \l_tmpb_tl
 %    \end{macrocode}
 % \begin{markdown}
 %
@@ -13218,21 +13229,25 @@ A PDF document named `document.pdf` should be produced and contain the text
         \keys_define:nn
           { markdown/options }
           {
+            #3~+ .value_required:n = { true },
             #3~+ .code:n = {
               \@@_append_option_value:nn
                 { #2 }
                 { ##1 }
             },
+            #3 + .value_required:n = { true },
             #3 + .code:n = {
               \@@_append_option_value:nn
                 { #2 }
                 { ##1 }
             },
+            #3~$ .value_required:n = { true },
             #3~$ .code:n = {
               \@@_append_option_value:nn
                 { #2 }
                 { ##1 }
             },
+            #3 $ .value_required:n = { true },
             #3 $ .code:n = {
               \@@_append_option_value:nn
                 { #2 }
@@ -13247,16 +13262,18 @@ A PDF document named `document.pdf` should be produced and contain the text
 %
 % \end{markdown}
 %  \begin{macrocode}
+            #3~^ .value_required:n = { true },
             #3~^ .code:n = {
               \@@_prepend_option_value:nn
                 { #2 }
                 { ##1 }
             },
+            #3 ^ .value_required:n = { true },
             #3 ^ .code:n = {
               \@@_prepend_option_value:nn
                 { #2 }
                 { ##1 }
-            }
+            },
           }
       }
   }
@@ -13347,10 +13364,12 @@ a specific look and other high-level goals without low-level programming.
 \keys_define:nn
   { markdown/options }
   {
+    theme .value_required:n = { true },
     theme .code:n = {
       \@@_set_theme:n
         { #1 }
     },
+    import .value_required:n = { true },
     import .code:n = {
       \tl_set:Nn
         \l_tmpa_tl
@@ -14125,6 +14144,7 @@ options locally.
 \keys_define:nn
   { markdown/options }
   {
+    snippet .value_required:n = { true },
     snippet .code:n = {
       \@@_resolve_snippet_name:nN
         { #1 }
@@ -14145,7 +14165,7 @@ options locally.
             { undefined-snippet }
             \l_tmpa_tl
         }
-    }
+    },
   }
 \msg_new:nnn
   { markdown }
@@ -14284,6 +14304,7 @@ variant of the `import` \LaTeX{} option:
 %
 % \end{markdown}
 %  \begin{macrocode}
+    unknown .value_required:n = { false },
     unknown .default:n = {},
     unknown .code:n = {
 %    \end{macrocode}
@@ -22212,6 +22233,7 @@ following text:
     \keys_define:nn
       { markdown/options/renderers }
       {
+        #1 .value_required:n = { true },
         #1 .code:n = {
           \tl_set:Nn
             \l_@@_renderer_definition_tl
@@ -22338,6 +22360,7 @@ following text:
 \keys_define:nn
   { markdown/options }
   {
+    renderers .value_required:n = { true },
     renderers .code:n = {
       \bool_gset_false:N
         \g_@@_unprotected_renderer_bool
@@ -22345,6 +22368,7 @@ following text:
         { markdown/options/renderers }
         { #1 }
     },
+    unprotectedRenderers .value_required:n = { true },
     unprotectedRenderers .code:n = {
       \bool_gset_true:N
         \g_@@_unprotected_renderer_bool
@@ -22386,6 +22410,7 @@ following text:
 \keys_define:nn
   { markdown/options/renderers }
   {
+    unknown .value_required:n = { true },
     unknown .code:n = {
 %    \end{macrocode}
 % \begin{markdown}
@@ -22893,6 +22918,7 @@ following text:
     \keys_define:nn
       { markdown/options }
       {
+        #1 .value_required:n = { true },
         #1 .code:n = {
           \tl_set:Nn
             \l_tmpa_tl
@@ -22921,6 +22947,7 @@ following text:
 \keys_define:nn
   { markdown/options/jekyll-data-renderers }
   {
+    unknown .value_required:n = { true },
     unknown .code:n = {
       \tl_set_eq:NN
         \l_tmpa_tl
@@ -23088,6 +23115,7 @@ following text:
     \keys_define:nn
       { markdown/options/renderer-prototypes }
       {
+        #1 .value_required:n = { true },
         #1 .code:n = {
           \tl_set:Nn
             \l_@@_renderer_prototype_definition_tl
@@ -23188,6 +23216,7 @@ following text:
 \keys_define:nn
   { markdown/options/renderer-prototypes }
   {
+    unknown .value_required:n = { true },
     unknown .code:n = {
 %    \end{macrocode}
 % \begin{markdown}
@@ -23352,6 +23381,7 @@ following text:
     \keys_define:nn
       { markdown/options }
       {
+        #1 .value_required:n = { true },
         #1 .code:n = {
           \bool_gset_false:N
             \g_@@_unprotected_renderer_prototype_bool
@@ -23367,6 +23397,7 @@ following text:
     \keys_define:nn
       { markdown/options }
       {
+        #1 .value_required:n = { true },
         #1 .code:n = {
           \bool_gset_true:N
             \g_@@_unprotected_renderer_prototype_bool
@@ -23467,6 +23498,7 @@ following text:
 \keys_define:nn
   { markdown/options }
   {
+    code .value_required:n = { true },
     code .code:n = { #1 },
   }
 \ExplSyntaxOff
@@ -39456,6 +39488,7 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
+        #1 .value_required:n = { false },
         #1 .default:n = { },
       }
   }
@@ -42748,14 +42781,17 @@ end
 \keys_define:nn
   { markdown / jekyllData }
   {
+    author .value_required:n = { true },
     author .code:n = {
       \author
         { #1 }
     },
+    date .value_required:n = { true },
     date .code:n = {
       \date
         { #1 }
     },
+    title .value_required:n = { true },
     title .code:n = {
       \title
         { #1 }


### PR DESCRIPTION
Fixes the issue described in https://github.com/Witiko/markdown/issues/615#issuecomment-4154147353.