### PR TITLE
Allow delimiters other than `{` and `}` after `\markinline`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changes
 
+## 3.16.0 (2026-06-13)
+
+### Development
+
+This version of the Markdown package has added the following new features:
+
+- Allow delimiters other than `{` and `}` after `\markinline`. (#646)
+
+  This allows potentially unbalanced braces to appear in the markdown text:
+
+  ``` tex
+  \documentclass{article}
+  \usepackage[bracketed_spans]{markdown}
+  \begin{document}
+  \markinline|[JSON]{.acronym}|,
+  \end{document}
+  ```
+
 ## 3.15.1 (2026-06-11)
 
 ### Fixes

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -12246,10 +12246,15 @@ pdftex --shell-escape document.tex
 % \input markdown
 % \markdownSetup{contentLevel=inline}
 % \markdownBegin
-% _Hello_ **world** ...
+% _Hello_ **world**
 % \markdownEnd
 % \bye
 % ```````
+%
+% Besides \mref{markinline}`{`\meta{markdown text}`}`, any other
+% delimiter such as `|`\meta{markdown text}`|` can also be used.
+% This allows potentially unbalanced braces to appear in
+% \meta{markdown text}.
 %
 % The \mref{markinline} macro is subject to the same limitations as the
 % \mref{markdownBegin} and \mref{markdownEnd} macros.
@@ -40960,8 +40965,44 @@ end
 %
 % \end{markdown}
 %  \begin{macrocode}
-    \peek_regex_replace_once:nnF
-      { { (.*?) } }
+    \peek_after:Nw
+      \@@_inline_read_markdown_text:
+  }
+\cs_new_protected:Nn
+  \@@_inline_read_markdown_text:
+  {
+%    \end{macrocode}
+% \begin{markdown}
+%
+% Allow both `{`\meta{markdown text}`}` but also any other
+% delimiter such as `|`\meta{markdown text}`|`.
+%
+% \end{markdown}
+%  \begin{macrocode}
+    \token_if_group_begin:NTF
+      \l_peek_token
+      {
+        \regex_set:Nn
+          \l_tmpa_regex
+          { { (.*?) } }
+      }
+      {
+        \tl_set:Nx
+          \l_tmpa_tl
+          {
+            \text_purify:n
+              { \l_peek_token }
+          }
+        \regex_set:Nn
+          \l_tmpa_regex
+          {
+            \u { l_tmpa_tl }
+            (.*?)
+            \u { l_tmpa_tl }
+          }
+      }
+    \peek_regex_replace_once:NnF
+      \l_tmpa_regex
       {
 %    \end{macrocode}
 % \begin{markdown}

--- a/markdown.dtx
+++ b/markdown.dtx
@@ -42080,8 +42080,8 @@ end
             \markdownSetup {
               unprotectedRenderers = {
                 acronym = { ##1 },
+              }
             }
-          }
             \@@_record_acronym:n
               { #1 }
             \tl_set:Nn


### PR DESCRIPTION
This PR makes the following change:

- Allow delimiters other than `{` and `}` after `\markinline`.