### PR TITLE
Format `[...]{.acronym}`s throughout the document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 3.15.1 (2026-05-XX)
+## 3.15.1 (2026-06-11)
 
 ### Fixes
 
@@ -20,6 +20,44 @@ default renderer and renderer prototype definitions.
 
   Previously, bracketed span contents were consumed by the default renderer
   prototype.
+
+- In LaTeX, format `[...]{.acronym}`s throughout the document. (#645)
+
+  After this change, explicitly listed acronyms using the HTML class `acronym`
+  will be recorded in the auxiliary file, so that they are applied throughout
+  the document in the next compilation run.
+
+  For example, assume the following LaTeX example document:
+
+  ``` tex
+  \documentclass{article}
+  \usepackage[plain]{markdown}
+  \markdownSetup {
+    acronyms = {HTML, YAML},
+  }
+  \begin{document}
+  \begin{markdown}
+
+  HTML, JSON, and YAML are two staples of modern tooling that often get mentioned
+  in the same breath, even though they live in very different layers of the stack.
+
+  Here, the author has explicitly marked up [JSON]{.acronym}.
+
+  \end{markdown}
+
+  \begin{markdown}
+
+  In the following compilation runs, the previous occurrence of JSON will also
+  be correctly formatted as an acronym.
+
+  \end{markdown}
+  \end{document}
+  ```
+
+  During the first compilation run, only HTML and YAML are formatted as acronyms
+  in the first paragraph, not JSON, which is only formatted as an acronym in the
+  second and third paragraphs. However, in the following compilation runs, JSON
+  is formatted as an acronym throughout.
 
 ### Continuous integration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ default renderer and renderer prototype definitions.
 
   ``` tex
   \documentclass{article}
-  \usepackage[plain]{markdown}
+  \usepackage[bracketed_spans]{markdown}
   \markdownSetup {
     acronyms = {HTML, YAML},
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -42011,48 +42011,48 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \tl_set:Nn
-      \l_tmpa_tl
-      { #1 }
-    \regex_replace_all:nnN
-      { \c { markdownRendererAcronym } | \cB\{ | \cE\} }
-      { }
-      \l_tmpa_tl
-    \bool_if:nT
+    \bool_if:NT
+      \g_@@_record_acronyms_bool
       {
-        \g_@@_record_acronyms_bool &&
-        ! \prop_if_in_p:NV
+        \tl_set:Nn
+          \l_tmpa_tl
+          { #1 }
+        \regex_replace_all:nnN
+          { \c { markdownRendererAcronym } | \cB\{ | \cE\} }
+          { }
+          \l_tmpa_tl
+        \prop_if_in:NVF
           \g_@@_recorded_acronyms_prop
           \l_tmpa_tl
-      }
-      {
-        \regex_if_match:nVF
-          { \cC. }
-          \l_tmpa_tl
           {
-            \prop_gput:NVn
-              \g_@@_recorded_acronyms_prop
+            \regex_if_match:nVF
+              { \cC. }
               \l_tmpa_tl
-              { true }
-            \tl_gput_right:Nx
-              \markdownOptionAcronyms
-              { , { \tl_use:N \l_tmpa_tl } }
-            \tl_set:Nn
-              \l_tmpb_tl
               {
-                \ExplSyntaxOn
-                  \tl_gput_right:Nn
+                \prop_gput:NVn
+                  \g_@@_recorded_acronyms_prop
+                  \l_tmpa_tl
+                  { true }
+                \tl_gput_right:Nx
                   \markdownOptionAcronyms
+                  { , { \tl_use:N \l_tmpa_tl } }
+                \tl_set:Nn
+                  \l_tmpb_tl
+                  {
+                    \ExplSyntaxOn
+                      \tl_gput_right:Nn
+                      \markdownOptionAcronyms
+                  }
+                \tl_gput_right:Nx
+                  \l_tmpb_tl
+                  { { , { \tl_use:N \l_tmpa_tl } } }
+                \tl_gput_right:Nx
+                  \l_tmpb_tl
+                  { \ExplSyntaxOff }
+                \iow_now:NV
+                  \@auxout
+                  \l_tmpb_tl
               }
-            \tl_gput_right:Nx
-              \l_tmpb_tl
-              { { , { \tl_use:N \l_tmpa_tl } } }
-            \tl_gput_right:Nx
-              \l_tmpb_tl
-              { \ExplSyntaxOff }
-            \iow_now:NV
-              \@auxout
-              \l_tmpb_tl
           }
       }
   }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -41992,6 +41992,60 @@ end
 % \end{markdown}
 %  \begin{macrocode}
 \ExplSyntaxOn
+\prop_new_linked:N
+  \g_@@_recorded_acronyms_prop
+\bool_new:N
+  \g_@@_record_acronyms_bool
+\bool_gset_false:N
+  \g_@@_record_acronyms_bool
+\cs_new:Nn
+  \@@_record_acronym:n
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% For explicitly listed acronyms using the HTML class `acronym` that only contain
+% simple text and not control sequences, record them in the auxiliary file, so
+% that they are applied throughout the document in the next compilation run.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \bool_if:nT
+      {
+        \g_@@_record_acronyms_bool &&
+        ! \prop_if_in_p:Nn
+          \g_@@_recorded_acronyms_prop
+          { #1 }
+      }
+      {
+        \regex_if_match:nnF
+          { \cC. }
+          { #1 }
+          {
+            \prop_gput:Nnn
+              \g_@@_recorded_acronyms_prop
+              { #1 }
+              { true }
+            \tl_gput_right:Nn
+              \markdownOptionAcronyms
+              { , { #1 } }
+            \immediate
+              \write
+              \@auxout
+              {
+                \exp_not:N
+                  \ExplSyntaxOn
+                \exp_not:N
+                  \tl_gput_right:Nn
+                \exp_not:N
+                  \markdownOptionAcronyms
+                { , { #1 } }
+                \exp_not:N
+                  \ExplSyntaxOff
+              }
+          }
+      }
+  }
 \int_new:N
   \g_@@_heading_nesting_depth_int
 \markdownSetup {
@@ -42017,9 +42071,15 @@ end
           \group_begin:
             \markdownSetup {
               unprotectedRenderers = {
-                acronym = { ##1 },
-              }
+                acronym = {
+                  ##1
+                  \@@_record_acronym:n
+                    { ##1 }
+                },
             }
+          }
+            \@@_record_acronym:n
+              { #1 }
             \tl_set:Nn
               \l_tmpa_tl
               { #1 }
@@ -43793,6 +43853,8 @@ end
                 \markdownSetup {
                   rendererPrototypes = {
                     bracketedSpan = {
+                      \bool_set_true:N
+                        \g__markdown_record_acronyms_bool
                       \markdownRendererAcronym
                         { ####1 }
                     }

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -42005,44 +42005,54 @@ end
 % \begin{markdown}
 %
 % For explicitly listed acronyms using the HTML class `acronym` that only contain
-% simple text and not control sequences, record them in the auxiliary file, so
-% that they are applied throughout the document in the next compilation run.
+% simple text and not control sequences after cleaning up any potential nested acronyms,
+% record them in the auxiliary file, so that they are applied throughout the
+% document in the next compilation run.
 %
 % \end{markdown}
 %  \begin{macrocode}
+    \tl_set:Nn
+      \l_tmpa_tl
+      { #1 }
+    \regex_replace_all:nnN
+      { \c { markdownRendererAcronym } | \cB\{ | \cE\} }
+      { }
+      \l_tmpa_tl
     \bool_if:nT
       {
         \g_@@_record_acronyms_bool &&
-        ! \prop_if_in_p:Nn
+        ! \prop_if_in_p:NV
           \g_@@_recorded_acronyms_prop
-          { #1 }
+          \l_tmpa_tl
       }
       {
-        \regex_if_match:nnF
+        \regex_if_match:nVF
           { \cC. }
-          { #1 }
+          \l_tmpa_tl
           {
-            \prop_gput:Nnn
+            \prop_gput:NVn
               \g_@@_recorded_acronyms_prop
-              { #1 }
+              \l_tmpa_tl
               { true }
-            \tl_gput_right:Nn
+            \tl_gput_right:Nx
               \markdownOptionAcronyms
-              { , { #1 } }
-            \immediate
-              \write
-              \@auxout
+              { , { \tl_use:N \l_tmpa_tl } }
+            \tl_set:Nn
+              \l_tmpb_tl
               {
-                \exp_not:N
-                  \ExplSyntaxOn
-                \exp_not:N
+                \ExplSyntaxOn
                   \tl_gput_right:Nn
-                \exp_not:N
                   \markdownOptionAcronyms
-                { , { #1 } }
-                \exp_not:N
-                  \ExplSyntaxOff
               }
+            \tl_gput_right:Nx
+              \l_tmpb_tl
+              { { , { \tl_use:N \l_tmpa_tl } } }
+            \tl_gput_right:Nx
+              \l_tmpb_tl
+              { \ExplSyntaxOff }
+            \iow_now:NV
+              \@auxout
+              \l_tmpb_tl
           }
       }
   }
@@ -42071,11 +42081,7 @@ end
           \group_begin:
             \markdownSetup {
               unprotectedRenderers = {
-                acronym = {
-                  ##1
-                  \@@_record_acronym:n
-                    { ##1 }
-                },
+                acronym = { ##1 },
             }
           }
             \@@_record_acronym:n

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -41998,7 +41998,7 @@ end
   \g_@@_record_acronyms_bool
 \bool_gset_false:N
   \g_@@_record_acronyms_bool
-\cs_new:Nn
+\cs_new_protected:Nn
   \@@_record_acronym:n
   {
 %    \end{macrocode}


### PR DESCRIPTION
This PR makes the following changes:

- For explicitly listed acronyms using the HTML class `acronym`, record them in the auxiliary file, so that they are applied throughout the document in the next compilation run.